### PR TITLE
fix: optimize finding demangle func name with wild card

### DIFF
--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -28,6 +28,13 @@ extern unsigned long long sig_cont_wait_interval;
 extern unsigned int heartbeat_time;
 static gulong peak_detach_count = G_MAXULONG;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static gboolean gum_find_functions_matching_initialize = false;
+static GHashTable* gum_symbol_demangled_mapping;
+static GHashTable* gum_symbol_short_mapping;
+
+gboolean str_equal_function_general(gconstpointer a, gconstpointer b) {
+    return g_strcmp0((const gchar *)a, (const gchar *)b) == 0;
+}
 
 gboolean heartbeat_running = true;
 
@@ -582,6 +589,50 @@ peak_general_overhead_bootstrapping()
     g_free(time);
 }
 
+static void peak_build_symbol_map_once(void) {
+    gum_find_functions_matching_initialize = true;
+    GArray* addresses = gum_find_functions_matching("_Z*");
+    gum_symbol_demangled_mapping = g_hash_table_new_full(g_str_hash,
+                                                         str_equal_function_general,
+                                                         g_free,
+                                                         (GDestroyNotify) g_ptr_array_unref);
+    gum_symbol_short_mapping = g_hash_table_new_full(g_str_hash,
+                                                     str_equal_function_general,
+                                                     g_free,
+                                                     (GDestroyNotify) g_ptr_array_unref);
+
+    for (gsize j = 0; j < addresses->len; j++) {
+        gpointer addr = g_array_index(addresses, gpointer, j);
+        if (!addr) continue;
+        gchar* mangled = gum_symbol_name_from_address(addr);
+        if (!mangled) continue;
+
+        char* demangled = cxa_demangle(mangled);
+        g_free(mangled);
+        if (!demangled) continue;
+
+        GPtrArray* demangled_candidates = g_hash_table_lookup(gum_symbol_demangled_mapping, demangled);
+        if (!demangled_candidates) {
+            demangled_candidates = g_ptr_array_new();
+            g_hash_table_insert(gum_symbol_demangled_mapping, g_strdup(demangled), demangled_candidates);
+        }
+        g_ptr_array_add(demangled_candidates, addr);
+
+        char* function_name = extract_function_name(demangled);
+        GPtrArray* short_candidates = g_hash_table_lookup(gum_symbol_short_mapping, function_name);
+        if (!short_candidates) {
+            short_candidates = g_ptr_array_new();
+            g_hash_table_insert(gum_symbol_short_mapping, g_strdup(function_name), short_candidates);
+        }
+        g_ptr_array_add(short_candidates, addr);
+
+        free(function_name);
+        free(demangled);
+    }
+
+    g_array_free(addresses, TRUE);
+}
+
 void peak_general_listener_attach()
 {
     pthread_pause_enable();
@@ -646,35 +697,31 @@ void peak_general_listener_attach()
                 peak_demangled_strings[i] = g_strdup(demangled);
                 free(demangled);
             } else {
+                if (!gum_find_functions_matching_initialize) {
+                    peak_build_symbol_map_once();
+                }
+
                 if (cxa_demangle_status(peak_hook_strings[i]) != 0) {
-                    // peak_hook_strings is just function name
-                    gchar* truncate_hook = g_strdup_printf("*%s*", peak_hook_strings[i]);
-                    GArray* addresses = gum_find_functions_matching(truncate_hook);
-                    for (gsize j = 0; j < addresses->len; j++) {
-                        gpointer addr = g_array_index(addresses, gpointer, j);
-                        gchar* mangled = gum_symbol_name_from_address(addr);
-                        gboolean function_match = FALSE;
-                        if (!mangled) continue;
-                    
-                        char* demangled = cxa_demangle(mangled);
-                        g_free(mangled);
-                        if (!demangled) continue;
-        
-                        gchar* function_name = extract_function_name(demangled);
-                        if (strcmp(peak_hook_strings[i], function_name) == 0) {
-                            hook_address[i] = addr;
+                    GPtrArray* candidates = g_hash_table_lookup(gum_symbol_demangled_mapping, peak_hook_strings[i]);
+                    if (candidates && candidates->len > 0) {
+                        // Candidate is demangled name and it will only match one symbol, so we can directly use it
+                        hook_address[i] = g_ptr_array_index(candidates, 0);
+                        peak_demangled_strings[i] = g_strdup(peak_hook_strings[i]);
+                    } else {
+                        // Candidates might be in short names mapping, try looking up in short mapping
+                        // if multiple candidates exist, we will use the first one
+                        candidates = g_hash_table_lookup(gum_symbol_short_mapping, peak_hook_strings[i]);
+                        if (candidates && candidates->len > 0) {
+                            hook_address[i] = g_ptr_array_index(candidates, 0);
+                            gchar* mangled = gum_symbol_name_from_address(hook_address[i]);
+                            if (!mangled) continue;
+                            char* demangled = cxa_demangle(mangled);
+                            g_free(mangled);
+                            if (!demangled) continue;
                             peak_demangled_strings[i] = g_strdup(demangled);
-                            function_match = TRUE;
-                        }
-                        free(demangled);
-                        free(function_name);
-    
-                        if (function_match) {
-                            break;
+                            free(demangled);
                         }
                     }
-                    g_array_free(addresses, TRUE);
-                    g_free(truncate_hook);
                 }
             }
         }
@@ -689,6 +736,13 @@ void peak_general_listener_attach()
         }
     }
     gum_interceptor_end_transaction(interceptor);
