### PR TITLE
Downgrade Ubuntu to 22.04 in Actions

### DIFF
--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         build_type: [Release]
         c_compiler: [gcc]
         mpi: [ 'mpich', 'openmpi', 'intelmpi']


### PR DESCRIPTION
This is to temporarily fix a bug in the Ubuntu 24.04: https://bugs.launchpad.net/ubuntu/+source/mpich/+bug/2072338. The issue is reported in a lot of other repos but we will have to wait for the ubuntu package maintainer to fix it by rebuilding the mpich package.