### PR TITLE
fix: segfault in cuda_interceptor_reduce_kernel_result (CASE_C)

### DIFF
--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -1025,7 +1025,7 @@ cuda_interceptor_reduce_kernel_result()
             guint index = 0;
             for (guint i = 0; i < global_kernel_count; i++) {
                 guint len = strlen(global_keys_string + index);
-                global_keys_array[i] = g_new(gchar, len);
+                global_keys_array[i] = g_new(gchar, len+1);
                 strcpy(global_keys_array[i], global_keys_string + index);
                 index += len + 1;
             }


### PR DESCRIPTION
In CASE_C (MILC GPU test with PEAK_GPU_MONITOR_ALL=TRUE and PEAK_HEARTBEAT_INTERVAL=0), a memory segfault occurred after printing out the 'KERNEL GRID SIZE ' table.

```
[c608-041:3291182:0:3291182] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x4565707974345d)
==== backtrace (tid:3291182) ====
 0  /opt/apps/ucx/1.17.0/lib/libucs.so.0(ucs_handle_error+0x288) [0x40004921eb98]
 1  /opt/apps/ucx/1.17.0/lib/libucs.so.0(+0x2ece8) [0x40004921ece8]
 2  /opt/apps/ucx/1.17.0/lib/libucs.so.0(+0x2f07c) [0x40004921f07c]
 3  linux-vdso.so.1(__kernel_rt_sigreturn+0) [0x4000270607f0]
 4  /scratch/05392/cylu/project/peak/1.test/4.cases/peak-install/lib/libpeak.so(_frida_mspace_free+0x304) [0x400027323ce8]
=================================
```

After debugging, a bug at L1028 was found
https://github.com/peak-team/peak/blob/9f95c3b5d59d69be2936fc3a925fd18e77489711/src/cuda_interceptor.cpp#L1028

Changing  global_keys_array[i] = g_new(gchar, len); to global_keys_array[i] = g_new(gchar, len+1); to include the null terminator should fix the issue


