### PR TITLE
fix: reset peak_need_detach[0] after bootstrapping to prevent unintended detach

### DIFF
--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -660,6 +660,7 @@ void peak_general_listener_attach()
         peak_general_overhead_bootstrapping();
         if (peak_detach_cost > 0)
             peak_detach_count = (peak_detach_cost > peak_general_overhead) ? peak_detach_cost / peak_general_overhead : 1;
+        peak_need_detach[0] = false;
     }
 }
 


### PR DESCRIPTION
Reset `peak_need_detach[0]` to false after bootstrapping to prevent unintended detach triggered by its value being set during initialization.