### PR TITLE
feat: [CUDA] add more kernel luanche support

### DIFF
--- a/include/cuda_interceptor.h
+++ b/include/cuda_interceptor.h
@@ -7,6 +7,7 @@
  */
 
 #include "frida-gum.h"
+#include "utils/utils.h"
 #include "utils/cxx_utils.h"
 #include <cuda.h>
 #include <cuda_runtime_api.h>

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -94,4 +94,18 @@ double median_double(double* arr, size_t n);
  */
 int check_command(const char *str);
 
+/**
+ * @brief Truncate a string and append ellipsis if it exceeds the specified length.
+ *
+ * This function creates a new dynamically allocated string. If the input string
+ * `s` is longer than `max_len`, the returned string will contain the first
+ * (max_len - 3) characters followed by "...". Otherwise, it returns a copy of the
+ * original string.
+ *
+ * @param s The input null-terminated string to truncate.
+ * @param max_len The maximum allowed length of the output string (including ellipsis).
+ * @return A newly allocated null-terminated string. The caller is responsible for freeing it.
+ */
+char* truncate_string(const char* s, size_t max_len);
+
 #endif /* __UTILS_H */

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -254,3 +254,13 @@ int check_command(const char *str) {
 
     return 0; // No match found
 }
+
+char* truncate_string(const char* s, size_t max_len) {
+    size_t len = strlen(s);
+    if (len <= max_len) return strdup(s);
+
+    char* result = (char*)malloc(max_len + 1);
+    strncpy(result, s, max_len - 3);
+    strcpy(result + max_len - 3, "...");
+    return result;
+}


### PR DESCRIPTION
Now kernel support
- cudaLaunchKernel
- cudaLaunchCooperativeKernel
- cudaLaunchCooperativeKernelMultiDevice
- cudaLaunchKernelEx
- cudaLaunchKernelExC
- cuLaunchKernel
- cuLaunchCooperativeKernel
- cuLaunchCooperativeKernelMultiDevice
- cuLaunchKernelEx

Testcase
```
c608-071[gh](1002)$ PEAK_TARGET=cudaMallocAsync,cublasDgemm_v2,cublasGemmEx,cuLaunchKernelEx,cudaLaunchKernelExC,__cudaLaunchKernel_ptsz,__cudaLaunchKernel,cudaLaunchKernel_ptsz,cudaLaunchKernel,cudaLaunchKernelExC_v11060 PEAK_GPU_MONITOR_ALL=TRUE LD_PRELOAD=~/peak/build/src/libpeak.so gemm.test
+--------------------+------------+----------+
| Operation          | Time (ms)  | T*OPS    |
+--------------------+------------+----------+
| Dgemm              |      2.254 |   60.968 |
| GemmEx(int8)       |      0.114 | 1204.388 |
| LtMatmul(int8)     |      0.117 | 1174.644 |
+--------------------+------------+----------+
-----------------------------------------------------------------------------
                                 PEAK Library
-----------------------------------------------------------------------------
Time: 1.901105
PEAK done with: gemm.test
Estimated overhead: 2.249e-07s per call and 1.305e-05s total

------------------------ function statistics (call)  ------------------------
 individual call counts and time (in seconds)
-----------------------------------------------------------------------------
|            function|     count|per thread|  per rank|       max|       min|
-----------------------------------------------------------------------------
|cudaError cudaMal...|         3|         3|         3| 2.141e-03| 2.849e-04|
|      cublasDgemm_v2|        11|        11|        11| 2.751e-02| 1.088e-05|
|        cublasGemmEx|        11|        11|        11| 5.725e-03| 1.245e-05|
|    cuLaunchKernelEx|        33|        33|        33| 3.246e-03| 3.648e-06|
-----------------------------------------------------------------------------

----------------------- function statistics (thread)  -----------------------
 thread aggregated time (in seconds)
-----------------------------------------------------------------------------
|            function|     total| exclusive|       max|       min|  overhead|
-----------------------------------------------------------------------------
|cudaError cudaMal...|     0.003|     0.003|     0.003|     0.003| 6.747e-07|
|      cublasDgemm_v2|     0.028|     0.024|     0.028|     0.028| 2.474e-06|
|        cublasGemmEx|     0.006|     0.006|     0.006|     0.006| 2.474e-06|
|    cuLaunchKernelEx|     0.003|     0.003|     0.003|     0.003| 7.422e-06|
-----------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------
                                          GPU STATISTICS                                           
----------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------
                                     KERNEL STATISTICS (GPU)                                     
----------------------------------------------------------------------------------------------------
| Kernel                                   |     Calls |  Total(s) |    Max(s) |    Min(s) |
----------------------------------------------------------------------------------------------------
| sm90_xmma_gemm_i8i32_i8i32_f32_tn_n_t... |        22 |  0.013266 |  0.001155 |  0.000122 |
| sm90_xmma_gemm_f64f64_f64f64_f64_tn_n... |        11 |  0.128374 |  0.022559 |  0.002424 |
----------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------
                                        KERNEL BLOCK SIZE                                        
----------------------------------------------------------------------------------------------------
| Kernel                                   |    AvgBlk |    MaxBlk |    MinBlk |
----------------------------------------------------------------------------------------------------
| sm90_xmma_gemm_i8i32_i8i32_f32_tn_n_t... |    384.00 |       384 |       384 |
| sm90_xmma_gemm_f64f64_f64f64_f64_tn_n... |    128.00 |       128 |       128 |
----------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------------
                                       KERNEL THREAD SIZE                                        
----------------------------------------------------------------------------------------------------
| Kernel                                   |   AvgGrid |   MaxGrid |   MinGrid |
----------------------------------------------------------------------------------------------------
| sm90_xmma_gemm_i8i32_i8i32_f32_tn_n_t... |    132.00 |       132 |       132 |
| sm90_xmma_gemm_f64f64_f64f64_f64_tn_n... |   2048.00 |      2048 |      2048 |
----------------------------------------------------------------------------------------------------
```