+    if (gum_find_functions_matching_initialize) {
+        g_hash_table_destroy(gum_symbol_demangled_mapping);
+        g_hash_table_destroy(gum_symbol_short_mapping);
+        gum_symbol_demangled_mapping = NULL;
+        gum_symbol_short_mapping = NULL;
+        gum_find_functions_matching_initialize = false;
+    }
     if (peak_hook_address_count) {
         peak_general_overhead_bootstrapping();
         if (peak_detach_cost > 0)

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -32,7 +32,7 @@ static gboolean gum_find_functions_matching_initialize = false;
 static GHashTable* gum_symbol_demangled_mapping;
 static GHashTable* gum_symbol_short_mapping;
 
-gboolean str_equal_function_general(gconstpointer a, gconstpointer b) {
+static gboolean str_equal_function_general(gconstpointer a, gconstpointer b) {
     return g_strcmp0((const gchar *)a, (const gchar *)b) == 0;
 }
 
@@ -714,12 +714,21 @@ void peak_general_listener_attach()
                         if (candidates && candidates->len > 0) {
                             hook_address[i] = g_ptr_array_index(candidates, 0);
                             gchar* mangled = gum_symbol_name_from_address(hook_address[i]);
-                            if (!mangled) continue;
-                            char* demangled = cxa_demangle(mangled);
-                            g_free(mangled);
-                            if (!demangled) continue;
-                            peak_demangled_strings[i] = g_strdup(demangled);
-                            free(demangled);
+
+                            if (mangled != NULL) {
+                                char* demangled = cxa_demangle(mangled);
+                                g_free(mangled);
+                                if (demangled != NULL) {
+                                    peak_demangled_strings[i] = g_strdup(demangled);
+                                    free(demangled);
+                                } else {
+                                    /* Failed to demangle; fall back to original hook string */
+                                    peak_demangled_strings[i] = g_strdup(peak_hook_strings[i]);
+                                }
+                            } else {
+                                /* Failed to get mangled name; fall back to original hook string */
+                                peak_demangled_strings[i] = g_strdup(peak_hook_strings[i]);
+                            }
                         }
                     }
                 }

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -221,6 +221,9 @@ static const char *check_list[] = {
     "git",
     "ssh",
     "sftp",
+    "bc",
+    "which",
+    "seq",
     NULL // Null terminator to mark the end of the list
 };
 


### PR DESCRIPTION
## Summary
This PR reduces the cost of resolving demangled C++ function names during listener attachment.

Instead of repeatedly calling `gum_find_functions_matching()` for each hook string, it builds a one-time symbol map from mangled symbols to:
- full demangled names
- short extracted function names
The attach path then reuses those cached candidates to resolve hooks more efficiently.

## What Changed
- Added a one-time symbol map build step in src/general_listener.c
- Cached mappings for:
    - demangled function name -> candidate addresses
    - short function name -> candidate addresses
- Replaced repeated wildcard symbol scans with hash table lookups during hook resolution
- Cleaned up the temporary symbol maps after interception setup completes

## Why
The previous implementation scanned symbols repeatedly for each unresolved hook string, which made demangled-name matching expensive. This change makes lookup cheaper and should improve attach-time performance, especially when many hooks are configured.

## Testing
Original Test is as below
```
real	3m40.408s
user	52m24.235s
sys	2m21.796s
```

Now with PEAK after modified
```
-----------------------------------------------------------------------------
                                 PEAK Library
-----------------------------------------------------------------------------
Time: 239.661170
PEAK done with: /work/05392/cylu/share/peak/app_install/1.milc/1.cpu/milc_qcd/ks_imp_rhmc/su3_rhmd_hisq
Estimated overhead: 1.056e-06s per call and 2.382e+01s total

real	4m15.169s
user	56m15.316s
sys	3m30.075s
```

## Behavior Note
If a user-provided target matches multiple symbols, we still attach to only one function. The resolver selects the first symbol that matches the current lookup logic rather than attaching to every match, because the current hook storage only has one slot per configured target. If we want to allow to attach to 1-to-multiple target attachment, we must do **re-design** for the array and vector initialization across the package.