### PR TITLE
Add robust exec-chain support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(peak C CXX Fortran)
+project(peak C CXX Fortran ASM)
 
 # Set build type to Release by default if CMAKE_BUILD_TYPE is not given
 set(default_build_type "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(peak C CXX Fortran ASM)
+project(peak C CXX Fortran)
 
 # Set build type to Release by default if CMAKE_BUILD_TYPE is not given
 set(default_build_type "Release")
@@ -63,11 +63,10 @@ message(STATUS "FRIDA_GUM_INCLUDE_DIRS = ${FRIDA_GUM_INCLUDE_DIRS}")
 message(STATUS "PEAK_GUM_PEAK_API_AVAILABLE = ${PEAK_GUM_PEAK_API_AVAILABLE}")
 message(STATUS "PEAK_GUM_PEAK_PC_API_AVAILABLE = ${PEAK_GUM_PEAK_PC_API_AVAILABLE}")
 
-set(PEAK_DETACH_HELPER_SUPPORTED OFF)
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64|aarch64|arm64|ARM64)$")
-    set(PEAK_DETACH_HELPER_SUPPORTED ON)
-endif()
+include(cmake/exec-platform.cmake)
+peak_exec_configure_platform_support()
+peak_exec_enable_raw_syscall_language()
+message(STATUS "PEAK_EXEC_RAW_SYSCALL_SUPPORTED = ${PEAK_EXEC_RAW_SYSCALL_SUPPORTED}")
 message(STATUS "PEAK_DETACH_HELPER_SUPPORTED = ${PEAK_DETACH_HELPER_SUPPORTED}")
 
 # Find or download otf2

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ full output and teardown behavior.
 For runtime behavior, accounting, and tuning, see
 [Heartbeat mechanism and runtime policy](docs/heartbeat.md).
 
+### Exec-Chain Profiling
+
+| Variable | Purpose |
+| --- | --- |
+| `PEAK_EXEC_CHAIN` | Keep PEAK available across eligible exec and spawn children. Default: enabled. |
+| `PEAK_EXEC_CHECKPOINT` | Write a best-effort checkpoint before direct exec calls. Default: enabled. |
+| `PEAK_EXEC_PROPAGATE_PEAK_ENV` | Copy missing parent `PEAK_*` settings into a child environment. Default: enabled. |
+
+See [Exec-chain profiling](docs/exec-chain.md) for supported API families,
+child-environment precedence, fork safety, and limitations.
+
 ### Detach and Safety
 
 | Variable | Purpose |
@@ -250,6 +261,8 @@ toolchains and host capabilities detected during configuration.
 
 - [Heartbeat mechanism and runtime policy](docs/heartbeat.md): implementation
   behavior, overhead accounting, and tuning.
+- [Exec-chain profiling](docs/exec-chain.md): child-environment behavior,
+  supported exec and spawn APIs, and fork safety limits.
 - [Physical detach controller](docs/physical-detach-controller.md): strict
   transition safety, MPI output, dynamic loading, and shutdown behavior.
 - [JIT profiling](docs/jit-profiling.md): provider guarantees, retry behavior,

--- a/README.md
+++ b/README.md
@@ -180,9 +180,24 @@ For runtime behavior, accounting, and tuning, see
 
 | Variable | Purpose |
 | --- | --- |
-| `PEAK_EXEC_CHAIN` | Keep PEAK available across eligible exec and spawn children. Default: enabled. |
-| `PEAK_EXEC_CHECKPOINT` | Write a best-effort checkpoint before direct exec calls. Default: enabled. |
+| `PEAK_EXEC_CHAIN` | Explicit startup opt-in to keep PEAK available across eligible exec and spawn children. Default: disabled. |
+| `PEAK_EXEC_CHECKPOINT` | Explicit startup opt-in to write a best-effort checkpoint before direct exec calls. Default: disabled. |
 | `PEAK_EXEC_PROPAGATE_PEAK_ENV` | Copy missing parent `PEAK_*` settings into a child environment. Default: enabled. |
+
+Enabling either startup option may enter PEAK's rich exec handling, which can
+inspect environments, allocate, trace, and checkpoint and is not
+async-signal-safe. With both options disabled, array-based wrappers bypass
+directly to primed libc functions; variadic adapters only perform their bounded
+stack-based argument scan before calling the corresponding primed libc
+function.
+
+Before constructor publication on Linux x86_64/aarch64, direct-path exec APIs
+issue raw kernel calls, while PATH-search APIs perform a bounded stack search
+whose candidates also use raw kernel calls. Unsupported architectures preserve
+native exec semantics through libc resolution in this window, so the
+resolver-free async-signal-safe guarantee does not apply there.
+Pre-constructor `posix_spawn*` retains libc resolution on every architecture to
+preserve native spawn semantics and is not async-signal-safe.
 
 See [Exec-chain profiling](docs/exec-chain.md) for supported API families,
 child-environment precedence, fork safety, and limitations.

--- a/cmake/exec-platform.cmake
+++ b/cmake/exec-platform.cmake
@@ -1,0 +1,45 @@
+function(peak_exec_raw_syscall_supported output_var system_name system_processor)
+    set(_peak_exec_supported OFF)
+    if("${system_name}" MATCHES "^Linux$" AND
+       "${system_processor}" MATCHES "^(x86_64|AMD64|amd64|aarch64|arm64|ARM64)$")
+        set(_peak_exec_supported ON)
+    endif()
+    set(${output_var} ${_peak_exec_supported} PARENT_SCOPE)
+endfunction()
+
+function(peak_detach_helper_supported output_var system_name system_processor)
+    # The helper depends on Linux ptrace/register ABI support, not on the
+    # syscall trampoline. Keep this predicate independent as architectures
+    # gain either capability on their own schedule.
+    set(_peak_detach_helper_supported OFF)
+    if("${system_name}" MATCHES "^Linux$" AND
+       "${system_processor}" MATCHES "^(x86_64|AMD64|amd64|aarch64|arm64|ARM64)$")
+        set(_peak_detach_helper_supported ON)
+    endif()
+    set(${output_var} ${_peak_detach_helper_supported} PARENT_SCOPE)
+endfunction()
+
+macro(peak_exec_configure_platform_support)
+    peak_exec_raw_syscall_supported(
+        PEAK_EXEC_RAW_SYSCALL_SUPPORTED
+        "${CMAKE_SYSTEM_NAME}"
+        "${CMAKE_SYSTEM_PROCESSOR}")
+    peak_detach_helper_supported(
+        PEAK_DETACH_HELPER_SUPPORTED
+        "${CMAKE_SYSTEM_NAME}"
+        "${CMAKE_SYSTEM_PROCESSOR}")
+endmacro()
+
+macro(peak_exec_enable_raw_syscall_language)
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        enable_language(ASM)
+    endif()
+endmacro()
+
+function(peak_exec_append_raw_syscall_trampoline sources_var trampoline_source)
+    set(_peak_exec_sources ${${sources_var}})
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        list(APPEND _peak_exec_sources "${trampoline_source}")
+    endif()
+    set(${sources_var} ${_peak_exec_sources} PARENT_SCOPE)
+endfunction()

--- a/docs/exec-chain.md
+++ b/docs/exec-chain.md
@@ -71,6 +71,8 @@ application signal handlers. With both startup options disabled, the direct
 array-based wrappers take the primed bypass described above; variadic adapters
 still perform their bounded stack scan.
 
+Checkpoint CSV rows count completed calls only and omit calls that are still in flight.
+
 ## Forked Children and Internal Helpers
 
 After `fork()` or `vfork()`, PEAK uses a bounded, allocation-free child path

--- a/docs/exec-chain.md
+++ b/docs/exec-chain.md
@@ -9,7 +9,7 @@ replace themselves with a later program image.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `PEAK_EXEC_CHAIN` | enabled | Keep PEAK available to an eligible child by carrying or adding PEAK's library to the child's `LD_PRELOAD`. Set to `0` to leave the child environment unchanged by exec-chain handling. |
-| `PEAK_EXEC_CHECKPOINT` | enabled | Write a best-effort profiling checkpoint before a direct exec. Set to `0` when that pre-exec snapshot is not wanted. This does not disable exec-chain environment handling. |
+| `PEAK_EXEC_CHECKPOINT` | enabled | Write a best-effort profiling checkpoint before a direct exec. The checkpoint performs allocation and I/O; set to `0` to avoid it. This does not disable exec-chain environment handling. |
 | `PEAK_EXEC_PROPAGATE_PEAK_ENV` | enabled | Copy missing `PEAK_*` settings from the parent environment into a child environment. Set to `0` to require each child environment to provide its own PEAK settings. |
 
 The explicit child environment is authoritative. Its values, including a
@@ -38,6 +38,11 @@ handles `posix_spawn` and `posix_spawnp`.
 
 The checkpoint applies to direct exec-family calls, not `posix_spawn` calls.
 `posix_spawn` can still receive the exec-chain child environment.
+
+The optional checkpoint is not async-signal-safe and is best-effort: an
+unavailable snapshot simply does not produce a checkpoint. Disabling
+`PEAK_EXEC_CHECKPOINT` avoids that checkpoint; it does not make broader
+exec-chain interposition async-signal-safe.
 
 ## Forked Children and Internal Helpers
 

--- a/docs/exec-chain.md
+++ b/docs/exec-chain.md
@@ -1,0 +1,66 @@
+# Exec-Chain Profiling
+
+PEAK can continue profiling when an instrumented process starts another
+program. This is useful for launchers, workflow drivers, and applications that
+replace themselves with a later program image.
+
+## Controls
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PEAK_EXEC_CHAIN` | enabled | Keep PEAK available to an eligible child by carrying or adding PEAK's library to the child's `LD_PRELOAD`. Set to `0` to leave the child environment unchanged by exec-chain handling. |
+| `PEAK_EXEC_CHECKPOINT` | enabled | Write a best-effort profiling checkpoint before a direct exec. Set to `0` when that pre-exec snapshot is not wanted. This does not disable exec-chain environment handling. |
+| `PEAK_EXEC_PROPAGATE_PEAK_ENV` | enabled | Copy missing `PEAK_*` settings from the parent environment into a child environment. Set to `0` to require each child environment to provide its own PEAK settings. |
+
+The explicit child environment is authoritative. Its values, including a
+`PEAK_*` value that differs from the parent, are preserved. With propagation
+enabled, PEAK copies only parent `PEAK_*` entries that the child did not
+provide. This matters for callers of APIs that accept an `envp` argument:
+provide the desired child settings there rather than relying on the parent.
+
+PEAK preserves existing `LD_PRELOAD` entries. It adds PEAK's library only when
+profiling is already active, PEAK work is requested, or PEAK is already present
+in the current or child environment. When PEAK newly adds its library and the
+child has no `LD_LIBRARY_PATH`, it may carry the loader path needed to find
+that library. In this case, PEAK copies the complete, nonempty parent
+`LD_LIBRARY_PATH` value cached when PEAK's constructor ran; it does not derive
+or narrow the path to libpeak-only directories. PEAK does not add that
+loader-path entry merely because it is propagating `PEAK_*` settings or
+preserving an existing PEAK preload.
+
+## Supported APIs
+
+The runtime handles the common exec families: `execve`, `execv`, `execvp`,
+`execvpe`, `execl`, `execlp`, and `execle`, plus Linux `fexecve` and
+`execveat`. Production Linux builds also handle raw
+`syscall(SYS_execve, ...)` and `syscall(SYS_execveat, ...)` calls. PEAK also
+handles `posix_spawn` and `posix_spawnp`.
+
+The checkpoint applies to direct exec-family calls, not `posix_spawn` calls.
+`posix_spawn` can still receive the exec-chain child environment.
+
+## Forked Children and Internal Helpers
+
+After `fork()` or `vfork()`, PEAK uses a bounded, allocation-free child path
+before the subsequent exec. It does not run the normal checkpoint or mutate
+shared runtime state there. If it cannot safely inspect or construct the child
+environment, it falls back to the original environment and lets the requested
+exec proceed. Secure-execution mode also suppresses preload injection.
+
+PEAK's own detach helper is an internal control process, not an exec-chain
+target. It starts with loader and `PEAK_*` settings removed and with
+`PEAK_EXEC_CHAIN=0`, so it does not inherit application profiling or start a
+further chain.
+
+## Practical Limits
+
+- Exec-chain support is for dynamically loaded Linux processes. A static
+  executable cannot load PEAK through `LD_PRELOAD`.
+- Secure-execution rules can cause the dynamic loader to ignore preload
+  variables; PEAK deliberately does not attempt to bypass them.
+- A child that intentionally supplies a minimal environment must include the
+  PEAK configuration it needs, or leave propagation enabled for missing
+  `PEAK_*` settings.
+- The bounded fork-child path may decline to modify unusually large, malformed,
+  or unreadable environments. The child still follows the original exec
+  request, but PEAK may not continue into that program.

--- a/docs/exec-chain.md
+++ b/docs/exec-chain.md
@@ -8,9 +8,33 @@ replace themselves with a later program image.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `PEAK_EXEC_CHAIN` | enabled | Keep PEAK available to an eligible child by carrying or adding PEAK's library to the child's `LD_PRELOAD`. Set to `0` to leave the child environment unchanged by exec-chain handling. |
-| `PEAK_EXEC_CHECKPOINT` | enabled | Write a best-effort profiling checkpoint before a direct exec. The checkpoint performs allocation and I/O; set to `0` to avoid it. This does not disable exec-chain environment handling. |
+| `PEAK_EXEC_CHAIN` | disabled | Explicit startup opt-in to keep PEAK available to an eligible child by carrying or adding PEAK's library to the child's `LD_PRELOAD`. |
+| `PEAK_EXEC_CHECKPOINT` | disabled | Explicit startup opt-in to write a best-effort profiling checkpoint before a direct exec. The checkpoint performs allocation and I/O. This does not enable exec-chain environment handling. |
 | `PEAK_EXEC_PROPAGATE_PEAK_ENV` | enabled | Copy missing `PEAK_*` settings from the parent environment into a child environment. Set to `0` to require each child environment to provide its own PEAK settings. |
+
+The constructor caches the two startup options after resolving the real libc
+symbols. If both are absent or false, the array-based exec and spawn wrappers
+directly call those primed functions before inspecting arguments or the
+environment, tracing, checkpointing, allocation, TLS bookkeeping, or lazy
+symbol resolution. The variadic `execl`, `execlp`, and `execle` adapters must
+first scan a bounded argument list into a stack array, then call the
+corresponding primed libc function directly without allocation or rich
+handling. `execvp` and `execlp` use libc's independently resolved `execvp`, not
+the optional GNU `execvpe`. A call-specific child environment cannot enable
+either feature in this mode. Once the rich owner path is enabled, a child
+environment may still disable either feature for that call;
+`PEAK_EXEC_CHAIN` and `PEAK_EXEC_CHECKPOINT` remain independent.
+
+Before constructor publication on Linux x86_64/aarch64, direct-path wrappers
+use raw kernel exec calls. `execvp`, `execvpe`, and `execlp` instead perform a
+bounded PATH scan with stack storage and issue each candidate through the same
+raw kernel path. On unsupported raw-syscall architectures, pre-constructor
+exec wrappers preserve native behavior through libc resolution; the
+resolver-free async-signal-safe guarantee is therefore limited to Linux
+x86_64/aarch64. `posix_spawn` and `posix_spawnp` retain libc symbol resolution
+in that narrow window on every architecture to preserve native file-action,
+attribute, and return-value semantics, so pre-constructor spawn calls are not
+async-signal-safe.
 
 The explicit child environment is authoritative. Its values, including a
 `PEAK_*` value that differs from the parent, are preserved. With propagation
@@ -31,8 +55,8 @@ preserving an existing PEAK preload.
 ## Supported APIs
 
 The runtime handles the common exec families: `execve`, `execv`, `execvp`,
-`execvpe`, `execl`, `execlp`, and `execle`, plus Linux `fexecve` and
-`execveat`. Production Linux builds also handle raw
+`execvpe`, `execl`, `execlp`, `execle`, and `fexecve`, plus Linux `execveat`.
+Linux x86_64 and aarch64 builds also handle raw
 `syscall(SYS_execve, ...)` and `syscall(SYS_execveat, ...)` calls. PEAK also
 handles `posix_spawn` and `posix_spawnp`.
 
@@ -40,9 +64,12 @@ The checkpoint applies to direct exec-family calls, not `posix_spawn` calls.
 `posix_spawn` can still receive the exec-chain child environment.
 
 The optional checkpoint is not async-signal-safe and is best-effort: an
-unavailable snapshot simply does not produce a checkpoint. Disabling
-`PEAK_EXEC_CHECKPOINT` avoids that checkpoint; it does not make broader
-exec-chain interposition async-signal-safe.
+unavailable snapshot simply does not produce a checkpoint. With either startup
+opt-in enabled, the rich direct-exec handling may inspect environments,
+allocate, trace, and checkpoint, so it is not async-signal-safe for arbitrary
+application signal handlers. With both startup options disabled, the direct
+array-based wrappers take the primed bypass described above; variadic adapters
+still perform their bounded stack scan.
 
 ## Forked Children and Internal Helpers
 
@@ -69,3 +96,13 @@ further chain.
 - The bounded fork-child path may decline to modify unusually large, malformed,
   or unreadable environments. The child still follows the original exec
   request, but PEAK may not continue into that program.
+- Exec-family calls from arbitrary application signal handlers require both
+  startup options to remain disabled. Array-based wrappers then delegate
+  directly to libc; variadic adapters still inspect the bounded argument list
+  on the caller's stack before delegating. The underlying libc API's own
+  async-signal-safety contract still applies.
+- The platform-selection configuration contract evaluates synthetic CMake
+  target metadata against the production predicate. It verifies that
+  unsupported shapes leave raw syscalls and the detach helper disabled, do not
+  enable ASM, and omit the syscall trampoline while a portable probe object is
+  compiled with the configured host compiler.

--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -1,0 +1,48 @@
+#ifndef PEAK_EXEC_INTERCEPTOR_H
+#define PEAK_EXEC_INTERCEPTOR_H
+
+/**
+ * @file exec_interceptor.h
+ * @brief Exec-chain checkpoint and environment propagation support.
+ */
+
+#if defined(__GNUC__) || defined(__clang__)
+#define PEAK_EXEC_API __attribute__((visibility("default")))
+#else
+#define PEAK_EXEC_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Returns nonzero when PEAK runtime state may be checkpointed.
+ */
+PEAK_EXEC_API int peak_runtime_is_active_for_checkpoint(void);
+
+/**
+ * @brief Write a best-effort, rank-local checkpoint before an exec handoff.
+ *
+ * This API is intentionally non-destructive: it must not call peak_fini(),
+ * detach or reattach hooks, stop PEAK background workers, or use MPI.
+ *
+ * @return 0 when a checkpoint artifact was written, -1 otherwise.
+ */
+PEAK_EXEC_API int peak_checkpoint_for_exec(const char* path,
+                                           char* const argv[]);
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+/* Test-only synchronization for the checkpoint/fini lifetime-gate regression. */
+PEAK_EXEC_API void peak_test_checkpoint_reader_pause_enable(void);
+PEAK_EXEC_API int peak_test_checkpoint_reader_is_held(void);
+PEAK_EXEC_API void peak_test_checkpoint_reader_release(void);
+PEAK_EXEC_API int peak_test_fini_waiting_for_checkpoint_reader(void);
+PEAK_EXEC_API void peak_test_fini(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PEAK_EXEC_INTERCEPTOR_H */

--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -26,6 +26,7 @@ PEAK_EXEC_API int peak_runtime_is_active_for_checkpoint(void);
  *
  * This API is intentionally non-destructive: it must not call peak_fini(),
  * detach or reattach hooks, stop PEAK background workers, or use MPI.
+ * It requires PEAK_EXEC_CHECKPOINT to be enabled at startup.
  *
  * @return 0 when a checkpoint artifact was written, -1 otherwise.
  */

--- a/include/general_listener.h
+++ b/include/general_listener.h
@@ -185,6 +185,8 @@ PEAK_API int peak_general_listener_test_mpi_uint64_type_size(void);
 #ifdef PEAK_ENABLE_TEST_HOOKS
 uint64_t peak_general_listener_test_add_uint64_saturated(uint64_t lhs,
                                                           uint64_t rhs);
+PEAK_API int peak_general_listener_test_checkpoint_snapshot_lock_hold(void);
+PEAK_API int peak_general_listener_test_checkpoint_snapshot_lock_release(void);
 #endif
 
 /**

--- a/include/general_listener.h
+++ b/include/general_listener.h
@@ -36,6 +36,27 @@
 
 typedef struct _PeakGeneralListener PeakGeneralListener;
 
+#if defined(__GNUC__) || defined(__clang__)
+typedef struct __attribute__((aligned(64))) {
+#else
+typedef struct {
+#endif
+    _Atomic gulong sequence;
+    _Atomic int invalid;
+    gulong completed_calls;
+    gdouble total_time;
+    gdouble exclusive_time;
+    gfloat max_time;
+    gfloat min_time;
+} PeakGeneralListenerCheckpointShadow;
+
+#if defined(__GNUC__) || defined(__clang__)
+_Static_assert(sizeof(PeakGeneralListenerCheckpointShadow) == 64,
+               "checkpoint shadow slot must occupy one cache line");
+_Static_assert(__alignof__(PeakGeneralListenerCheckpointShadow) == 64,
+               "checkpoint shadow slot must be cache-line aligned");
+#endif
+
 #define PEAKGENERAL_TYPE_LISTENER (peak_general_listener_get_type())
 G_DECLARE_FINAL_TYPE(PeakGeneralListener, peak_general_listener, PEAKGENERAL, LISTENER, GObject)
 
@@ -73,6 +94,7 @@ struct _PeakGeneralListener {
     gfloat* max_time;
     gfloat* min_time;
     gboolean* target_thread_called;
+    PeakGeneralListenerCheckpointShadow* checkpoint_shadow;
 };
 
 typedef struct {
@@ -187,6 +209,13 @@ uint64_t peak_general_listener_test_add_uint64_saturated(uint64_t lhs,
                                                           uint64_t rhs);
 PEAK_API int peak_general_listener_test_checkpoint_snapshot_lock_hold(void);
 PEAK_API int peak_general_listener_test_checkpoint_snapshot_lock_release(void);
+PEAK_API int peak_general_listener_test_checkpoint_mutation_begin(void);
+PEAK_API void peak_general_listener_test_checkpoint_mutation_release(void);
+PEAK_API int peak_general_listener_test_checkpoint_mutation_contend(void);
+PEAK_API int peak_general_listener_test_checkpoint_mutation_contender_invalidated(void);
+PEAK_API void peak_general_listener_test_checkpoint_busy_pause_enable(void);
+PEAK_API int peak_general_listener_test_checkpoint_busy_is_held(void);
+PEAK_API void peak_general_listener_test_checkpoint_busy_release(void);
 #endif
 
 /**

--- a/include/internal/exec_interceptor_internal.h
+++ b/include/internal/exec_interceptor_internal.h
@@ -1,0 +1,12 @@
+#ifndef __PEAK_EXEC_INTERCEPTOR_INTERNAL_H
+#define __PEAK_EXEC_INTERCEPTOR_INTERNAL_H
+
+#if defined(__GNUC__) || defined(__clang__)
+#define PEAK_EXEC_INTERNAL __attribute__((visibility("hidden")))
+#else
+#define PEAK_EXEC_INTERNAL
+#endif
+
+PEAK_EXEC_INTERNAL int peak_exec_checkpoint_enabled_at_startup(void);
+
+#endif /* __PEAK_EXEC_INTERCEPTOR_INTERNAL_H */

--- a/include/internal/exec_memory.h
+++ b/include/internal/exec_memory.h
@@ -1,0 +1,26 @@
+#ifndef PEAK_INTERNAL_EXEC_MEMORY_H
+#define PEAK_INTERNAL_EXEC_MEMORY_H
+
+#include <stddef.h>
+
+#ifndef PEAK_EXEC_MAX_ENV_ENTRIES
+#define PEAK_EXEC_MAX_ENV_ENTRIES 32768U
+#endif
+
+#ifndef PEAK_EXEC_USER_STRING_MAX
+#define PEAK_EXEC_USER_STRING_MAX (1024U * 1024U)
+#endif
+
+typedef enum {
+    PEAK_EXEC_PREFLIGHT_VALID = 0,
+    PEAK_EXEC_PREFLIGHT_INVALID,
+    PEAK_EXEC_PREFLIGHT_UNKNOWN
+} PeakExecPreflightResult;
+
+PeakExecPreflightResult peak_exec_args_readable(const char* path,
+                                                char* const argv[],
+                                                char* const envp[]);
+PeakExecPreflightResult peak_exec_argv_envp_readable(char* const argv[],
+                                                     char* const envp[]);
+
+#endif

--- a/include/internal/exec_raw_syscall.h
+++ b/include/internal/exec_raw_syscall.h
@@ -1,0 +1,93 @@
+#ifndef PEAK_INTERNAL_EXEC_RAW_SYSCALL_H
+#define PEAK_INTERNAL_EXEC_RAW_SYSCALL_H
+
+#include <errno.h>
+
+int peak_exec_raw_syscall_execve(const char* path,
+                                 char* const argv[],
+                                 char* const envp[]);
+
+int peak_exec_raw_syscall_handle(long number,
+                                 long arg1,
+                                 long arg2,
+                                 long arg3,
+                                 long arg4,
+                                 long arg5,
+                                 long arg6,
+                                 long* result);
+
+#if defined(__linux__)
+int peak_exec_raw_syscall_execveat(int dirfd,
+                                   const char* pathname,
+                                   char* const argv[],
+                                   char* const envp[],
+                                   int flags);
+#endif
+
+static inline long
+peak_exec_raw_syscall6(long number,
+                       long arg1,
+                       long arg2,
+                       long arg3,
+                       long arg4,
+                       long arg5,
+                       long arg6)
+{
+#if defined(__linux__) && defined(__x86_64__)
+    long result;
+    register long r10 __asm__("r10") = arg4;
+    register long r8 __asm__("r8") = arg5;
+    register long r9 __asm__("r9") = arg6;
+
+    __asm__ volatile("syscall"
+                     : "=a"(result)
+                     : "a"(number),
+                       "D"(arg1),
+                       "S"(arg2),
+                       "d"(arg3),
+                       "r"(r10),
+                       "r"(r8),
+                       "r"(r9)
+                     : "rcx", "r11", "memory");
+    if (result < 0 && result >= -4095) {
+        errno = (int)-result;
+        return -1;
+    }
+    return result;
+#elif defined(__linux__) && defined(__aarch64__)
+    register long x0 __asm__("x0") = arg1;
+    register long x1 __asm__("x1") = arg2;
+    register long x2 __asm__("x2") = arg3;
+    register long x3 __asm__("x3") = arg4;
+    register long x4 __asm__("x4") = arg5;
+    register long x5 __asm__("x5") = arg6;
+    register long x8 __asm__("x8") = number;
+
+    __asm__ volatile("svc #0"
+                     : "+r"(x0)
+                     : "r"(x1),
+                       "r"(x2),
+                       "r"(x3),
+                       "r"(x4),
+                       "r"(x5),
+                       "r"(x8)
+                     : "cc", "memory");
+    if (x0 < 0 && x0 >= -4095) {
+        errno = (int)-x0;
+        return -1;
+    }
+    return x0;
+#else
+    (void)number;
+    (void)arg1;
+    (void)arg2;
+    (void)arg3;
+    (void)arg4;
+    (void)arg5;
+    (void)arg6;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+#endif

--- a/include/internal/general_listener_internal.h
+++ b/include/internal/general_listener_internal.h
@@ -20,4 +20,7 @@ gboolean peak_general_listener_dynamic_symbol_matches_any_target(
     const char* symbol_name,
     const char* provider_name);
 
+gboolean peak_general_listener_checkpoint_for_exec(
+    unsigned long long checkpoint_index);
+
 #endif /* __PEAK_GENERAL_LISTENER_INTERNAL_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,12 @@ set(sources_peak
     pthread_listener.c
     syscall_interceptor.c
     unsafe_gum_prologue.c
+    exec_memory.c
+    exec_interceptor.c
+    exec_raw_syscall.c
+    exec_raw_syscall_trampoline.S
 )
+
 FILE(GLOB sources_peak_mpi
     mpi_interceptor.c
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,12 @@ set(sources_peak
     exec_memory.c
     exec_interceptor.c
     exec_raw_syscall.c
-    exec_raw_syscall_trampoline.S
 )
+
+# The C dispatcher is portable. Its assembly syscall interposer is selected by
+# the shared platform contract used at the project root and in platform tests.
+peak_exec_append_raw_syscall_trampoline(
+    sources_peak exec_raw_syscall_trampoline.S)
 
 FILE(GLOB sources_peak_mpi
     mpi_interceptor.c

--- a/src/detach_controller.c
+++ b/src/detach_controller.c
@@ -1057,6 +1057,7 @@ peak_detach_controller_build_helper_env(void)
 {
     size_t count = 0;
     size_t kept = 0;
+    static const char helper_exec_chain_env[] = "PEAK_EXEC_CHAIN=0";
 
     if (environ == NULL) {
         return NULL;
@@ -1066,7 +1067,7 @@ peak_detach_controller_build_helper_env(void)
         count++;
     }
 
-    char** helper_env = calloc(count + 1, sizeof(*helper_env));
+    char** helper_env = calloc(count + 2, sizeof(*helper_env));
     if (helper_env == NULL) {
         return NULL;
     }
@@ -1084,6 +1085,16 @@ peak_detach_controller_build_helper_env(void)
             kept++;
         }
     }
+    /* The helper is an internal control process, never an exec-chain target. */
+    helper_env[kept] = strdup(helper_exec_chain_env);
+    if (helper_env[kept] == NULL) {
+        for (size_t j = 0; j < kept; j++) {
+            free(helper_env[j]);
+        }
+        free(helper_env);
+        return NULL;
+    }
+    kept++;
     helper_env[kept] = NULL;
     return helper_env;
 }

--- a/src/exec_interceptor.c
+++ b/src/exec_interceptor.c
@@ -91,6 +91,11 @@ static __thread int peak_exec_spawn_depth;
 static pid_t peak_exec_owner_pid;
 static char peak_exec_cached_libpeak_path[PATH_MAX];
 static int peak_exec_cached_libpeak_path_ready;
+static char* peak_exec_cached_ld_library_path;
+static int peak_exec_cached_ld_library_path_ready;
+static int peak_exec_cached_ld_library_path_failed;
+static int peak_exec_cached_secure_mode;
+static int peak_exec_cached_secure_mode_ready;
 
 static int
 peak_exec_in_fork_child(void)
@@ -217,7 +222,7 @@ peak_exec_child_entry_matches(const char* entry, const char* name)
     }
 }
 
-/* Returns 0 when found, 1 when absent, and -1 when memory is unreadable. */
+/* Returns 0 when found, 1 when absent, and -1 when unreadable or unterminated. */
 static int
 peak_exec_child_env_get(char* const envp[], const char* name, const char** value)
 {
@@ -243,7 +248,7 @@ peak_exec_child_env_get(char* const envp[], const char* name, const char** value
             return 0;
         }
     }
-    return 1;
+    return -1;
 }
 
 static int
@@ -372,10 +377,14 @@ peak_exec_child_build_env(char* const envp[],
     size_t out = 0;
     size_t ld_len = sizeof("LD_PRELOAD=") - 1;
     size_t libpeak_len = 0;
+    int child_has_ld_library_path = 0;
+    int libpeak_already_present = 0;
+    int env_terminated = envp == NULL;
     int propagate_peak_env;
     int chain_enabled;
 
-    if (!peak_exec_cached_libpeak_path_ready ||
+    if (!peak_exec_cached_secure_mode_ready || peak_exec_cached_secure_mode ||
+        !peak_exec_cached_libpeak_path_ready ||
         peak_exec_child_control_enabled(envp,
                                         PEAK_EXEC_CHAIN_ENV,
                                         &chain_enabled) != 0 ||
@@ -396,19 +405,31 @@ peak_exec_child_build_env(char* const envp[],
     if (envp != NULL) {
         for (size_t index = 0; index < PEAK_EXEC_CHILD_ENV_SLOTS; index++) {
             const char* entry;
-            int matches;
+            int preload_matches;
+            int library_path_matches;
 
             if (peak_exec_child_read_pointer(envp, index, &entry) != 0) {
                 return envp;
             }
             if (entry == NULL) {
+                env_terminated = 1;
                 break;
             }
-            matches = peak_exec_child_entry_matches(entry, "LD_PRELOAD");
-            if (matches < 0) {
+            preload_matches = peak_exec_child_entry_matches(entry, "LD_PRELOAD");
+            if (preload_matches < 0) {
                 return envp;
             }
-            if (matches != 0) {
+            if (preload_matches == 0) {
+                library_path_matches = peak_exec_child_entry_matches(
+                    entry, "LD_LIBRARY_PATH");
+                if (library_path_matches < 0) {
+                    return envp;
+                }
+                if (library_path_matches != 0) {
+                    child_has_ld_library_path = 1;
+                }
+            }
+            if (preload_matches != 0) {
                 const char* value = entry + sizeof("LD_PRELOAD=") - 1;
                 const char* cursor = value;
                 size_t cursor_index = 0;
@@ -442,6 +463,9 @@ peak_exec_child_build_env(char* const envp[],
                         peak_exec_child_token_is_cached_libpeak(
                             (const char*)((uintptr_t)cursor + token_start),
                             token_len)) {
+                        if (token_len != 0) {
+                            libpeak_already_present = 1;
+                        }
                         continue;
                     }
                     if (ld_len + 1 + token_len + 1 >
@@ -464,9 +488,24 @@ peak_exec_child_build_env(char* const envp[],
                 return envp;
             }
         }
+        if (!env_terminated) {
+            return envp;
+        }
     }
     if (peak_exec_child_append_preload(output, &out, ld_preload) != 0) {
         return envp;
+    }
+    if (!libpeak_already_present && !child_has_ld_library_path) {
+        if (!peak_exec_cached_ld_library_path_ready ||
+            peak_exec_cached_ld_library_path_failed) {
+            return envp;
+        }
+        if (peak_exec_cached_ld_library_path != NULL &&
+            peak_exec_child_append_preload(output,
+                                           &out,
+                                           peak_exec_cached_ld_library_path) != 0) {
+            return envp;
+        }
     }
 
     if (peak_exec_child_control_enabled(envp,
@@ -475,6 +514,8 @@ peak_exec_child_build_env(char* const envp[],
         return envp;
     }
     if (propagate_peak_env && environ != NULL) {
+        int parent_env_terminated = 0;
+
         for (size_t index = 0; index < PEAK_EXEC_CHILD_ENV_SLOTS; index++) {
             const char* entry;
             char prefix[5];
@@ -486,6 +527,7 @@ peak_exec_child_build_env(char* const envp[],
                 return envp;
             }
             if (entry == NULL) {
+                parent_env_terminated = 1;
                 break;
             }
             if (peak_exec_child_read(entry, prefix, sizeof(prefix)) != 0 ||
@@ -518,6 +560,9 @@ peak_exec_child_build_env(char* const envp[],
                     return envp;
                 }
             }
+        }
+        if (!parent_env_terminated) {
+            return envp;
         }
     }
     output[out] = NULL;
@@ -1150,6 +1195,8 @@ peak_exec_build_env(char* const envp[],
     int secure;
     int should_touch_ld = 0;
     int new_ld_changed = 0;
+    int libpeak_already_present = 0;
+    int add_ld_library_path = 0;
     int ld_written = 0;
     char* libpeak_path = NULL;
     char* existing_ld_joined = NULL;
@@ -1182,6 +1229,8 @@ peak_exec_build_env(char* const envp[],
             errno = ENOMEM;
             return -1;
         }
+        libpeak_already_present = peak_exec_preload_contains_libpeak(
+            existing_ld_joined, libpeak_path);
         new_ld_value = peak_exec_build_ld_preload(existing_ld_joined,
                                                   libpeak_path,
                                                   &new_ld_changed);
@@ -1195,7 +1244,21 @@ peak_exec_build_env(char* const envp[],
         missing_peak_count = peak_exec_count_missing_peak_env(base_env);
     }
 
-    if (!new_ld_changed && missing_peak_count == 0 && ld_entry_count <= 1) {
+    if (new_ld_changed && !libpeak_already_present &&
+        !peak_exec_env_has_name(base_env, "LD_LIBRARY_PATH")) {
+        if (!peak_exec_cached_ld_library_path_ready ||
+            peak_exec_cached_ld_library_path_failed) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            errno = ENOMEM;
+            return -1;
+        }
+        add_ld_library_path = peak_exec_cached_ld_library_path != NULL;
+    }
+
+    if (!new_ld_changed && !add_ld_library_path && missing_peak_count == 0 &&
+        ld_entry_count <= 1) {
         free(new_ld_value);
         free(existing_ld_joined);
         free(libpeak_path);
@@ -1204,7 +1267,8 @@ peak_exec_build_env(char* const envp[],
 
     if (peak_exec_size_add(
             missing_peak_count,
-            (should_touch_ld && ld_entry_count == 0) ? 1 : 0,
+            ((should_touch_ld && ld_entry_count == 0) ? 1 : 0) +
+                (add_ld_library_path ? 1 : 0),
             &extra_count) != 0 ||
         peak_exec_size_add(base_count, extra_count, &env_capacity) != 0 ||
         peak_exec_size_add(env_capacity, 1, &env_capacity) != 0) {
@@ -1344,6 +1408,18 @@ peak_exec_build_env(char* const envp[],
             return -1;
         }
         built->envp[out++] = entry;
+        built->changed = 1;
+    }
+
+    if (add_ld_library_path) {
+        if (out + 1 >= env_capacity) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            errno = E2BIG;
+            return -1;
+        }
+        built->envp[out++] = peak_exec_cached_ld_library_path;
         built->changed = 1;
     }
 
@@ -1545,12 +1621,49 @@ peak_exec_cache_libpeak_path(void)
     free(libpeak_path);
 }
 
+static void
+peak_exec_cache_ld_library_path(void)
+{
+    const char* value = getenv("LD_LIBRARY_PATH");
+    const size_t prefix_length = sizeof("LD_LIBRARY_PATH=") - 1;
+    size_t value_length;
+    char* entry;
+
+    if (value == NULL || value[0] == '\0') {
+        peak_exec_cached_ld_library_path_ready = 1;
+        return;
+    }
+    value_length = strlen(value);
+    if (value_length > SIZE_MAX - prefix_length - 1) {
+        peak_exec_cached_ld_library_path_failed = 1;
+        return;
+    }
+    entry = malloc(prefix_length + value_length + 1);
+    if (entry == NULL) {
+        peak_exec_cached_ld_library_path_failed = 1;
+        return;
+    }
+    memcpy(entry, "LD_LIBRARY_PATH=", prefix_length);
+    memcpy(entry + prefix_length, value, value_length + 1);
+    peak_exec_cached_ld_library_path = entry;
+    peak_exec_cached_ld_library_path_ready = 1;
+}
+
+static void
+peak_exec_cache_secure_mode(void)
+{
+    peak_exec_cached_secure_mode = peak_exec_secure_mode();
+    peak_exec_cached_secure_mode_ready = 1;
+}
+
 __attribute__((constructor))
 static void
 peak_exec_prime_real_symbols(void)
 {
     peak_exec_owner_pid = getpid();
     peak_exec_cache_libpeak_path();
+    peak_exec_cache_ld_library_path();
+    peak_exec_cache_secure_mode();
     (void)peak_real_execve();
     (void)peak_real_execvpe();
     (void)peak_real_fexecve();

--- a/src/exec_interceptor.c
+++ b/src/exec_interceptor.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include "exec_interceptor.h"
+#include "internal/exec_interceptor_internal.h"
 #include "internal/exec_memory.h"
 #include "internal/exec_raw_syscall.h"
 #include "utils/utils.h"
@@ -131,6 +132,12 @@ _Static_assert(ATOMIC_INT_LOCK_FREE == 2,
 _Static_assert(ATOMIC_LONG_LOCK_FREE == 2,
                "exec resolver ownership must always be lock-free");
 static atomic_int peak_exec_priming_complete = ATOMIC_VAR_INIT(0);
+
+PEAK_EXEC_INTERNAL int
+peak_exec_checkpoint_enabled_at_startup(void)
+{
+    return peak_exec_startup_checkpoint_enabled;
+}
 #if !PEAK_EXEC_DIRECT_RAW_SUPPORTED
 /* This guard only breaks loader-time resolver recursion; it is not signal-safe. */
 static __thread int peak_exec_prepublication_execve_resolving;

--- a/src/exec_interceptor.c
+++ b/src/exec_interceptor.c
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include <pthread.h>
 #include <spawn.h>
+#include <stdatomic.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -58,6 +59,7 @@
 extern char** environ;
 
 typedef int (*peak_execve_fn)(const char*, char* const[], char* const[]);
+typedef int (*peak_execvp_fn)(const char*, char* const[]);
 typedef int (*peak_execvpe_fn)(const char*, char* const[], char* const[]);
 typedef int (*peak_fexecve_fn)(int, char* const[], char* const[]);
 typedef int (*peak_execveat_fn)(int,
@@ -78,6 +80,30 @@ typedef int (*peak_posix_spawnp_fn)(pid_t*,
                                     char* const[],
                                     char* const[]);
 
+#if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__))
+#define PEAK_EXEC_DIRECT_RAW_SUPPORTED 1
+#else
+#define PEAK_EXEC_DIRECT_RAW_SUPPORTED 0
+#endif
+
+static int peak_call_real_execve(const char*,
+                                 char* const[],
+                                 char* const[]);
+#if !PEAK_EXEC_DIRECT_RAW_SUPPORTED
+static int peak_call_real_execvp(const char*, char* const[]);
+static int peak_call_real_execvpe(const char*,
+                                  char* const[],
+                                  char* const[]);
+#endif
+static int peak_call_real_fexecve(int, char* const[], char* const[]);
+#if defined(__linux__)
+static int peak_call_real_execveat(int,
+                                   const char*,
+                                   char* const[],
+                                   char* const[],
+                                   int);
+#endif
+
 typedef struct {
     char** envp;
     char** owned_strings;
@@ -96,6 +122,276 @@ static int peak_exec_cached_ld_library_path_ready;
 static int peak_exec_cached_ld_library_path_failed;
 static int peak_exec_cached_secure_mode;
 static int peak_exec_cached_secure_mode_ready;
+/* Immutable after constructor priming; wrappers read these without libc calls. */
+static int peak_exec_startup_chain_enabled;
+static int peak_exec_startup_checkpoint_enabled;
+static int peak_exec_startup_policy_enabled;
+_Static_assert(ATOMIC_INT_LOCK_FREE == 2,
+               "exec policy publication must always be lock-free");
+_Static_assert(ATOMIC_LONG_LOCK_FREE == 2,
+               "exec resolver ownership must always be lock-free");
+static atomic_int peak_exec_priming_complete = ATOMIC_VAR_INIT(0);
+#if !PEAK_EXEC_DIRECT_RAW_SUPPORTED
+/* This guard only breaks loader-time resolver recursion; it is not signal-safe. */
+static __thread int peak_exec_prepublication_execve_resolving;
+#endif
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+static int peak_exec_test_force_execvpe_fallback;
+extern void peak_test_exec_resolver_reentry_hook(void)
+    __attribute__((weak));
+#endif
+
+static int
+peak_exec_priming_is_complete(void)
+{
+    return atomic_load_explicit(&peak_exec_priming_complete,
+                                memory_order_acquire) != 0;
+}
+
+static int
+peak_exec_prepublication_execve(const char* path,
+                                char* const argv[],
+                                char* const envp[])
+{
+#if PEAK_EXEC_DIRECT_RAW_SUPPORTED && defined(SYS_execve)
+    return (int)peak_exec_raw_syscall6(
+        SYS_execve,
+        (long)(uintptr_t)path,
+        (long)(uintptr_t)argv,
+        (long)(uintptr_t)envp,
+        0,
+        0,
+        0);
+#else
+    peak_execve_fn fn;
+
+    if (peak_exec_prepublication_execve_resolving) {
+        errno = ENOSYS;
+        return -1;
+    }
+    peak_exec_prepublication_execve_resolving = 1;
+    fn = (peak_execve_fn)dlsym(RTLD_NEXT, "execve");
+    peak_exec_prepublication_execve_resolving = 0;
+    if (fn == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return fn(path, argv, envp);
+#endif
+}
+
+static size_t
+peak_exec_prepublication_strlen(const char* value, size_t limit)
+{
+    size_t length = 0;
+
+    if (value == NULL) {
+        return 0;
+    }
+    while (length < limit && value[length] != '\0') {
+        length++;
+    }
+    return length;
+}
+
+static const char*
+peak_exec_prepublication_path(void)
+{
+    static const char prefix[] = "PATH=";
+
+    if (environ != NULL) {
+        for (size_t index = 0; environ[index] != NULL; index++) {
+            const char* entry = environ[index];
+            size_t offset = 0;
+
+            while (offset + 1 < sizeof(prefix) &&
+                   entry[offset] == prefix[offset]) {
+                offset++;
+            }
+            if (offset + 1 == sizeof(prefix)) {
+                return entry + offset;
+            }
+        }
+    }
+    return PEAK_EXEC_DEFAULT_PATH;
+}
+
+static int
+peak_exec_prepublication_shell(const char* path,
+                               char* const argv[],
+                               char* const envp[])
+{
+    size_t argc = 0;
+
+    if (argv != NULL) {
+        while (argv[argc] != NULL) {
+            argc++;
+            if (argc >= PEAK_EXEC_MAX_VARARGS) {
+                errno = E2BIG;
+                return -1;
+            }
+        }
+    }
+    {
+        char* shell_argv[argc + 3U];
+
+        shell_argv[0] = (char*)"/bin/sh";
+        shell_argv[1] = (char*)path;
+        for (size_t index = 1; index < argc; index++) {
+            shell_argv[index + 1] = argv[index];
+        }
+        shell_argv[argc > 0 ? argc + 1 : 2] = NULL;
+        return peak_exec_prepublication_execve("/bin/sh", shell_argv, envp);
+    }
+}
+
+static int
+peak_exec_prepublication_path_search(const char* file,
+                                     char* const argv[],
+                                     char* const envp[])
+{
+    char candidate[PATH_MAX];
+    const char* path;
+    const char* cursor;
+    size_t file_length;
+    int saved_errno = ENOENT;
+    int saw_eacces = 0;
+
+    if (file == NULL || file[0] == '\0') {
+        errno = ENOENT;
+        return -1;
+    }
+    file_length = peak_exec_prepublication_strlen(file, PATH_MAX);
+    if (file_length == PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    for (size_t index = 0; index < file_length; index++) {
+        if (file[index] == '/') {
+            int result = peak_exec_prepublication_execve(file, argv, envp);
+
+            if (result < 0 && errno == ENOEXEC) {
+                return peak_exec_prepublication_shell(file, argv, envp);
+            }
+            return result;
+        }
+    }
+
+    path = peak_exec_prepublication_path();
+    cursor = path;
+    for (;;) {
+        const char* start = cursor;
+        size_t directory_length;
+        size_t candidate_length;
+
+        while (*cursor != '\0' && *cursor != ':') {
+            cursor++;
+        }
+        directory_length = (size_t)(cursor - start);
+        candidate_length = directory_length +
+                           (directory_length != 0 ? 1U : 0U) + file_length;
+        if (candidate_length + 1U <= sizeof(candidate)) {
+            size_t output = 0;
+
+            for (size_t index = 0; index < directory_length; index++) {
+                candidate[output++] = start[index];
+            }
+            if (directory_length != 0) {
+                candidate[output++] = '/';
+            }
+            for (size_t index = 0; index < file_length; index++) {
+                candidate[output++] = file[index];
+            }
+            candidate[output] = '\0';
+            (void)peak_exec_prepublication_execve(candidate, argv, envp);
+            saved_errno = errno;
+            if (saved_errno == ENOEXEC) {
+                return peak_exec_prepublication_shell(candidate, argv, envp);
+            }
+            if (saved_errno == EACCES) {
+                saw_eacces = 1;
+            } else if (saved_errno != ENOENT && saved_errno != ENOTDIR &&
+                       saved_errno != ESTALE && saved_errno != ENODEV &&
+                       saved_errno != ETIMEDOUT) {
+                errno = saved_errno;
+                return -1;
+            }
+        } else {
+            saved_errno = ENAMETOOLONG;
+        }
+        if (*cursor == '\0') {
+            break;
+        }
+        cursor++;
+    }
+    errno = saw_eacces ? EACCES : saved_errno;
+    return -1;
+}
+
+static int
+peak_exec_prepublication_execvp(const char* file, char* const argv[])
+{
+#if PEAK_EXEC_DIRECT_RAW_SUPPORTED
+    return peak_exec_prepublication_path_search(file, argv, environ);
+#else
+    return peak_call_real_execvp(file, argv);
+#endif
+}
+
+static int
+peak_exec_prepublication_execvpe(const char* file,
+                                 char* const argv[],
+                                 char* const envp[])
+{
+#if PEAK_EXEC_DIRECT_RAW_SUPPORTED
+    return peak_exec_prepublication_path_search(file, argv, envp);
+#else
+    return peak_call_real_execvpe(file, argv, envp);
+#endif
+}
+
+static int
+peak_exec_prepublication_fexecve(int fd,
+                                 char* const argv[],
+                                 char* const envp[])
+{
+#if PEAK_EXEC_DIRECT_RAW_SUPPORTED && defined(SYS_execveat) && \
+    defined(AT_EMPTY_PATH)
+    return (int)peak_exec_raw_syscall6(
+        SYS_execveat,
+        fd,
+        (long)(uintptr_t)"",
+        (long)(uintptr_t)argv,
+        (long)(uintptr_t)envp,
+        AT_EMPTY_PATH,
+        0);
+#else
+    return peak_call_real_fexecve(fd, argv, envp);
+#endif
+}
+
+#if defined(__linux__)
+static int
+peak_exec_prepublication_execveat(int dirfd,
+                                  const char* pathname,
+                                  char* const argv[],
+                                  char* const envp[],
+                                  int flags)
+{
+#if PEAK_EXEC_DIRECT_RAW_SUPPORTED && defined(SYS_execveat)
+    return (int)peak_exec_raw_syscall6(
+        SYS_execveat,
+        dirfd,
+        (long)(uintptr_t)pathname,
+        (long)(uintptr_t)argv,
+        (long)(uintptr_t)envp,
+        flags,
+        0);
+#else
+    return peak_call_real_execveat(dirfd, pathname, argv, envp, flags);
+#endif
+}
+#endif
 
 static int
 peak_exec_in_fork_child(void)
@@ -383,7 +679,8 @@ peak_exec_child_build_env(char* const envp[],
     int propagate_peak_env;
     int chain_enabled;
 
-    if (!peak_exec_cached_secure_mode_ready || peak_exec_cached_secure_mode ||
+    if (!peak_exec_startup_chain_enabled ||
+        !peak_exec_cached_secure_mode_ready || peak_exec_cached_secure_mode ||
         !peak_exec_cached_libpeak_path_ready ||
         peak_exec_child_control_enabled(envp,
                                         PEAK_EXEC_CHAIN_ENV,
@@ -1463,8 +1760,9 @@ peak_exec_prepare(const char* path,
                   int allow_checkpoint)
 {
     int saved_errno = errno;
-    int chain_enabled =
-        peak_exec_env_default_true_for_child(envp, PEAK_EXEC_CHAIN_ENV);
+    int chain_enabled = peak_exec_startup_chain_enabled &&
+                        peak_exec_env_default_true_for_child(
+                            envp, PEAK_EXEC_CHAIN_ENV);
     int propagate_peak_env =
         peak_exec_env_default_true_for_child(
             envp,
@@ -1474,6 +1772,7 @@ peak_exec_prepare(const char* path,
     peak_exec_trace_event("exec-before", path, "", 0);
     if (allow_checkpoint &&
         peak_exec_spawn_depth == 0 &&
+        peak_exec_startup_checkpoint_enabled &&
         peak_exec_env_default_true_for_child(envp,
                                              PEAK_EXEC_CHECKPOINT_ENV)) {
         int checkpoint_result = peak_checkpoint_for_exec(path, argv);
@@ -1509,21 +1808,41 @@ peak_exec_prepare(const char* path,
 }
 
 static pthread_once_t peak_real_execve_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_execvp_once = PTHREAD_ONCE_INIT;
 static pthread_once_t peak_real_execvpe_once = PTHREAD_ONCE_INIT;
 static pthread_once_t peak_real_fexecve_once = PTHREAD_ONCE_INIT;
 static pthread_once_t peak_real_execveat_once = PTHREAD_ONCE_INIT;
-static pthread_once_t peak_real_posix_spawn_once = PTHREAD_ONCE_INIT;
-static pthread_once_t peak_real_posix_spawnp_once = PTHREAD_ONCE_INIT;
 static peak_execve_fn peak_real_execve_ptr;
+static peak_execvp_fn peak_real_execvp_ptr;
 static peak_execvpe_fn peak_real_execvpe_ptr;
 static peak_fexecve_fn peak_real_fexecve_ptr;
 static peak_execveat_fn peak_real_execveat_ptr;
 static peak_posix_spawn_fn peak_real_posix_spawn_ptr;
 static peak_posix_spawnp_fn peak_real_posix_spawnp_ptr;
+enum {
+    PEAK_SPAWN_RESOLVER_UNRESOLVED = 0,
+    PEAK_SPAWN_RESOLVER_IN_PROGRESS = 1,
+    PEAK_SPAWN_RESOLVER_READY = 2,
+};
+static atomic_int peak_real_posix_spawn_state = ATOMIC_VAR_INIT(0);
+static atomic_int peak_real_posix_spawnp_state = ATOMIC_VAR_INIT(0);
+static atomic_long peak_real_posix_spawn_owner_pid = ATOMIC_VAR_INIT(0);
+static atomic_long peak_real_posix_spawnp_owner_pid = ATOMIC_VAR_INIT(0);
+static __thread int peak_posix_spawn_resolving;
 
 static void peak_lookup_execve(void)
 {
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (peak_test_exec_resolver_reentry_hook != NULL) {
+        peak_test_exec_resolver_reentry_hook();
+    }
+#endif
     peak_real_execve_ptr = (peak_execve_fn)dlsym(RTLD_NEXT, "execve");
+}
+
+static void peak_lookup_execvp(void)
+{
+    peak_real_execvp_ptr = (peak_execvp_fn)dlsym(RTLD_NEXT, "execvp");
 }
 
 static void peak_lookup_execvpe(void)
@@ -1541,16 +1860,32 @@ static void peak_lookup_execveat(void)
     peak_real_execveat_ptr = (peak_execveat_fn)dlsym(RTLD_NEXT, "execveat");
 }
 
-static void peak_lookup_posix_spawn(void)
+static peak_posix_spawn_fn
+peak_lookup_posix_spawn(void)
 {
-    peak_real_posix_spawn_ptr =
-        (peak_posix_spawn_fn)dlsym(RTLD_NEXT, "posix_spawn");
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    extern void peak_test_exec_spawn_resolver_reentry_hook(int)
+        __attribute__((weak));
+
+    if (peak_test_exec_spawn_resolver_reentry_hook != NULL) {
+        peak_test_exec_spawn_resolver_reentry_hook(0);
+    }
+#endif
+    return (peak_posix_spawn_fn)dlsym(RTLD_NEXT, "posix_spawn");
 }
 
-static void peak_lookup_posix_spawnp(void)
+static peak_posix_spawnp_fn
+peak_lookup_posix_spawnp(void)
 {
-    peak_real_posix_spawnp_ptr =
-        (peak_posix_spawnp_fn)dlsym(RTLD_NEXT, "posix_spawnp");
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    extern void peak_test_exec_spawn_resolver_reentry_hook(int)
+        __attribute__((weak));
+
+    if (peak_test_exec_spawn_resolver_reentry_hook != NULL) {
+        peak_test_exec_spawn_resolver_reentry_hook(1);
+    }
+#endif
+    return (peak_posix_spawnp_fn)dlsym(RTLD_NEXT, "posix_spawnp");
 }
 
 static peak_execve_fn
@@ -1560,14 +1895,19 @@ peak_real_execve(void)
     return peak_real_execve_ptr;
 }
 
+static peak_execvp_fn
+peak_real_execvp(void)
+{
+    (void)pthread_once(&peak_real_execvp_once, peak_lookup_execvp);
+    return peak_real_execvp_ptr;
+}
+
 static peak_execvpe_fn
 peak_real_execvpe(void)
 {
     (void)pthread_once(&peak_real_execvpe_once, peak_lookup_execvpe);
 #if defined(PEAK_ENABLE_TEST_HOOKS)
-    const char* forced_fallback = getenv("PEAK_TEST_EXECVPE_FALLBACK");
-
-    if (forced_fallback != NULL && !peak_exec_env_false(forced_fallback)) {
+    if (peak_exec_test_force_execvpe_fallback) {
         return NULL;
     }
 #endif
@@ -1591,17 +1931,163 @@ peak_real_execveat(void)
 static peak_posix_spawn_fn
 peak_real_posix_spawn(void)
 {
-    (void)pthread_once(&peak_real_posix_spawn_once,
-                       peak_lookup_posix_spawn);
-    return peak_real_posix_spawn_ptr;
+    peak_posix_spawn_fn resolved;
+    const long self = (long)getpid();
+
+    for (;;) {
+        int state = atomic_load_explicit(&peak_real_posix_spawn_state,
+                                         memory_order_acquire);
+        long owner;
+
+        if (state == PEAK_SPAWN_RESOLVER_READY) {
+            return peak_real_posix_spawn_ptr;
+        }
+        if (peak_posix_spawn_resolving) {
+            return NULL;
+        }
+        owner = atomic_load_explicit(&peak_real_posix_spawn_owner_pid,
+                                     memory_order_acquire);
+        if (owner == 0) {
+            long expected = 0;
+
+            peak_posix_spawn_resolving = 1;
+            if (atomic_compare_exchange_strong_explicit(
+                    &peak_real_posix_spawn_owner_pid,
+                    &expected,
+                    self,
+                    memory_order_acq_rel,
+                    memory_order_acquire)) {
+                atomic_store_explicit(&peak_real_posix_spawn_state,
+                                      PEAK_SPAWN_RESOLVER_IN_PROGRESS,
+                                      memory_order_release);
+                resolved = peak_lookup_posix_spawn();
+                peak_real_posix_spawn_ptr = resolved;
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+                {
+                    extern void peak_test_exec_spawn_publication_hook(int)
+                        __attribute__((weak));
+
+                    if (peak_test_exec_spawn_publication_hook != NULL) {
+                        peak_test_exec_spawn_publication_hook(0);
+                    }
+                }
+#endif
+                peak_posix_spawn_resolving = 0;
+                atomic_store_explicit(&peak_real_posix_spawn_state,
+                                      PEAK_SPAWN_RESOLVER_READY,
+                                      memory_order_release);
+                return resolved;
+            }
+            peak_posix_spawn_resolving = 0;
+            continue;
+        }
+        if (owner != self) {
+            return NULL;
+        }
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+        {
+            extern void peak_test_exec_spawn_waiter_hook(int)
+                __attribute__((weak));
+
+            if (peak_test_exec_spawn_waiter_hook != NULL) {
+                peak_test_exec_spawn_waiter_hook(0);
+            }
+        }
+#endif
+        do {
+            state = atomic_load_explicit(&peak_real_posix_spawn_state,
+                                         memory_order_acquire);
+            if (state == PEAK_SPAWN_RESOLVER_READY) {
+                return peak_real_posix_spawn_ptr;
+            }
+            if (peak_posix_spawn_resolving ||
+                atomic_load_explicit(&peak_real_posix_spawn_owner_pid,
+                                     memory_order_acquire) != self) {
+                return NULL;
+            }
+        } while (state != PEAK_SPAWN_RESOLVER_READY);
+    }
 }
 
 static peak_posix_spawnp_fn
 peak_real_posix_spawnp(void)
 {
-    (void)pthread_once(&peak_real_posix_spawnp_once,
-                       peak_lookup_posix_spawnp);
-    return peak_real_posix_spawnp_ptr;
+    peak_posix_spawnp_fn resolved;
+    const long self = (long)getpid();
+
+    for (;;) {
+        int state = atomic_load_explicit(&peak_real_posix_spawnp_state,
+                                         memory_order_acquire);
+        long owner;
+
+        if (state == PEAK_SPAWN_RESOLVER_READY) {
+            return peak_real_posix_spawnp_ptr;
+        }
+        if (peak_posix_spawn_resolving) {
+            return NULL;
+        }
+        owner = atomic_load_explicit(&peak_real_posix_spawnp_owner_pid,
+                                     memory_order_acquire);
+        if (owner == 0) {
+            long expected = 0;
+
+            peak_posix_spawn_resolving = 1;
+            if (atomic_compare_exchange_strong_explicit(
+                    &peak_real_posix_spawnp_owner_pid,
+                    &expected,
+                    self,
+                    memory_order_acq_rel,
+                    memory_order_acquire)) {
+                atomic_store_explicit(&peak_real_posix_spawnp_state,
+                                      PEAK_SPAWN_RESOLVER_IN_PROGRESS,
+                                      memory_order_release);
+                resolved = peak_lookup_posix_spawnp();
+                peak_real_posix_spawnp_ptr = resolved;
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+                {
+                    extern void peak_test_exec_spawn_publication_hook(int)
+                        __attribute__((weak));
+
+                    if (peak_test_exec_spawn_publication_hook != NULL) {
+                        peak_test_exec_spawn_publication_hook(1);
+                    }
+                }
+#endif
+                peak_posix_spawn_resolving = 0;
+                atomic_store_explicit(&peak_real_posix_spawnp_state,
+                                      PEAK_SPAWN_RESOLVER_READY,
+                                      memory_order_release);
+                return resolved;
+            }
+            peak_posix_spawn_resolving = 0;
+            continue;
+        }
+        if (owner != self) {
+            return NULL;
+        }
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+        {
+            extern void peak_test_exec_spawn_waiter_hook(int)
+                __attribute__((weak));
+
+            if (peak_test_exec_spawn_waiter_hook != NULL) {
+                peak_test_exec_spawn_waiter_hook(1);
+            }
+        }
+#endif
+        do {
+            state = atomic_load_explicit(&peak_real_posix_spawnp_state,
+                                         memory_order_acquire);
+            if (state == PEAK_SPAWN_RESOLVER_READY) {
+                return peak_real_posix_spawnp_ptr;
+            }
+            if (peak_posix_spawn_resolving ||
+                atomic_load_explicit(&peak_real_posix_spawnp_owner_pid,
+                                     memory_order_acquire) != self) {
+                return NULL;
+            }
+        } while (state != PEAK_SPAWN_RESOLVER_READY);
+    }
 }
 
 static void
@@ -1660,16 +2146,36 @@ __attribute__((constructor))
 static void
 peak_exec_prime_real_symbols(void)
 {
-    peak_exec_owner_pid = getpid();
-    peak_exec_cache_libpeak_path();
-    peak_exec_cache_ld_library_path();
-    peak_exec_cache_secure_mode();
     (void)peak_real_execve();
+    (void)peak_real_execvp();
     (void)peak_real_execvpe();
     (void)peak_real_fexecve();
     (void)peak_real_execveat();
     (void)peak_real_posix_spawn();
     (void)peak_real_posix_spawnp();
+    peak_exec_owner_pid = getpid();
+    peak_exec_cache_libpeak_path();
+    peak_exec_cache_ld_library_path();
+    peak_exec_cache_secure_mode();
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    {
+        const char* forced_fallback = getenv("PEAK_TEST_EXECVPE_FALLBACK");
+
+        peak_exec_test_force_execvpe_fallback =
+            forced_fallback != NULL && !peak_exec_env_false(forced_fallback);
+    }
+#endif
+    peak_exec_startup_chain_enabled =
+        getenv(PEAK_EXEC_CHAIN_ENV) != NULL &&
+        !peak_exec_env_false(getenv(PEAK_EXEC_CHAIN_ENV));
+    peak_exec_startup_checkpoint_enabled =
+        getenv(PEAK_EXEC_CHECKPOINT_ENV) != NULL &&
+        !peak_exec_env_false(getenv(PEAK_EXEC_CHECKPOINT_ENV));
+    peak_exec_startup_policy_enabled = peak_exec_startup_chain_enabled ||
+                                       peak_exec_startup_checkpoint_enabled;
+    atomic_store_explicit(&peak_exec_priming_complete,
+                          1,
+                          memory_order_release);
 }
 
 static int
@@ -1680,15 +2186,197 @@ peak_call_real_execve(const char* path,
     peak_execve_fn fn = peak_real_execve();
 
     if (fn == NULL) {
+#if defined(__linux__) && defined(SYS_execve)
+        return (int)peak_exec_raw_syscall6(
+            SYS_execve,
+            (long)(uintptr_t)path,
+            (long)(uintptr_t)argv,
+            (long)(uintptr_t)envp,
+            0,
+            0,
+            0);
+#else
         errno = ENOSYS;
         return -1;
+#endif
     }
     return fn(path, argv, envp);
 }
 
+#if !PEAK_EXEC_DIRECT_RAW_SUPPORTED
+static int
+peak_call_real_execvp(const char* file, char* const argv[])
+{
+    peak_execvp_fn fn = peak_real_execvp();
+
+    if (fn == NULL) {
+        return peak_exec_prepublication_path_search(file, argv, environ);
+    }
+    return fn(file, argv);
+}
+
+static int
+peak_call_real_execvpe(const char* file,
+                       char* const argv[],
+                       char* const envp[])
+{
+    peak_execvpe_fn fn = peak_real_execvpe();
+
+    if (fn == NULL) {
+        return peak_exec_prepublication_path_search(file, argv, envp);
+    }
+    return fn(file, argv, envp);
+}
+#endif
+
+static int
+peak_call_primed_execve(const char* path,
+                        char* const argv[],
+                        char* const envp[])
+{
+    if (peak_real_execve_ptr == NULL) {
+#if defined(__linux__) && defined(SYS_execve)
+        return (int)peak_exec_raw_syscall6(
+            SYS_execve,
+            (long)(uintptr_t)path,
+            (long)(uintptr_t)argv,
+            (long)(uintptr_t)envp,
+            0,
+            0,
+            0);
+#else
+        errno = ENOSYS;
+        return -1;
+#endif
+    }
+    return peak_real_execve_ptr(path, argv, envp);
+}
+
+static int
+peak_call_primed_execvp(const char* file, char* const argv[])
+{
+    if (peak_real_execvp_ptr == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return peak_real_execvp_ptr(file, argv);
+}
+
+static int
+peak_call_primed_execvpe(const char* file,
+                         char* const argv[],
+                         char* const envp[])
+{
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (peak_exec_test_force_execvpe_fallback) {
+        errno = ENOSYS;
+        return -1;
+    }
+#endif
+    if (peak_real_execvpe_ptr == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return peak_real_execvpe_ptr(file, argv, envp);
+}
+
+static peak_execvpe_fn
+peak_primed_execvpe_for_rich_path(void)
+{
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (peak_exec_test_force_execvpe_fallback) {
+        return NULL;
+    }
+#endif
+    return peak_real_execvpe_ptr;
+}
+
+static int
+peak_call_real_fexecve(int fd, char* const argv[], char* const envp[])
+{
+    peak_fexecve_fn fn = peak_real_fexecve();
+
+    if (fn == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return fn(fd, argv, envp);
+}
+
+static int
+peak_call_primed_fexecve(int fd, char* const argv[], char* const envp[])
+{
+    if (peak_real_fexecve_ptr == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return peak_real_fexecve_ptr(fd, argv, envp);
+}
+
+#if defined(__linux__)
+static int
+peak_call_real_execveat(int dirfd,
+                        const char* pathname,
+                        char* const argv[],
+                        char* const envp[],
+                        int flags)
+{
+    peak_execveat_fn fn = peak_real_execveat();
+
+    if (fn != NULL) {
+        return fn(dirfd, pathname, argv, envp, flags);
+    }
+#if defined(SYS_execveat)
+    return (int)peak_exec_raw_syscall6(
+        SYS_execveat,
+        dirfd,
+        (long)(uintptr_t)pathname,
+        (long)(uintptr_t)argv,
+        (long)(uintptr_t)envp,
+        flags,
+        0);
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+static int
+peak_call_primed_execveat(int dirfd,
+                          const char* pathname,
+                          char* const argv[],
+                          char* const envp[],
+                          int flags)
+{
+    if (peak_real_execveat_ptr != NULL) {
+        return peak_real_execveat_ptr(dirfd, pathname, argv, envp, flags);
+    }
+#if defined(SYS_execveat)
+    return (int)peak_exec_raw_syscall6(
+        SYS_execveat,
+        dirfd,
+        (long)(uintptr_t)pathname,
+        (long)(uintptr_t)argv,
+        (long)(uintptr_t)envp,
+        flags,
+        0);
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+#endif
+
 PEAK_EXEC_API int
 execve(const char* path, char* const argv[], char* const envp[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_execve(path, argv, envp);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_execve(path, argv, envp);
+    }
+
     PeakExecEnv built_env = {0};
     char* const* exec_envp;
     int saved_errno;
@@ -1701,11 +2389,8 @@ execve(const char* path, char* const argv[], char* const envp[])
                                                              child_env,
                                                              child_ld_preload);
 
-        if (peak_real_execve_ptr == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return peak_real_execve_ptr(path, argv, (char* const*)child_envp);
+        return peak_call_primed_execve(
+            path, argv, (char* const*)child_envp);
     }
     if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
         return peak_call_real_execve(path, argv, envp);
@@ -1735,12 +2420,22 @@ peak_exec_raw_syscall_execve(const char* path,
                              char* const argv[],
                              char* const envp[])
 {
+    if (!peak_exec_priming_is_complete() ||
+        !peak_exec_startup_policy_enabled) {
+        return peak_exec_prepublication_execve(path, argv, envp);
+    }
     return execve(path, argv, envp);
 }
 
 PEAK_EXEC_API int
 execv(const char* path, char* const argv[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_execve(path, argv, environ);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_execve(path, argv, environ);
+    }
     return execve(path, argv, environ);
 }
 
@@ -1882,7 +2577,9 @@ peak_execvpe_fallback(const char* file,
 
         if (saved_errno == EACCES) {
             saw_eacces = 1;
-        } else if (saved_errno != ENOENT && saved_errno != ENOTDIR) {
+        } else if (saved_errno != ENOENT && saved_errno != ENOTDIR &&
+                   saved_errno != ESTALE && saved_errno != ENODEV &&
+                   saved_errno != ETIMEDOUT) {
             break;
         }
         if (*cursor == '\0') {
@@ -1902,6 +2599,13 @@ out:
 PEAK_EXEC_API int
 execvpe(const char* file, char* const argv[], char* const envp[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_execvpe(file, argv, envp);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_execvpe(file, argv, envp);
+    }
+
     peak_execvpe_fn fn;
     PeakExecEnv built_env = {0};
     char* const* exec_envp;
@@ -1915,7 +2619,7 @@ execvpe(const char* file, char* const argv[], char* const envp[])
                                                              child_env,
                                                              child_ld_preload);
 
-        fn = peak_real_execvpe_ptr;
+        fn = peak_primed_execvpe_for_rich_path();
         if (fn == NULL) {
             errno = ENOSYS;
             return -1;
@@ -1965,6 +2669,24 @@ execvpe(const char* file, char* const argv[], char* const envp[])
 PEAK_EXEC_API int
 execvp(const char* file, char* const argv[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_execvp(file, argv);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_execvp(file, argv);
+    }
+    if (peak_exec_in_fork_child()) {
+        char* child_env[PEAK_EXEC_CHILD_ENV_SLOTS];
+        char child_ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY];
+        char* const* child_envp = peak_exec_child_build_env(
+            environ, child_env, child_ld_preload);
+        peak_execvpe_fn execvpe_fn = peak_primed_execvpe_for_rich_path();
+
+        if (child_envp != environ && execvpe_fn != NULL) {
+            return execvpe_fn(file, argv, (char* const*)child_envp);
+        }
+        return peak_call_primed_execvp(file, argv);
+    }
     return execvpe(file, argv, environ);
 }
 
@@ -2038,32 +2760,80 @@ peak_exec_collect_argv_noalloc(const char* arg,
     return 0;
 }
 
+static int
+peak_exec_count_argv(const char* arg, va_list* ap, size_t* argc)
+{
+    va_list count_ap;
+    size_t count = 0;
+
+    if (argc == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (arg != NULL) {
+        va_copy(count_ap, *ap);
+        do {
+            count++;
+            if (count >= PEAK_EXEC_MAX_VARARGS) {
+                va_end(count_ap);
+                errno = E2BIG;
+                return -1;
+            }
+        } while (va_arg(count_ap, const char*) != NULL);
+        va_end(count_ap);
+    }
+    *argc = count;
+    return 0;
+}
+
 PEAK_EXEC_API int
 execl(const char* path, const char* arg, ...)
 {
     va_list ap;
-    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
     char** argv = NULL;
-    int noalloc_child = peak_exec_in_fork_child();
+    int priming_complete = peak_exec_priming_is_complete();
+    int direct_bypass = !priming_complete ||
+                        !peak_exec_startup_policy_enabled;
+    int noalloc_child = direct_bypass || peak_exec_in_fork_child();
     int result;
     int saved_errno;
+    size_t child_argc = 0;
 
     va_start(ap, arg);
-    if (noalloc_child) {
-        result = peak_exec_collect_argv_noalloc(
-            arg,
-            &ap,
-            child_argv,
-            sizeof(child_argv) / sizeof(child_argv[0]));
-        argv = child_argv;
-    } else {
+    if (noalloc_child && peak_exec_count_argv(arg, &ap, &child_argc) != 0) {
+        va_end(ap);
+        return -1;
+    }
+    if (!noalloc_child) {
         result = peak_exec_collect_argv(arg, &ap, &argv);
+    } else {
+        char* child_argv[child_argc + 1U];
+
+        result = peak_exec_collect_argv_noalloc(
+            arg, &ap, child_argv, child_argc + 1U);
+        if (result == 0) {
+            if (priming_complete && !direct_bypass) {
+                result = execve(path, child_argv, environ);
+            } else if (priming_complete) {
+                result = peak_call_primed_execve(path, child_argv, environ);
+            } else {
+                result = peak_exec_prepublication_execve(path,
+                                                         child_argv,
+                                                         environ);
+            }
+        }
+        saved_errno = errno;
+        va_end(ap);
+        errno = saved_errno;
+        return result;
     }
     va_end(ap);
     if (result != 0) {
         return -1;
     }
-    result = execv(path, argv);
+    if (!direct_bypass) {
+        result = execv(path, argv);
+    }
     saved_errno = errno;
     if (!noalloc_child) {
         free(argv);
@@ -2076,28 +2846,48 @@ PEAK_EXEC_API int
 execlp(const char* file, const char* arg, ...)
 {
     va_list ap;
-    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
     char** argv = NULL;
-    int noalloc_child = peak_exec_in_fork_child();
+    int priming_complete = peak_exec_priming_is_complete();
+    int direct_bypass = !priming_complete ||
+                        !peak_exec_startup_policy_enabled;
+    int noalloc_child = direct_bypass || peak_exec_in_fork_child();
     int result;
     int saved_errno;
+    size_t child_argc = 0;
 
     va_start(ap, arg);
-    if (noalloc_child) {
-        result = peak_exec_collect_argv_noalloc(
-            arg,
-            &ap,
-            child_argv,
-            sizeof(child_argv) / sizeof(child_argv[0]));
-        argv = child_argv;
-    } else {
+    if (noalloc_child && peak_exec_count_argv(arg, &ap, &child_argc) != 0) {
+        va_end(ap);
+        return -1;
+    }
+    if (!noalloc_child) {
         result = peak_exec_collect_argv(arg, &ap, &argv);
+    } else {
+        char* child_argv[child_argc + 1U];
+
+        result = peak_exec_collect_argv_noalloc(
+            arg, &ap, child_argv, child_argc + 1U);
+        if (result == 0) {
+            if (priming_complete && !direct_bypass) {
+                result = execvp(file, child_argv);
+            } else if (priming_complete) {
+                result = peak_call_primed_execvp(file, child_argv);
+            } else {
+                result = peak_exec_prepublication_execvp(file, child_argv);
+            }
+        }
+        saved_errno = errno;
+        va_end(ap);
+        errno = saved_errno;
+        return result;
     }
     va_end(ap);
     if (result != 0) {
         return -1;
     }
-    result = execvp(file, argv);
+    if (!direct_bypass) {
+        result = execvp(file, argv);
+    }
     saved_errno = errno;
     if (!noalloc_child) {
         free(argv);
@@ -2110,23 +2900,45 @@ PEAK_EXEC_API int
 execle(const char* path, const char* arg, ...)
 {
     va_list ap;
-    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
     char** argv = NULL;
     char* const* envp;
-    int noalloc_child = peak_exec_in_fork_child();
+    int priming_complete = peak_exec_priming_is_complete();
+    int direct_bypass = !priming_complete ||
+                        !peak_exec_startup_policy_enabled;
+    int noalloc_child = direct_bypass || peak_exec_in_fork_child();
     int result;
     int saved_errno;
+    size_t child_argc = 0;
 
     va_start(ap, arg);
-    if (noalloc_child) {
-        result = peak_exec_collect_argv_noalloc(
-            arg,
-            &ap,
-            child_argv,
-            sizeof(child_argv) / sizeof(child_argv[0]));
-        argv = child_argv;
-    } else {
+    if (noalloc_child && peak_exec_count_argv(arg, &ap, &child_argc) != 0) {
+        va_end(ap);
+        return -1;
+    }
+    if (!noalloc_child) {
         result = peak_exec_collect_argv(arg, &ap, &argv);
+    } else {
+        char* child_argv[child_argc + 1U];
+
+        result = peak_exec_collect_argv_noalloc(
+            arg, &ap, child_argv, child_argc + 1U);
+        if (result == 0) {
+            envp = va_arg(ap, char* const*);
+            if (priming_complete && !direct_bypass) {
+                result = execve(path, child_argv, (char* const*)envp);
+            } else if (priming_complete) {
+                result = peak_call_primed_execve(path,
+                                                 child_argv,
+                                                 (char* const*)envp);
+            } else {
+                result = peak_exec_prepublication_execve(
+                    path, child_argv, (char* const*)envp);
+            }
+        }
+        saved_errno = errno;
+        va_end(ap);
+        errno = saved_errno;
+        return result;
     }
     if (result == 0) {
         envp = va_arg(ap, char* const*);
@@ -2135,7 +2947,9 @@ execle(const char* path, const char* arg, ...)
     if (result != 0) {
         return -1;
     }
-    result = execve(path, argv, (char* const*)envp);
+    if (!direct_bypass) {
+        result = execve(path, argv, (char* const*)envp);
+    }
     saved_errno = errno;
     if (!noalloc_child) {
         free(argv);
@@ -2147,6 +2961,13 @@ execle(const char* path, const char* arg, ...)
 PEAK_EXEC_API int
 fexecve(int fd, char* const argv[], char* const envp[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_fexecve(fd, argv, envp);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_fexecve(fd, argv, envp);
+    }
+
     peak_fexecve_fn fn;
     PeakExecEnv built_env = {0};
     char* const* exec_envp;
@@ -2161,29 +2982,15 @@ fexecve(int fd, char* const argv[], char* const envp[])
                                                              child_env,
                                                              child_ld_preload);
 
-        fn = peak_real_fexecve_ptr;
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(fd, argv, (char* const*)child_envp);
+        return peak_call_primed_fexecve(
+            fd, argv, (char* const*)child_envp);
     }
     if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
-        fn = peak_real_fexecve();
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(fd, argv, envp);
+        return peak_call_real_fexecve(fd, argv, envp);
     }
     if (peak_exec_argv_envp_readable(argv, envp) !=
         PEAK_EXEC_PREFLIGHT_VALID) {
-        fn = peak_real_fexecve();
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(fd, argv, envp);
+        return peak_call_real_fexecve(fd, argv, envp);
     }
 
     snprintf(label, sizeof(label), "<fd:%d>", fd);
@@ -2215,7 +3022,15 @@ execveat(int dirfd,
          char* const envp[],
          int flags)
 {
-    peak_execveat_fn fn;
+    if (!peak_exec_priming_is_complete()) {
+        return peak_exec_prepublication_execveat(
+            dirfd, pathname, argv, envp, flags);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        return peak_call_primed_execveat(
+            dirfd, pathname, argv, envp, flags);
+    }
+
     PeakExecEnv built_env = {0};
     char* const* exec_envp;
     int saved_errno;
@@ -2228,29 +3043,17 @@ execveat(int dirfd,
                                                              child_env,
                                                              child_ld_preload);
 
-        fn = peak_real_execveat_ptr;
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(dirfd, pathname, argv, (char* const*)child_envp, flags);
+        return peak_call_primed_execveat(
+            dirfd, pathname, argv, (char* const*)child_envp, flags);
     }
     if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
-        fn = peak_real_execveat();
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(dirfd, pathname, argv, envp, flags);
+        return peak_call_real_execveat(
+            dirfd, pathname, argv, envp, flags);
     }
     if (peak_exec_args_readable(pathname, argv, envp) !=
         PEAK_EXEC_PREFLIGHT_VALID) {
-        fn = peak_real_execveat();
-        if (fn == NULL) {
-            errno = ENOSYS;
-            return -1;
-        }
-        return fn(dirfd, pathname, argv, envp, flags);
+        return peak_call_real_execveat(
+            dirfd, pathname, argv, envp, flags);
     }
 
     peak_exec_wrapper_depth++;
@@ -2260,13 +3063,9 @@ execveat(int dirfd,
     } else {
         exec_envp = peak_exec_env_to_use(&built_env, envp);
     }
-    fn = peak_real_execveat();
-    if (fn == NULL) {
-        saved_errno = ENOSYS;
-    } else {
-        (void)fn(dirfd, pathname, argv, (char* const*)exec_envp, flags);
-        saved_errno = errno;
-    }
+    (void)peak_call_real_execveat(
+        dirfd, pathname, argv, (char* const*)exec_envp, flags);
+    saved_errno = errno;
     peak_exec_env_clear(&built_env);
     peak_exec_wrapper_depth--;
     errno = saved_errno;
@@ -2274,6 +3073,7 @@ execveat(int dirfd,
 }
 #endif
 
+#if defined(__linux__)
 int
 peak_exec_raw_syscall_execveat(int dirfd,
                                const char* pathname,
@@ -2281,8 +3081,14 @@ peak_exec_raw_syscall_execveat(int dirfd,
                                char* const envp[],
                                int flags)
 {
+    if (!peak_exec_priming_is_complete() ||
+        !peak_exec_startup_policy_enabled) {
+        return peak_exec_prepublication_execveat(
+            dirfd, pathname, argv, envp, flags);
+    }
     return execveat(dirfd, pathname, argv, envp, flags);
 }
+#endif
 
 PEAK_EXEC_API int
 posix_spawn(pid_t* pid,
@@ -2292,6 +3098,25 @@ posix_spawn(pid_t* pid,
             char* const argv[],
             char* const envp[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        int entry_errno = errno;
+        peak_posix_spawn_fn fn = peak_real_posix_spawn();
+
+        if (fn == NULL) {
+            errno = entry_errno;
+            return ENOSYS;
+        }
+        errno = entry_errno;
+        return fn(pid, path, file_actions, attrp, argv, envp);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        if (peak_real_posix_spawn_ptr == NULL) {
+            return ENOSYS;
+        }
+        return peak_real_posix_spawn_ptr(
+            pid, path, file_actions, attrp, argv, envp);
+    }
+
     int entry_errno = errno;
     peak_posix_spawn_fn fn = peak_real_posix_spawn();
     PeakExecEnv built_env = {0};
@@ -2346,6 +3171,25 @@ posix_spawnp(pid_t* pid,
              char* const argv[],
              char* const envp[])
 {
+    if (!peak_exec_priming_is_complete()) {
+        int entry_errno = errno;
+        peak_posix_spawnp_fn fn = peak_real_posix_spawnp();
+
+        if (fn == NULL) {
+            errno = entry_errno;
+            return ENOSYS;
+        }
+        errno = entry_errno;
+        return fn(pid, file, file_actions, attrp, argv, envp);
+    }
+    if (!peak_exec_startup_policy_enabled) {
+        if (peak_real_posix_spawnp_ptr == NULL) {
+            return ENOSYS;
+        }
+        return peak_real_posix_spawnp_ptr(
+            pid, file, file_actions, attrp, argv, envp);
+    }
+
     int entry_errno = errno;
     peak_posix_spawnp_fn fn = peak_real_posix_spawnp();
     PeakExecEnv built_env = {0};

--- a/src/exec_interceptor.c
+++ b/src/exec_interceptor.c
@@ -1,0 +1,2274 @@
+#define _GNU_SOURCE
+#include "exec_interceptor.h"
+#include "internal/exec_memory.h"
+#include "internal/exec_raw_syscall.h"
+#include "utils/utils.h"
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <spawn.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
+
+#if defined(__linux__)
+#include <sys/auxv.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#ifndef PEAK_EXEC_MAX_VARARGS
+#define PEAK_EXEC_MAX_VARARGS 4096U
+#endif
+
+#ifndef PEAK_EXEC_DEFAULT_PATH
+#define PEAK_EXEC_DEFAULT_PATH "/bin:/usr/bin"
+#endif
+
+#define PEAK_EXEC_CHAIN_ENV "PEAK_EXEC_CHAIN"
+#define PEAK_EXEC_CHECKPOINT_ENV "PEAK_EXEC_CHECKPOINT"
+#define PEAK_EXEC_PROPAGATE_PEAK_ENV_ENV "PEAK_EXEC_PROPAGATE_PEAK_ENV"
+#define PEAK_EXEC_TRACE_PATH_ENV "PEAK_EXEC_TRACE_PATH"
+
+/*
+ * Post-fork execution is deliberately bounded.  These buffers live in the
+ * exec wrapper's frame so a child never allocates or changes shared runtime
+ * state before it reaches libc execve.
+ */
+#define PEAK_EXEC_CHILD_ENV_SLOTS 256U
+#define PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY (PATH_MAX * 2U)
+#define PEAK_EXEC_CHILD_NAME_CAPACITY 256U
+
+extern char** environ;
+
+typedef int (*peak_execve_fn)(const char*, char* const[], char* const[]);
+typedef int (*peak_execvpe_fn)(const char*, char* const[], char* const[]);
+typedef int (*peak_fexecve_fn)(int, char* const[], char* const[]);
+typedef int (*peak_execveat_fn)(int,
+                                const char*,
+                                char* const[],
+                                char* const[],
+                                int);
+typedef int (*peak_posix_spawn_fn)(pid_t*,
+                                   const char*,
+                                   const posix_spawn_file_actions_t*,
+                                   const posix_spawnattr_t*,
+                                   char* const[],
+                                   char* const[]);
+typedef int (*peak_posix_spawnp_fn)(pid_t*,
+                                    const char*,
+                                    const posix_spawn_file_actions_t*,
+                                    const posix_spawnattr_t*,
+                                    char* const[],
+                                    char* const[]);
+
+typedef struct {
+    char** envp;
+    char** owned_strings;
+    size_t owned_count;
+    size_t owned_capacity;
+    int changed;
+} PeakExecEnv;
+
+static __thread int peak_exec_wrapper_depth;
+static __thread int peak_exec_spawn_depth;
+static pid_t peak_exec_owner_pid;
+static char peak_exec_cached_libpeak_path[PATH_MAX];
+static int peak_exec_cached_libpeak_path_ready;
+
+static int
+peak_exec_in_fork_child(void)
+{
+    return peak_exec_owner_pid > 0 && getpid() != peak_exec_owner_pid;
+}
+
+static long
+peak_exec_child_pid(void)
+{
+#if defined(SYS_getpid) && defined(__x86_64__)
+    long pid;
+
+    __asm__ volatile("syscall"
+                     : "=a"(pid)
+                     : "a"((long)SYS_getpid)
+                     : "rcx", "r11", "memory");
+    return pid;
+#elif defined(SYS_getpid) && defined(__aarch64__)
+    register long x0 __asm__("x0");
+    register long x8 __asm__("x8") = (long)SYS_getpid;
+
+    __asm__ volatile("svc #0" : "=r"(x0) : "r"(x8) : "cc", "memory");
+    return x0;
+#else
+    return (long)getpid();
+#endif
+}
+
+static int
+peak_exec_child_read(const void* remote, void* local, size_t length)
+{
+    struct iovec local_iov = {local, length};
+    struct iovec remote_iov = {(void*)remote, length};
+    long copied;
+
+#if defined(SYS_process_vm_readv) && defined(__x86_64__)
+    register long r10 __asm__("r10") = (long)&remote_iov;
+    register long r8 __asm__("r8") = 1L;
+    register long r9 __asm__("r9") = 0L;
+
+    /* Do not let a failed probe update vfork-shared errno. */
+    __asm__ volatile("syscall"
+                     : "=a"(copied)
+                     : "a"((long)SYS_process_vm_readv),
+                       "D"(peak_exec_child_pid()),
+                       "S"((long)&local_iov),
+                       "d"(1L),
+                       "r"(r10),
+                       "r"(r8),
+                       "r"(r9)
+                     : "rcx", "r11", "memory");
+#elif defined(SYS_process_vm_readv) && defined(__aarch64__)
+    register long x0 __asm__("x0") = peak_exec_child_pid();
+    register long x1 __asm__("x1") = (long)&local_iov;
+    register long x2 __asm__("x2") = 1L;
+    register long x3 __asm__("x3") = (long)&remote_iov;
+    register long x4 __asm__("x4") = 1L;
+    register long x5 __asm__("x5") = 0L;
+    register long x8 __asm__("x8") = (long)SYS_process_vm_readv;
+
+    __asm__ volatile("svc #0"
+                     : "+r"(x0)
+                     : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x5), "r"(x8)
+                     : "cc", "memory");
+    copied = x0;
+#else
+    copied = -1;
+#endif
+    return copied == (ssize_t)length ? 0 : -1;
+}
+
+static int
+peak_exec_child_read_pointer(char* const envp[], size_t index, const char** entry)
+{
+    uintptr_t base = (uintptr_t)envp;
+    uintptr_t offset;
+
+    if (entry == NULL || index > (UINTPTR_MAX - base) / sizeof(*envp)) {
+        return -1;
+    }
+    offset = base + index * sizeof(*envp);
+    return peak_exec_child_read((const void*)offset, entry, sizeof(*entry));
+}
+
+static int
+peak_exec_child_read_byte(const char* source, size_t index, char* value)
+{
+    uintptr_t address = (uintptr_t)source;
+
+    if (value == NULL || index > UINTPTR_MAX - address) {
+        return -1;
+    }
+    return peak_exec_child_read((const void*)(address + index), value, 1);
+}
+
+/* Returns 1 for a match, 0 for a non-match, and -1 for unreadable memory. */
+static int
+peak_exec_child_entry_matches(const char* entry, const char* name)
+{
+    size_t index = 0;
+
+    if (entry == NULL || name == NULL) {
+        return 0;
+    }
+    while (name[index] != '\0') {
+        char actual;
+
+        if (peak_exec_child_read_byte(entry, index, &actual) != 0) {
+            return -1;
+        }
+        if (actual != name[index]) {
+            return 0;
+        }
+        index++;
+    }
+    {
+        char actual;
+
+        if (peak_exec_child_read_byte(entry, index, &actual) != 0) {
+            return -1;
+        }
+        return actual == '=';
+    }
+}
+
+/* Returns 0 when found, 1 when absent, and -1 when memory is unreadable. */
+static int
+peak_exec_child_env_get(char* const envp[], const char* name, const char** value)
+{
+    if (envp == NULL) {
+        return 1;
+    }
+    for (size_t index = 0; index < PEAK_EXEC_CHILD_ENV_SLOTS; index++) {
+        const char* entry;
+        int matches;
+
+        if (peak_exec_child_read_pointer(envp, index, &entry) != 0) {
+            return -1;
+        }
+        if (entry == NULL) {
+            return 1;
+        }
+        matches = peak_exec_child_entry_matches(entry, name);
+        if (matches < 0) {
+            return -1;
+        }
+        if (matches != 0) {
+            *value = entry + strlen(name) + 1;
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+peak_exec_child_value_false(const char* value, int* result)
+{
+    static const char* const false_values[] = {"0", "false", "no", "off"};
+
+    for (size_t candidate_index = 0;
+         candidate_index < sizeof(false_values) / sizeof(false_values[0]);
+         candidate_index++) {
+        const char* candidate = false_values[candidate_index];
+        size_t index = 0;
+
+        for (;;) {
+            char actual;
+
+            if (index >= PEAK_EXEC_CHILD_NAME_CAPACITY ||
+                peak_exec_child_read_byte(value, index, &actual) != 0) {
+                return -1;
+            }
+            if (actual >= 'A' && actual <= 'Z') {
+                actual = (char)(actual - 'A' + 'a');
+            }
+            if (actual != candidate[index]) {
+                break;
+            }
+            if (actual == '\0') {
+                *result = 1;
+                return 0;
+            }
+            index++;
+        }
+    }
+    *result = 0;
+    return 0;
+}
+
+static int
+peak_exec_child_control_enabled(char* const child_envp[], const char* name, int* enabled)
+{
+    const char* value = NULL;
+    int found = peak_exec_child_env_get(child_envp, name, &value);
+    int is_false;
+
+    if (found < 0) {
+        return -1;
+    }
+    if (found != 0) {
+        found = peak_exec_child_env_get(environ, name, &value);
+        if (found < 0) {
+            return -1;
+        }
+    }
+    if (found != 0) {
+        *enabled = 1;
+        return 0;
+    }
+    if (peak_exec_child_value_false(value, &is_false) != 0) {
+        return -1;
+    }
+    *enabled = !is_false;
+    return 0;
+}
+
+static int
+peak_exec_child_has_name(char* const envp[], const char* name, int* has_name)
+{
+    const char* value = NULL;
+    int found = peak_exec_child_env_get(envp, name, &value);
+
+    if (found < 0) {
+        return -1;
+    }
+    *has_name = found == 0;
+    return 0;
+}
+
+static int
+peak_exec_child_is_separator(char value)
+{
+    return value == ':' || value == ' ' || value == '\t' || value == '\n';
+}
+
+static int
+peak_exec_child_token_is_cached_libpeak(const char* token, size_t token_len)
+{
+    size_t libpeak_len = 0;
+
+    if (token == NULL || !peak_exec_cached_libpeak_path_ready) {
+        return 0;
+    }
+    while (peak_exec_cached_libpeak_path[libpeak_len] != '\0') {
+        libpeak_len++;
+    }
+    if (token_len == libpeak_len) {
+        for (size_t index = 0; index < token_len; index++) {
+            char actual;
+
+            if (peak_exec_child_read_byte(token, index, &actual) != 0 ||
+                actual != peak_exec_cached_libpeak_path[index]) {
+                return 0;
+            }
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static int
+peak_exec_child_append_preload(char* output[],
+                               size_t* count,
+                               const char* entry)
+{
+    if (*count + 1 >= PEAK_EXEC_CHILD_ENV_SLOTS) {
+        return -1;
+    }
+    output[(*count)++] = (char*)entry;
+    return 0;
+}
+
+static char* const*
+peak_exec_child_build_env(char* const envp[],
+                          char* output[PEAK_EXEC_CHILD_ENV_SLOTS],
+                          char ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY])
+{
+    size_t out = 0;
+    size_t ld_len = sizeof("LD_PRELOAD=") - 1;
+    size_t libpeak_len = 0;
+    int propagate_peak_env;
+    int chain_enabled;
+
+    if (!peak_exec_cached_libpeak_path_ready ||
+        peak_exec_child_control_enabled(envp,
+                                        PEAK_EXEC_CHAIN_ENV,
+                                        &chain_enabled) != 0 ||
+        !chain_enabled) {
+        return envp;
+    }
+    while (peak_exec_cached_libpeak_path[libpeak_len] != '\0') {
+        libpeak_len++;
+    }
+    if (ld_len + libpeak_len + 1 > PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY) {
+        return envp;
+    }
+    memcpy(ld_preload, "LD_PRELOAD=", ld_len);
+    memcpy(ld_preload + ld_len, peak_exec_cached_libpeak_path, libpeak_len);
+    ld_len += libpeak_len;
+    ld_preload[ld_len] = '\0';
+
+    if (envp != NULL) {
+        for (size_t index = 0; index < PEAK_EXEC_CHILD_ENV_SLOTS; index++) {
+            const char* entry;
+            int matches;
+
+            if (peak_exec_child_read_pointer(envp, index, &entry) != 0) {
+                return envp;
+            }
+            if (entry == NULL) {
+                break;
+            }
+            matches = peak_exec_child_entry_matches(entry, "LD_PRELOAD");
+            if (matches < 0) {
+                return envp;
+            }
+            if (matches != 0) {
+                const char* value = entry + sizeof("LD_PRELOAD=") - 1;
+                const char* cursor = value;
+                size_t cursor_index = 0;
+
+                for (;;) {
+                    char current;
+                    size_t token_start;
+                    size_t token_len = 0;
+
+                    if (peak_exec_child_read_byte(cursor, cursor_index, &current) != 0) {
+                        return envp;
+                    }
+                    while (current != '\0' && peak_exec_child_is_separator(current)) {
+                        if (++cursor_index >= PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY ||
+                            peak_exec_child_read_byte(cursor, cursor_index, &current) != 0) {
+                            return envp;
+                        }
+                    }
+                    if (current == '\0') {
+                        break;
+                    }
+                    token_start = cursor_index;
+                    while (current != '\0' && !peak_exec_child_is_separator(current)) {
+                        if (++token_len >= PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY ||
+                            ++cursor_index >= PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY ||
+                            peak_exec_child_read_byte(cursor, cursor_index, &current) != 0) {
+                            return envp;
+                        }
+                    }
+                    if (token_len == 0 ||
+                        peak_exec_child_token_is_cached_libpeak(
+                            (const char*)((uintptr_t)cursor + token_start),
+                            token_len)) {
+                        continue;
+                    }
+                    if (ld_len + 1 + token_len + 1 >
+                        PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY) {
+                        return envp;
+                    }
+                    ld_preload[ld_len++] = ':';
+                    for (size_t copy = 0; copy < token_len; copy++) {
+                        if (peak_exec_child_read_byte(cursor,
+                                                      token_start + copy,
+                                                      ld_preload + ld_len++) != 0) {
+                            return envp;
+                        }
+                    }
+                    ld_preload[ld_len] = '\0';
+                }
+                continue;
+            }
+            if (peak_exec_child_append_preload(output, &out, entry) != 0) {
+                return envp;
+            }
+        }
+    }
+    if (peak_exec_child_append_preload(output, &out, ld_preload) != 0) {
+        return envp;
+    }
+
+    if (peak_exec_child_control_enabled(envp,
+                                        PEAK_EXEC_PROPAGATE_PEAK_ENV_ENV,
+                                        &propagate_peak_env) != 0) {
+        return envp;
+    }
+    if (propagate_peak_env && environ != NULL) {
+        for (size_t index = 0; index < PEAK_EXEC_CHILD_ENV_SLOTS; index++) {
+            const char* entry;
+            char prefix[5];
+            size_t name_len = 0;
+            char name[PEAK_EXEC_CHILD_NAME_CAPACITY];
+            int has_name;
+
+            if (peak_exec_child_read_pointer(environ, index, &entry) != 0) {
+                return envp;
+            }
+            if (entry == NULL) {
+                break;
+            }
+            if (peak_exec_child_read(entry, prefix, sizeof(prefix)) != 0 ||
+                memcmp(prefix, "PEAK_", 5) != 0) {
+                continue;
+            }
+            while (name_len + 1 < sizeof(name)) {
+                if (peak_exec_child_read_byte(entry, name_len, name + name_len) != 0) {
+                    return envp;
+                }
+                if (name[name_len] == '=') {
+                    break;
+                }
+                if (name[name_len] == '\0') {
+                    name_len = 0;
+                    break;
+                }
+                name_len++;
+            }
+            if (name_len == 0 || name_len + 1 >= sizeof(name) ||
+                name[name_len] != '=') {
+                continue;
+            }
+            name[name_len] = '\0';
+            if (peak_exec_child_has_name(envp, name, &has_name) != 0) {
+                return envp;
+            }
+            if (!has_name) {
+                if (peak_exec_child_append_preload(output, &out, entry) != 0) {
+                    return envp;
+                }
+            }
+        }
+    }
+    output[out] = NULL;
+    return output;
+}
+
+static int
+peak_exec_size_add(size_t left, size_t right, size_t* result)
+{
+    if (result == NULL || left > SIZE_MAX - right) {
+        errno = E2BIG;
+        return -1;
+    }
+    *result = left + right;
+    return 0;
+}
+
+static int
+peak_exec_size_mul(size_t left, size_t right, size_t* result)
+{
+    if (result == NULL || (left != 0 && right > SIZE_MAX / left)) {
+        errno = E2BIG;
+        return -1;
+    }
+    *result = left * right;
+    return 0;
+}
+
+static void
+peak_exec_trace_event(const char* event,
+                      const char* path,
+                      const char* detail,
+                      int event_errno)
+{
+    const char* trace_path = getenv(PEAK_EXEC_TRACE_PATH_ENV);
+    int saved_errno = errno;
+    int fd;
+
+    if (trace_path == NULL || trace_path[0] == '\0') {
+        return;
+    }
+
+    fd = open(trace_path,
+              O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NONBLOCK,
+              0600);
+    if (fd >= 0) {
+        char row[1024];
+        int n = snprintf(row,
+                         sizeof(row),
+                         "pid=%ld event=%s path=%s detail=%s errno=%d\n",
+                         (long)getpid(),
+                         event != NULL ? event : "",
+                         path != NULL ? path : "",
+                         detail != NULL ? detail : "",
+                         event_errno);
+        if (n > 0) {
+            size_t length = (size_t)n < sizeof(row) ?
+                (size_t)n : sizeof(row) - 1;
+            (void)write(fd, row, length);
+        }
+        (void)close(fd);
+    }
+    errno = saved_errno;
+}
+
+static int
+peak_exec_env_false(const char* value)
+{
+    return value != NULL &&
+           (strcasecmp(value, "0") == 0 ||
+            strcasecmp(value, "false") == 0 ||
+            strcasecmp(value, "no") == 0 ||
+            strcasecmp(value, "off") == 0);
+}
+
+static int
+peak_exec_env_default_true(const char* name)
+{
+    return !peak_exec_env_false(getenv(name));
+}
+
+static int
+peak_exec_is_separator(char ch)
+{
+    return ch == ':' || ch == ' ' || ch == '\t' || ch == '\n';
+}
+
+static int
+peak_exec_name_len(const char* entry)
+{
+    const char* equals;
+
+    if (entry == NULL) {
+        return -1;
+    }
+    equals = strchr(entry, '=');
+    if (equals == NULL) {
+        return -1;
+    }
+    return (int)(equals - entry);
+}
+
+static int
+peak_exec_env_entry_matches(const char* entry, const char* name)
+{
+    int name_len = peak_exec_name_len(entry);
+
+    return name_len >= 0 &&
+           strlen(name) == (size_t)name_len &&
+           strncmp(entry, name, (size_t)name_len) == 0;
+}
+
+static const char*
+peak_exec_env_get(char* const envp[], const char* name)
+{
+    if (envp == NULL) {
+        return NULL;
+    }
+    for (char* const* scan = envp; *scan != NULL; scan++) {
+        if (peak_exec_env_entry_matches(*scan, name)) {
+            return strchr(*scan, '=') + 1;
+        }
+    }
+    return NULL;
+}
+
+static int
+peak_exec_env_default_true_for_child(char* const envp[], const char* name)
+{
+    const char* child_value = peak_exec_env_get(envp, name);
+
+    return child_value != NULL ? !peak_exec_env_false(child_value) :
+                                 peak_exec_env_default_true(name);
+}
+
+static int
+peak_exec_env_has_name(char* const envp[], const char* name)
+{
+    return peak_exec_env_get(envp, name) != NULL;
+}
+
+static int
+peak_exec_storage_has_name(char** envp, size_t count, const char* name)
+{
+    for (size_t i = 0; i < count; i++) {
+        if (peak_exec_env_entry_matches(envp[i], name)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+peak_exec_env_count_bounded(char* const envp[], size_t* count_out)
+{
+    size_t count = 0;
+
+    if (count_out == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (envp == NULL) {
+        *count_out = 0;
+        return 0;
+    }
+    while (envp[count] != NULL) {
+        count++;
+        if (count > PEAK_EXEC_MAX_ENV_ENTRIES) {
+            errno = E2BIG;
+            return -1;
+        }
+    }
+    *count_out = count;
+    return 0;
+}
+
+static size_t
+peak_exec_env_name_count(char* const envp[], const char* name)
+{
+    size_t count = 0;
+
+    if (envp == NULL) {
+        return 0;
+    }
+    for (char* const* scan = envp; *scan != NULL; scan++) {
+        if (peak_exec_env_entry_matches(*scan, name)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+peak_exec_current_env_has_peak_entry(void)
+{
+    if (environ == NULL) {
+        return 0;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        if (strncmp(*scan, "PEAK_", 5) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+peak_exec_env_has_peak_entry(char* const envp[])
+{
+    if (envp == NULL) {
+        return 0;
+    }
+    for (char* const* scan = envp; *scan != NULL; scan++) {
+        if (strncmp(*scan, "PEAK_", 5) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static char*
+peak_exec_env_join_values(char* const envp[], const char* name)
+{
+    size_t total = 0;
+    size_t value_count = 0;
+    size_t out = 0;
+    char* joined;
+
+    if (envp == NULL) {
+        return NULL;
+    }
+    for (char* const* scan = envp; *scan != NULL; scan++) {
+        const char* value;
+
+        if (!peak_exec_env_entry_matches(*scan, name)) {
+            continue;
+        }
+        value = strchr(*scan, '=') + 1;
+        if (value[0] == '\0') {
+            continue;
+        }
+        if (peak_exec_size_add(total, strlen(value), &total) != 0) {
+            return NULL;
+        }
+        if (value_count == SIZE_MAX) {
+            errno = E2BIG;
+            return NULL;
+        }
+        value_count++;
+    }
+    if (peak_exec_env_name_count(envp, name) == 0) {
+        return NULL;
+    }
+
+    size_t allocation_size;
+    if (peak_exec_size_add(total,
+                           value_count > 0 ? value_count : 1,
+                           &allocation_size) != 0) {
+        return NULL;
+    }
+    joined = malloc(allocation_size);
+    if (joined == NULL) {
+        return NULL;
+    }
+    for (char* const* scan = envp; *scan != NULL; scan++) {
+        const char* value;
+        size_t len;
+
+        if (!peak_exec_env_entry_matches(*scan, name)) {
+            continue;
+        }
+        value = strchr(*scan, '=') + 1;
+        len = strlen(value);
+        if (len == 0) {
+            continue;
+        }
+        if (out != 0) {
+            if (out + 1 >= allocation_size) {
+                free(joined);
+                errno = E2BIG;
+                return NULL;
+            }
+            joined[out++] = ':';
+        }
+        if (out >= allocation_size ||
+            len >= allocation_size - out) {
+            free(joined);
+            errno = E2BIG;
+            return NULL;
+        }
+        memcpy(joined + out, value, len);
+        out += len;
+    }
+    if (out >= allocation_size) {
+        free(joined);
+        errno = E2BIG;
+        return NULL;
+    }
+    joined[out] = '\0';
+    return joined;
+}
+
+static int
+peak_exec_secure_mode(void)
+{
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    const char* forced_secure = getenv("PEAK_TEST_EXEC_AT_SECURE");
+    if (forced_secure != NULL && !peak_exec_env_false(forced_secure)) {
+        return 1;
+    }
+#endif
+#if defined(__linux__) && defined(AT_SECURE)
+    return getauxval(AT_SECURE) != 0;
+#else
+    return 0;
+#endif
+}
+
+static char*
+peak_exec_realpath_or_dup(const char* path)
+{
+    char resolved[PATH_MAX];
+
+    if (path != NULL && realpath(path, resolved) != NULL) {
+        return strdup(resolved);
+    }
+    return path != NULL ? strdup(path) : NULL;
+}
+
+static char*
+peak_exec_libpeak_path(void)
+{
+    Dl_info info;
+
+    memset(&info, 0, sizeof(info));
+    if (dladdr((void*)&peak_runtime_is_active_for_checkpoint, &info) == 0 ||
+        info.dli_fname == NULL ||
+        info.dli_fname[0] == '\0') {
+        return NULL;
+    }
+    return peak_exec_realpath_or_dup(info.dli_fname);
+}
+
+static int
+peak_exec_token_is_same_file(const char* token,
+                             size_t token_len,
+                             const char* libpeak_path)
+{
+    char* token_copy;
+    char* token_real;
+    struct stat token_stat;
+    struct stat lib_stat;
+    int same = 0;
+
+    if (token == NULL || token_len == 0 || libpeak_path == NULL) {
+        return 0;
+    }
+    if (token_len == strlen(libpeak_path) &&
+        strncmp(token, libpeak_path, token_len) == 0) {
+        return 1;
+    }
+
+    token_copy = strndup(token, token_len);
+    if (token_copy == NULL) {
+        return 0;
+    }
+    token_real = peak_exec_realpath_or_dup(token_copy);
+    if (token_real != NULL && strcmp(token_real, libpeak_path) == 0) {
+        same = 1;
+    }
+    free(token_real);
+    if (!same &&
+        stat(token_copy, &token_stat) == 0 &&
+        stat(libpeak_path, &lib_stat) == 0 &&
+        token_stat.st_dev == lib_stat.st_dev &&
+        token_stat.st_ino == lib_stat.st_ino) {
+        same = 1;
+    }
+    free(token_copy);
+    return same;
+}
+
+static int
+peak_exec_preload_contains_libpeak(const char* value,
+                                   const char* libpeak_path)
+{
+    const char* cursor = value;
+
+    if (value == NULL || libpeak_path == NULL) {
+        return 0;
+    }
+    while (*cursor != '\0') {
+        const char* start;
+        size_t token_len;
+
+        while (*cursor != '\0' && peak_exec_is_separator(*cursor)) {
+            cursor++;
+        }
+        start = cursor;
+        while (*cursor != '\0' && !peak_exec_is_separator(*cursor)) {
+            cursor++;
+        }
+        token_len = (size_t)(cursor - start);
+        if (token_len != 0 &&
+            peak_exec_token_is_same_file(start, token_len, libpeak_path)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static char*
+peak_exec_build_ld_preload(const char* existing,
+                           const char* libpeak_path,
+                           int* changed)
+{
+    size_t capacity;
+    size_t length;
+    size_t lib_len;
+    char* output;
+    const char* cursor;
+
+    if (changed == NULL || libpeak_path == NULL || libpeak_path[0] == '\0') {
+        errno = EINVAL;
+        return NULL;
+    }
+    *changed = 0;
+    lib_len = strlen(libpeak_path);
+    size_t existing_len = existing != NULL ? strlen(existing) : 0;
+    if (peak_exec_size_add(lib_len, existing_len, &capacity) != 0 ||
+        peak_exec_size_add(capacity, 2, &capacity) != 0) {
+        return NULL;
+    }
+    output = malloc(capacity);
+    if (output == NULL) {
+        return NULL;
+    }
+
+    memcpy(output, libpeak_path, lib_len);
+    length = lib_len;
+    output[length] = '\0';
+
+    cursor = existing;
+    while (cursor != NULL && *cursor != '\0') {
+        const char* start;
+        size_t token_len;
+
+        while (*cursor != '\0' && peak_exec_is_separator(*cursor)) {
+            cursor++;
+        }
+        start = cursor;
+        while (*cursor != '\0' && !peak_exec_is_separator(*cursor)) {
+            cursor++;
+        }
+        token_len = (size_t)(cursor - start);
+        if (token_len == 0 ||
+            peak_exec_token_is_same_file(start, token_len, libpeak_path)) {
+            continue;
+        }
+        size_t required;
+        if (peak_exec_size_add(length, token_len, &required) != 0 ||
+            peak_exec_size_add(required, 2, &required) != 0) {
+            free(output);
+            return NULL;
+        }
+        if (required > capacity) {
+            size_t doubled;
+            size_t new_capacity;
+
+            if (peak_exec_size_mul(capacity, 2, &doubled) != 0 ||
+                peak_exec_size_add(doubled, token_len, &new_capacity) != 0 ||
+                peak_exec_size_add(new_capacity, 2, &new_capacity) != 0) {
+                free(output);
+                return NULL;
+            }
+            if (new_capacity < required) {
+                new_capacity = required;
+            }
+            char* grown = realloc(output, new_capacity);
+            if (grown == NULL) {
+                free(output);
+                return NULL;
+            }
+            output = grown;
+            capacity = new_capacity;
+        }
+        output[length++] = ':';
+        memcpy(output + length, start, token_len);
+        length += token_len;
+        output[length] = '\0';
+    }
+
+    if (existing == NULL || strcmp(existing, output) != 0) {
+        *changed = 1;
+    }
+    return output;
+}
+
+static int
+peak_exec_add_owned(PeakExecEnv* built, char* value)
+{
+    if (built == NULL || value == NULL) {
+        free(value);
+        errno = EINVAL;
+        return -1;
+    }
+    if (built->owned_count >= built->owned_capacity ||
+        built->owned_strings == NULL) {
+        free(value);
+        errno = E2BIG;
+        return -1;
+    }
+    built->owned_strings[built->owned_count++] = value;
+    return 0;
+}
+
+static size_t
+peak_exec_count_missing_peak_env(char* const envp[])
+{
+    size_t count = 0;
+
+    if (environ == NULL) {
+        return 0;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        int name_len;
+        char name[256];
+
+        if (strncmp(*scan, "PEAK_", 5) != 0) {
+            continue;
+        }
+        name_len = peak_exec_name_len(*scan);
+        if (name_len <= 0 || (size_t)name_len >= sizeof(name)) {
+            continue;
+        }
+        memcpy(name, *scan, (size_t)name_len);
+        name[name_len] = '\0';
+        if (!peak_exec_env_has_name(envp, name)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+peak_exec_append_missing_peak_env(PeakExecEnv* built,
+                                  char* const base_env[],
+                                  size_t capacity,
+                                  size_t* out_index)
+{
+    if (environ == NULL) {
+        return 0;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        int name_len;
+        char name[256];
+        char* copy;
+
+        if (strncmp(*scan, "PEAK_", 5) != 0) {
+            continue;
+        }
+        name_len = peak_exec_name_len(*scan);
+        if (name_len <= 0 || (size_t)name_len >= sizeof(name)) {
+            continue;
+        }
+        memcpy(name, *scan, (size_t)name_len);
+        name[name_len] = '\0';
+        if (peak_exec_env_has_name(base_env, name) ||
+            peak_exec_storage_has_name(built->envp, *out_index, name)) {
+            continue;
+        }
+        copy = strdup(*scan);
+        if (peak_exec_add_owned(built, copy) != 0) {
+            return -1;
+        }
+        if (*out_index + 1 >= capacity) {
+            errno = E2BIG;
+            return -1;
+        }
+        built->envp[(*out_index)++] = copy;
+        built->changed = 1;
+    }
+    return 0;
+}
+
+static void
+peak_exec_env_clear(PeakExecEnv* built)
+{
+    if (built == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < built->owned_count; i++) {
+        free(built->owned_strings[i]);
+    }
+    free(built->owned_strings);
+    free(built->envp);
+    memset(built, 0, sizeof(*built));
+}
+
+static int
+peak_exec_should_inject_libpeak(const char* libpeak_path,
+                                char* const child_envp[])
+{
+    const char* current_preload = getenv("LD_PRELOAD");
+
+    if (libpeak_path == NULL || libpeak_path[0] == '\0') {
+        return 0;
+    }
+    return peak_runtime_is_active_for_checkpoint() ||
+           peak_process_requests_work() ||
+           peak_exec_current_env_has_peak_entry() ||
+           peak_exec_env_has_peak_entry(child_envp) ||
+           peak_exec_preload_contains_libpeak(current_preload, libpeak_path);
+}
+
+static int
+peak_exec_build_env(char* const envp[],
+                    int chain_enabled,
+                    int propagate_peak_env,
+                    PeakExecEnv* built)
+{
+    char* const* base_env = envp;
+    size_t base_count = 0;
+    size_t ld_entry_count;
+    size_t missing_peak_count = 0;
+    size_t extra_count;
+    size_t env_capacity;
+    size_t owned_capacity;
+    size_t out = 0;
+    int secure;
+    int should_touch_ld = 0;
+    int new_ld_changed = 0;
+    int ld_written = 0;
+    char* libpeak_path = NULL;
+    char* existing_ld_joined = NULL;
+    char* new_ld_value = NULL;
+
+    memset(built, 0, sizeof(*built));
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    const char* forced_build_fail = getenv("PEAK_TEST_EXEC_ENV_BUILD_FAIL");
+    if (forced_build_fail != NULL &&
+        !peak_exec_env_false(forced_build_fail)) {
+        errno = ENOMEM;
+        return -1;
+    }
+#endif
+    if (!chain_enabled) {
+        return 0;
+    }
+    if (peak_exec_env_count_bounded(base_env, &base_count) != 0) {
+        return -1;
+    }
+    ld_entry_count = peak_exec_env_name_count(base_env, "LD_PRELOAD");
+    secure = peak_exec_secure_mode();
+    libpeak_path = peak_exec_libpeak_path();
+
+    if (!secure && peak_exec_should_inject_libpeak(libpeak_path, envp)) {
+        should_touch_ld = 1;
+        existing_ld_joined = peak_exec_env_join_values(base_env, "LD_PRELOAD");
+        if (ld_entry_count > 0 && existing_ld_joined == NULL) {
+            free(libpeak_path);
+            errno = ENOMEM;
+            return -1;
+        }
+        new_ld_value = peak_exec_build_ld_preload(existing_ld_joined,
+                                                  libpeak_path,
+                                                  &new_ld_changed);
+        if (new_ld_value == NULL) {
+            free(existing_ld_joined);
+            free(libpeak_path);
+            return -1;
+        }
+    }
+    if (propagate_peak_env) {
+        missing_peak_count = peak_exec_count_missing_peak_env(base_env);
+    }
+
+    if (!new_ld_changed && missing_peak_count == 0 && ld_entry_count <= 1) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        return 0;
+    }
+
+    if (peak_exec_size_add(
+            missing_peak_count,
+            (should_touch_ld && ld_entry_count == 0) ? 1 : 0,
+            &extra_count) != 0 ||
+        peak_exec_size_add(base_count, extra_count, &env_capacity) != 0 ||
+        peak_exec_size_add(env_capacity, 1, &env_capacity) != 0) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        return -1;
+    }
+    built->envp = calloc(env_capacity, sizeof(char*));
+    if (built->envp == NULL) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        return -1;
+    }
+    if (peak_exec_size_add(missing_peak_count,
+                           (should_touch_ld && new_ld_changed) ? 1 : 0,
+                           &owned_capacity) != 0) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        return -1;
+    }
+    if (owned_capacity != 0) {
+        built->owned_strings = calloc(owned_capacity, sizeof(char*));
+        if (built->owned_strings == NULL) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            return -1;
+        }
+        built->owned_capacity = owned_capacity;
+    }
+
+    for (size_t i = 0; i < base_count; i++) {
+        if (should_touch_ld &&
+            peak_exec_env_entry_matches(base_env[i], "LD_PRELOAD")) {
+            if (ld_written) {
+                built->changed = 1;
+                continue;
+            }
+            if (new_ld_changed) {
+                size_t value_len = strlen(new_ld_value);
+                size_t entry_size;
+                char* entry;
+
+                if (peak_exec_size_add(strlen("LD_PRELOAD="),
+                                       value_len,
+                                       &entry_size) != 0 ||
+                    peak_exec_size_add(entry_size, 1, &entry_size) != 0) {
+                    free(new_ld_value);
+                    free(existing_ld_joined);
+                    free(libpeak_path);
+                    return -1;
+                }
+                entry = malloc(entry_size);
+                if (entry == NULL) {
+                    free(new_ld_value);
+                    free(existing_ld_joined);
+                    free(libpeak_path);
+                    return -1;
+                }
+                sprintf(entry, "LD_PRELOAD=%s", new_ld_value);
+                if (out + 1 >= env_capacity) {
+                    free(entry);
+                    free(new_ld_value);
+                    free(existing_ld_joined);
+                    free(libpeak_path);
+                    errno = E2BIG;
+                    return -1;
+                }
+                if (peak_exec_add_owned(built, entry) != 0) {
+                    free(new_ld_value);
+                    free(existing_ld_joined);
+                    free(libpeak_path);
+                    return -1;
+                }
+                built->envp[out++] = entry;
+                built->changed = 1;
+            } else {
+                if (out + 1 >= env_capacity) {
+                    free(new_ld_value);
+                    free(existing_ld_joined);
+                    free(libpeak_path);
+                    errno = E2BIG;
+                    return -1;
+                }
+                built->envp[out++] = base_env[i];
+            }
+            ld_written = 1;
+        } else {
+            if (out + 1 >= env_capacity) {
+                free(new_ld_value);
+                free(existing_ld_joined);
+                free(libpeak_path);
+                errno = E2BIG;
+                return -1;
+            }
+            built->envp[out++] = base_env[i];
+        }
+    }
+
+    if (should_touch_ld && ld_entry_count == 0) {
+        size_t value_len = strlen(new_ld_value);
+        size_t entry_size;
+        char* entry;
+
+        if (peak_exec_size_add(strlen("LD_PRELOAD="),
+                               value_len,
+                               &entry_size) != 0 ||
+            peak_exec_size_add(entry_size, 1, &entry_size) != 0) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            return -1;
+        }
+        entry = malloc(entry_size);
+        if (entry == NULL) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            return -1;
+        }
+        sprintf(entry, "LD_PRELOAD=%s", new_ld_value);
+        if (out + 1 >= env_capacity) {
+            free(entry);
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            errno = E2BIG;
+            return -1;
+        }
+        if (peak_exec_add_owned(built, entry) != 0) {
+            free(new_ld_value);
+            free(existing_ld_joined);
+            free(libpeak_path);
+            return -1;
+        }
+        built->envp[out++] = entry;
+        built->changed = 1;
+    }
+
+    if (propagate_peak_env &&
+        peak_exec_append_missing_peak_env(built,
+                                          base_env,
+                                          env_capacity,
+                                          &out) != 0) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        return -1;
+    }
+
+    if (out >= env_capacity) {
+        free(new_ld_value);
+        free(existing_ld_joined);
+        free(libpeak_path);
+        errno = E2BIG;
+        return -1;
+    }
+    built->envp[out] = NULL;
+    free(new_ld_value);
+    free(existing_ld_joined);
+    free(libpeak_path);
+    return 0;
+}
+
+static char* const*
+peak_exec_env_to_use(PeakExecEnv* built_env, char* const original_envp[])
+{
+    return built_env != NULL && built_env->envp != NULL ?
+        built_env->envp : original_envp;
+}
+
+static int
+peak_exec_prepare(const char* path,
+                  char* const argv[],
+                  char* const envp[],
+                  PeakExecEnv* built_env,
+                  int allow_checkpoint)
+{
+    int saved_errno = errno;
+    int chain_enabled =
+        peak_exec_env_default_true_for_child(envp, PEAK_EXEC_CHAIN_ENV);
+    int propagate_peak_env =
+        peak_exec_env_default_true_for_child(
+            envp,
+            PEAK_EXEC_PROPAGATE_PEAK_ENV_ENV);
+    memset(built_env, 0, sizeof(*built_env));
+
+    peak_exec_trace_event("exec-before", path, "", 0);
+    if (allow_checkpoint &&
+        peak_exec_spawn_depth == 0 &&
+        peak_exec_env_default_true_for_child(envp,
+                                             PEAK_EXEC_CHECKPOINT_ENV)) {
+        int checkpoint_result = peak_checkpoint_for_exec(path, argv);
+        int checkpoint_errno = errno;
+        peak_exec_trace_event(checkpoint_result == 0 ?
+                                  "exec-checkpoint-ok" :
+                                  "exec-checkpoint-skipped",
+                              path,
+                              "",
+                              checkpoint_result == 0 ? 0 : checkpoint_errno);
+        errno = saved_errno;
+    }
+
+    if (peak_exec_build_env(envp,
+                            chain_enabled,
+                            propagate_peak_env,
+                            built_env) != 0) {
+        int build_errno = errno;
+        peak_exec_trace_event("exec-env-build-failed",
+                              path,
+                              "using-original-env",
+                              build_errno);
+        errno = build_errno;
+        return -1;
+    }
+    peak_exec_trace_event(built_env->changed ? "exec-env-injected" :
+                                               "exec-env-unchanged",
+                          path,
+                          "",
+                          0);
+    errno = saved_errno;
+    return 0;
+}
+
+static pthread_once_t peak_real_execve_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_execvpe_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_fexecve_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_execveat_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_posix_spawn_once = PTHREAD_ONCE_INIT;
+static pthread_once_t peak_real_posix_spawnp_once = PTHREAD_ONCE_INIT;
+static peak_execve_fn peak_real_execve_ptr;
+static peak_execvpe_fn peak_real_execvpe_ptr;
+static peak_fexecve_fn peak_real_fexecve_ptr;
+static peak_execveat_fn peak_real_execveat_ptr;
+static peak_posix_spawn_fn peak_real_posix_spawn_ptr;
+static peak_posix_spawnp_fn peak_real_posix_spawnp_ptr;
+
+static void peak_lookup_execve(void)
+{
+    peak_real_execve_ptr = (peak_execve_fn)dlsym(RTLD_NEXT, "execve");
+}
+
+static void peak_lookup_execvpe(void)
+{
+    peak_real_execvpe_ptr = (peak_execvpe_fn)dlsym(RTLD_NEXT, "execvpe");
+}
+
+static void peak_lookup_fexecve(void)
+{
+    peak_real_fexecve_ptr = (peak_fexecve_fn)dlsym(RTLD_NEXT, "fexecve");
+}
+
+static void peak_lookup_execveat(void)
+{
+    peak_real_execveat_ptr = (peak_execveat_fn)dlsym(RTLD_NEXT, "execveat");
+}
+
+static void peak_lookup_posix_spawn(void)
+{
+    peak_real_posix_spawn_ptr =
+        (peak_posix_spawn_fn)dlsym(RTLD_NEXT, "posix_spawn");
+}
+
+static void peak_lookup_posix_spawnp(void)
+{
+    peak_real_posix_spawnp_ptr =
+        (peak_posix_spawnp_fn)dlsym(RTLD_NEXT, "posix_spawnp");
+}
+
+static peak_execve_fn
+peak_real_execve(void)
+{
+    (void)pthread_once(&peak_real_execve_once, peak_lookup_execve);
+    return peak_real_execve_ptr;
+}
+
+static peak_execvpe_fn
+peak_real_execvpe(void)
+{
+    (void)pthread_once(&peak_real_execvpe_once, peak_lookup_execvpe);
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    const char* forced_fallback = getenv("PEAK_TEST_EXECVPE_FALLBACK");
+
+    if (forced_fallback != NULL && !peak_exec_env_false(forced_fallback)) {
+        return NULL;
+    }
+#endif
+    return peak_real_execvpe_ptr;
+}
+
+static peak_fexecve_fn
+peak_real_fexecve(void)
+{
+    (void)pthread_once(&peak_real_fexecve_once, peak_lookup_fexecve);
+    return peak_real_fexecve_ptr;
+}
+
+static peak_execveat_fn
+peak_real_execveat(void)
+{
+    (void)pthread_once(&peak_real_execveat_once, peak_lookup_execveat);
+    return peak_real_execveat_ptr;
+}
+
+static peak_posix_spawn_fn
+peak_real_posix_spawn(void)
+{
+    (void)pthread_once(&peak_real_posix_spawn_once,
+                       peak_lookup_posix_spawn);
+    return peak_real_posix_spawn_ptr;
+}
+
+static peak_posix_spawnp_fn
+peak_real_posix_spawnp(void)
+{
+    (void)pthread_once(&peak_real_posix_spawnp_once,
+                       peak_lookup_posix_spawnp);
+    return peak_real_posix_spawnp_ptr;
+}
+
+static void
+peak_exec_cache_libpeak_path(void)
+{
+    char* libpeak_path = peak_exec_libpeak_path();
+    size_t length;
+
+    if (libpeak_path == NULL) {
+        return;
+    }
+    length = strlen(libpeak_path);
+    if (length != 0 && length < sizeof(peak_exec_cached_libpeak_path)) {
+        memcpy(peak_exec_cached_libpeak_path, libpeak_path, length + 1);
+        peak_exec_cached_libpeak_path_ready = 1;
+    }
+    free(libpeak_path);
+}
+
+__attribute__((constructor))
+static void
+peak_exec_prime_real_symbols(void)
+{
+    peak_exec_owner_pid = getpid();
+    peak_exec_cache_libpeak_path();
+    (void)peak_real_execve();
+    (void)peak_real_execvpe();
+    (void)peak_real_fexecve();
+    (void)peak_real_execveat();
+    (void)peak_real_posix_spawn();
+    (void)peak_real_posix_spawnp();
+}
+
+static int
+peak_call_real_execve(const char* path,
+                      char* const argv[],
+                      char* const envp[])
+{
+    peak_execve_fn fn = peak_real_execve();
+
+    if (fn == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return fn(path, argv, envp);
+}
+
+PEAK_EXEC_API int
+execve(const char* path, char* const argv[], char* const envp[])
+{
+    PeakExecEnv built_env = {0};
+    char* const* exec_envp;
+    int saved_errno;
+    int entry_errno = errno;
+
+    if (peak_exec_in_fork_child()) {
+        char* child_env[PEAK_EXEC_CHILD_ENV_SLOTS];
+        char child_ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY];
+        char* const* child_envp = peak_exec_child_build_env(envp,
+                                                             child_env,
+                                                             child_ld_preload);
+
+        if (peak_real_execve_ptr == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return peak_real_execve_ptr(path, argv, (char* const*)child_envp);
+    }
+    if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
+        return peak_call_real_execve(path, argv, envp);
+    }
+    if (peak_exec_args_readable(path, argv, envp) !=
+        PEAK_EXEC_PREFLIGHT_VALID) {
+        return peak_call_real_execve(path, argv, envp);
+    }
+
+    peak_exec_wrapper_depth++;
+    if (peak_exec_prepare(path, argv, envp, &built_env, 1) != 0) {
+        exec_envp = envp;
+        errno = entry_errno;
+    } else {
+        exec_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    (void)peak_call_real_execve(path, argv, (char* const*)exec_envp);
+    saved_errno = errno;
+    peak_exec_env_clear(&built_env);
+    peak_exec_wrapper_depth--;
+    errno = saved_errno;
+    return -1;
+}
+
+int
+peak_exec_raw_syscall_execve(const char* path,
+                             char* const argv[],
+                             char* const envp[])
+{
+    return execve(path, argv, envp);
+}
+
+PEAK_EXEC_API int
+execv(const char* path, char* const argv[])
+{
+    return execve(path, argv, environ);
+}
+
+static char**
+peak_exec_build_shell_argv(const char* file, char* const argv[])
+{
+    size_t argc = 0;
+    size_t shell_argc;
+    char** shell_argv;
+
+    if (argv != NULL) {
+        while (argv[argc] != NULL) {
+            argc++;
+            if (argc >= PEAK_EXEC_MAX_VARARGS) {
+                errno = E2BIG;
+                return NULL;
+            }
+        }
+    }
+
+    shell_argc = argc > 0 ? argc + 1 : 2;
+    shell_argv = calloc(shell_argc + 1, sizeof(char*));
+    if (shell_argv == NULL) {
+        return NULL;
+    }
+    shell_argv[0] = (char*)"/bin/sh";
+    shell_argv[1] = (char*)file;
+    for (size_t i = 1; i < argc; i++) {
+        shell_argv[i + 1] = argv[i];
+    }
+    shell_argv[shell_argc] = NULL;
+    return shell_argv;
+}
+
+static int
+peak_exec_enoexec_shell_fallback(const char* file,
+                                 char* const argv[],
+                                 char* const envp[])
+{
+    char** shell_argv = peak_exec_build_shell_argv(file, argv);
+    int saved_errno;
+
+    if (shell_argv == NULL) {
+        return -1;
+    }
+    (void)peak_call_real_execve("/bin/sh", shell_argv, envp);
+    saved_errno = errno;
+    free(shell_argv);
+    errno = saved_errno;
+    return -1;
+}
+
+static int
+peak_execvpe_fallback(const char* file,
+                      char* const argv[],
+                      char* const envp[])
+{
+    PeakExecEnv built_env = {0};
+    char* const* exec_envp;
+    const char* path_value;
+    int saved_errno = ENOENT;
+    int saw_eacces = 0;
+    int entry_errno = errno;
+
+    if (file == NULL || file[0] == '\0') {
+        errno = ENOENT;
+        return -1;
+    }
+
+    peak_exec_wrapper_depth++;
+    if (peak_exec_prepare(file, argv, envp, &built_env, 1) != 0) {
+        exec_envp = envp;
+        errno = entry_errno;
+    } else {
+        exec_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+
+    if (strchr(file, '/') != NULL) {
+        (void)peak_call_real_execve(file, argv, (char* const*)exec_envp);
+        saved_errno = errno;
+        if (saved_errno == ENOEXEC) {
+            (void)peak_exec_enoexec_shell_fallback(file,
+                                                   argv,
+                                                   (char* const*)exec_envp);
+            saved_errno = errno;
+        }
+        goto out;
+    }
+
+    path_value = getenv("PATH");
+    if (path_value == NULL) {
+        path_value = PEAK_EXEC_DEFAULT_PATH;
+    }
+
+    const char* cursor = path_value;
+    while (1) {
+        const char* start = cursor;
+        size_t dir_len;
+        size_t file_len = strlen(file);
+        size_t candidate_len;
+        char* candidate;
+
+        while (*cursor != '\0' && *cursor != ':') {
+            cursor++;
+        }
+        dir_len = (size_t)(cursor - start);
+        candidate_len = dir_len + (dir_len > 0 ? 1 : 0) + file_len;
+        if (candidate_len + 1 > PATH_MAX) {
+            saved_errno = ENAMETOOLONG;
+            if (*cursor == '\0') {
+                break;
+            }
+            cursor++;
+            continue;
+        }
+        candidate = malloc(candidate_len + 1);
+        if (candidate == NULL) {
+            saved_errno = errno;
+            break;
+        }
+        if (dir_len == 0) {
+            memcpy(candidate, file, file_len + 1);
+        } else {
+            memcpy(candidate, start, dir_len);
+            candidate[dir_len] = '/';
+            memcpy(candidate + dir_len + 1, file, file_len + 1);
+        }
+
+        (void)peak_call_real_execve(candidate, argv, (char* const*)exec_envp);
+        saved_errno = errno;
+        if (saved_errno == ENOEXEC) {
+            (void)peak_exec_enoexec_shell_fallback(
+                candidate,
+                argv,
+                (char* const*)exec_envp);
+            saved_errno = errno;
+        }
+        free(candidate);
+
+        if (saved_errno == EACCES) {
+            saw_eacces = 1;
+        } else if (saved_errno != ENOENT && saved_errno != ENOTDIR) {
+            break;
+        }
+        if (*cursor == '\0') {
+            saved_errno = saw_eacces ? EACCES : saved_errno;
+            break;
+        }
+        cursor++;
+    }
+
+out:
+    peak_exec_env_clear(&built_env);
+    peak_exec_wrapper_depth--;
+    errno = saved_errno != 0 ? saved_errno : entry_errno;
+    return -1;
+}
+
+PEAK_EXEC_API int
+execvpe(const char* file, char* const argv[], char* const envp[])
+{
+    peak_execvpe_fn fn;
+    PeakExecEnv built_env = {0};
+    char* const* exec_envp;
+    int saved_errno;
+    int entry_errno = errno;
+
+    if (peak_exec_in_fork_child()) {
+        char* child_env[PEAK_EXEC_CHILD_ENV_SLOTS];
+        char child_ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY];
+        char* const* child_envp = peak_exec_child_build_env(envp,
+                                                             child_env,
+                                                             child_ld_preload);
+
+        fn = peak_real_execvpe_ptr;
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(file, argv, (char* const*)child_envp);
+    }
+    if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
+        fn = peak_real_execvpe();
+        if (fn != NULL) {
+            return fn(file, argv, envp);
+        }
+        return peak_execvpe_fallback(file, argv, envp);
+    }
+
+    fn = peak_real_execvpe();
+    PeakExecPreflightResult preflight_result =
+        peak_exec_args_readable(file, argv, envp);
+    if (preflight_result != PEAK_EXEC_PREFLIGHT_VALID) {
+        int preflight_errno = errno;
+
+        if (fn != NULL) {
+            return fn(file, argv, envp);
+        }
+        errno = preflight_result == PEAK_EXEC_PREFLIGHT_INVALID ?
+            preflight_errno : ENOSYS;
+        return -1;
+    }
+    if (fn == NULL) {
+        return peak_execvpe_fallback(file, argv, envp);
+    }
+
+    peak_exec_wrapper_depth++;
+    if (peak_exec_prepare(file, argv, envp, &built_env, 1) != 0) {
+        exec_envp = envp;
+        errno = entry_errno;
+    } else {
+        exec_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    (void)fn(file, argv, (char* const*)exec_envp);
+    saved_errno = errno;
+    peak_exec_env_clear(&built_env);
+    peak_exec_wrapper_depth--;
+    errno = saved_errno;
+    return -1;
+}
+
+PEAK_EXEC_API int
+execvp(const char* file, char* const argv[])
+{
+    return execvpe(file, argv, environ);
+}
+
+static int
+peak_exec_collect_argv(const char* arg, va_list* ap, char*** out_argv)
+{
+    va_list count_ap;
+    const char* value;
+    size_t argc = 0;
+    char** argv;
+
+    if (arg != NULL) {
+        argc = 1;
+        va_copy(count_ap, *ap);
+        while ((value = va_arg(count_ap, const char*)) != NULL) {
+            (void)value;
+            argc++;
+            if (argc >= PEAK_EXEC_MAX_VARARGS) {
+                va_end(count_ap);
+                errno = E2BIG;
+                return -1;
+            }
+        }
+        va_end(count_ap);
+    }
+
+    argv = calloc(argc + 1, sizeof(char*));
+    if (argv == NULL) {
+        return -1;
+    }
+    if (arg != NULL) {
+        argv[0] = (char*)arg;
+        for (size_t i = 1; i < argc; i++) {
+            argv[i] = va_arg(*ap, char*);
+        }
+        (void)va_arg(*ap, char*);
+    }
+    argv[argc] = NULL;
+    *out_argv = argv;
+    return 0;
+}
+
+static int
+peak_exec_collect_argv_noalloc(const char* arg,
+                               va_list* ap,
+                               char** argv,
+                               size_t capacity)
+{
+    size_t argc = 0;
+
+    if (argv == NULL || capacity == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (arg != NULL) {
+        argv[argc++] = (char*)arg;
+        for (;;) {
+            char* value = va_arg(*ap, char*);
+
+            if (value == NULL) {
+                break;
+            }
+            if (argc + 1 >= capacity) {
+                errno = E2BIG;
+                return -1;
+            }
+            argv[argc++] = value;
+        }
+    }
+    argv[argc] = NULL;
+    return 0;
+}
+
+PEAK_EXEC_API int
+execl(const char* path, const char* arg, ...)
+{
+    va_list ap;
+    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
+    char** argv = NULL;
+    int noalloc_child = peak_exec_in_fork_child();
+    int result;
+    int saved_errno;
+
+    va_start(ap, arg);
+    if (noalloc_child) {
+        result = peak_exec_collect_argv_noalloc(
+            arg,
+            &ap,
+            child_argv,
+            sizeof(child_argv) / sizeof(child_argv[0]));
+        argv = child_argv;
+    } else {
+        result = peak_exec_collect_argv(arg, &ap, &argv);
+    }
+    va_end(ap);
+    if (result != 0) {
+        return -1;
+    }
+    result = execv(path, argv);
+    saved_errno = errno;
+    if (!noalloc_child) {
+        free(argv);
+    }
+    errno = saved_errno;
+    return result;
+}
+
+PEAK_EXEC_API int
+execlp(const char* file, const char* arg, ...)
+{
+    va_list ap;
+    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
+    char** argv = NULL;
+    int noalloc_child = peak_exec_in_fork_child();
+    int result;
+    int saved_errno;
+
+    va_start(ap, arg);
+    if (noalloc_child) {
+        result = peak_exec_collect_argv_noalloc(
+            arg,
+            &ap,
+            child_argv,
+            sizeof(child_argv) / sizeof(child_argv[0]));
+        argv = child_argv;
+    } else {
+        result = peak_exec_collect_argv(arg, &ap, &argv);
+    }
+    va_end(ap);
+    if (result != 0) {
+        return -1;
+    }
+    result = execvp(file, argv);
+    saved_errno = errno;
+    if (!noalloc_child) {
+        free(argv);
+    }
+    errno = saved_errno;
+    return result;
+}
+
+PEAK_EXEC_API int
+execle(const char* path, const char* arg, ...)
+{
+    va_list ap;
+    char* child_argv[PEAK_EXEC_MAX_VARARGS + 1];
+    char** argv = NULL;
+    char* const* envp;
+    int noalloc_child = peak_exec_in_fork_child();
+    int result;
+    int saved_errno;
+
+    va_start(ap, arg);
+    if (noalloc_child) {
+        result = peak_exec_collect_argv_noalloc(
+            arg,
+            &ap,
+            child_argv,
+            sizeof(child_argv) / sizeof(child_argv[0]));
+        argv = child_argv;
+    } else {
+        result = peak_exec_collect_argv(arg, &ap, &argv);
+    }
+    if (result == 0) {
+        envp = va_arg(ap, char* const*);
+    }
+    va_end(ap);
+    if (result != 0) {
+        return -1;
+    }
+    result = execve(path, argv, (char* const*)envp);
+    saved_errno = errno;
+    if (!noalloc_child) {
+        free(argv);
+    }
+    errno = saved_errno;
+    return result;
+}
+
+PEAK_EXEC_API int
+fexecve(int fd, char* const argv[], char* const envp[])
+{
+    peak_fexecve_fn fn;
+    PeakExecEnv built_env = {0};
+    char* const* exec_envp;
+    char label[64];
+    int saved_errno;
+    int entry_errno = errno;
+
+    if (peak_exec_in_fork_child()) {
+        char* child_env[PEAK_EXEC_CHILD_ENV_SLOTS];
+        char child_ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY];
+        char* const* child_envp = peak_exec_child_build_env(envp,
+                                                             child_env,
+                                                             child_ld_preload);
+
+        fn = peak_real_fexecve_ptr;
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(fd, argv, (char* const*)child_envp);
+    }
+    if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
+        fn = peak_real_fexecve();
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(fd, argv, envp);
+    }
+    if (peak_exec_argv_envp_readable(argv, envp) !=
+        PEAK_EXEC_PREFLIGHT_VALID) {
+        fn = peak_real_fexecve();
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(fd, argv, envp);
+    }
+
+    snprintf(label, sizeof(label), "<fd:%d>", fd);
+    peak_exec_wrapper_depth++;
+    if (peak_exec_prepare(label, argv, envp, &built_env, 1) != 0) {
+        exec_envp = envp;
+        errno = entry_errno;
+    } else {
+        exec_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    fn = peak_real_fexecve();
+    if (fn == NULL) {
+        saved_errno = ENOSYS;
+    } else {
+        (void)fn(fd, argv, (char* const*)exec_envp);
+        saved_errno = errno;
+    }
+    peak_exec_env_clear(&built_env);
+    peak_exec_wrapper_depth--;
+    errno = saved_errno;
+    return -1;
+}
+
+#if defined(__linux__)
+PEAK_EXEC_API int
+execveat(int dirfd,
+         const char* pathname,
+         char* const argv[],
+         char* const envp[],
+         int flags)
+{
+    peak_execveat_fn fn;
+    PeakExecEnv built_env = {0};
+    char* const* exec_envp;
+    int saved_errno;
+    int entry_errno = errno;
+
+    if (peak_exec_in_fork_child()) {
+        char* child_env[PEAK_EXEC_CHILD_ENV_SLOTS];
+        char child_ld_preload[PEAK_EXEC_CHILD_LD_PRELOAD_CAPACITY];
+        char* const* child_envp = peak_exec_child_build_env(envp,
+                                                             child_env,
+                                                             child_ld_preload);
+
+        fn = peak_real_execveat_ptr;
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(dirfd, pathname, argv, (char* const*)child_envp, flags);
+    }
+    if (peak_exec_wrapper_depth > 0 || peak_exec_spawn_depth > 0) {
+        fn = peak_real_execveat();
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(dirfd, pathname, argv, envp, flags);
+    }
+    if (peak_exec_args_readable(pathname, argv, envp) !=
+        PEAK_EXEC_PREFLIGHT_VALID) {
+        fn = peak_real_execveat();
+        if (fn == NULL) {
+            errno = ENOSYS;
+            return -1;
+        }
+        return fn(dirfd, pathname, argv, envp, flags);
+    }
+
+    peak_exec_wrapper_depth++;
+    if (peak_exec_prepare(pathname, argv, envp, &built_env, 1) != 0) {
+        exec_envp = envp;
+        errno = entry_errno;
+    } else {
+        exec_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    fn = peak_real_execveat();
+    if (fn == NULL) {
+        saved_errno = ENOSYS;
+    } else {
+        (void)fn(dirfd, pathname, argv, (char* const*)exec_envp, flags);
+        saved_errno = errno;
+    }
+    peak_exec_env_clear(&built_env);
+    peak_exec_wrapper_depth--;
+    errno = saved_errno;
+    return -1;
+}
+#endif
+
+int
+peak_exec_raw_syscall_execveat(int dirfd,
+                               const char* pathname,
+                               char* const argv[],
+                               char* const envp[],
+                               int flags)
+{
+    return execveat(dirfd, pathname, argv, envp, flags);
+}
+
+PEAK_EXEC_API int
+posix_spawn(pid_t* pid,
+            const char* path,
+            const posix_spawn_file_actions_t* file_actions,
+            const posix_spawnattr_t* attrp,
+            char* const argv[],
+            char* const envp[])
+{
+    peak_posix_spawn_fn fn = peak_real_posix_spawn();
+    PeakExecEnv built_env = {0};
+    char* const* spawn_envp;
+    int result;
+    int entry_errno = errno;
+
+    if (fn == NULL) {
+        errno = entry_errno;
+        return ENOSYS;
+    }
+    PeakExecPreflightResult preflight_result =
+        peak_exec_args_readable(path, argv, envp);
+    if (preflight_result != PEAK_EXEC_PREFLIGHT_VALID) {
+        int preflight_errno = errno;
+
+        if (preflight_result == PEAK_EXEC_PREFLIGHT_INVALID &&
+            preflight_errno == EFAULT) {
+            errno = entry_errno;
+            return EFAULT;
+        }
+        result = fn(pid, path, file_actions, attrp, argv, envp);
+        errno = entry_errno;
+        return result;
+    }
+    if (peak_exec_prepare(path, argv, envp, &built_env, 0) != 0) {
+        spawn_envp = envp;
+        errno = entry_errno;
+    } else {
+        spawn_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    peak_exec_spawn_depth++;
+    result = fn(pid,
+                path,
+                file_actions,
+                attrp,
+                argv,
+                (char* const*)spawn_envp);
+    peak_exec_spawn_depth--;
+    peak_exec_env_clear(&built_env);
+    errno = entry_errno;
+    return result;
+}
+
+PEAK_EXEC_API int
+posix_spawnp(pid_t* pid,
+             const char* file,
+             const posix_spawn_file_actions_t* file_actions,
+             const posix_spawnattr_t* attrp,
+             char* const argv[],
+             char* const envp[])
+{
+    peak_posix_spawnp_fn fn = peak_real_posix_spawnp();
+    PeakExecEnv built_env = {0};
+    char* const* spawn_envp;
+    int result;
+    int entry_errno = errno;
+
+    if (fn == NULL) {
+        errno = entry_errno;
+        return ENOSYS;
+    }
+    PeakExecPreflightResult preflight_result =
+        peak_exec_args_readable(file, argv, envp);
+    if (preflight_result != PEAK_EXEC_PREFLIGHT_VALID) {
+        int preflight_errno = errno;
+
+        if (preflight_result == PEAK_EXEC_PREFLIGHT_INVALID &&
+            preflight_errno == EFAULT) {
+            errno = entry_errno;
+            return EFAULT;
+        }
+        result = fn(pid, file, file_actions, attrp, argv, envp);
+        errno = entry_errno;
+        return result;
+    }
+    if (peak_exec_prepare(file, argv, envp, &built_env, 0) != 0) {
+        spawn_envp = envp;
+        errno = entry_errno;
+    } else {
+        spawn_envp = peak_exec_env_to_use(&built_env, envp);
+    }
+    peak_exec_spawn_depth++;
+    result = fn(pid,
+                file,
+                file_actions,
+                attrp,
+                argv,
+                (char* const*)spawn_envp);
+    peak_exec_spawn_depth--;
+    peak_exec_env_clear(&built_env);
+    errno = entry_errno;
+    return result;
+}

--- a/src/exec_interceptor.c
+++ b/src/exec_interceptor.c
@@ -2179,11 +2179,19 @@ posix_spawn(pid_t* pid,
             char* const argv[],
             char* const envp[])
 {
+    int entry_errno = errno;
     peak_posix_spawn_fn fn = peak_real_posix_spawn();
     PeakExecEnv built_env = {0};
     char* const* spawn_envp;
     int result;
-    int entry_errno = errno;
+    int spawn_errno;
+
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (getenv("PEAK_TEST_EXEC_SPAWN_RESOLVER_NULL") != NULL) {
+        errno = EIO;
+        fn = NULL;
+    }
+#endif
 
     if (fn == NULL) {
         errno = entry_errno;
@@ -2192,23 +2200,17 @@ posix_spawn(pid_t* pid,
     PeakExecPreflightResult preflight_result =
         peak_exec_args_readable(path, argv, envp);
     if (preflight_result != PEAK_EXEC_PREFLIGHT_VALID) {
-        int preflight_errno = errno;
-
-        if (preflight_result == PEAK_EXEC_PREFLIGHT_INVALID &&
-            preflight_errno == EFAULT) {
-            errno = entry_errno;
-            return EFAULT;
-        }
-        result = fn(pid, path, file_actions, attrp, argv, envp);
         errno = entry_errno;
-        return result;
+        return fn(pid, path, file_actions, attrp, argv, envp);
     }
     if (peak_exec_prepare(path, argv, envp, &built_env, 0) != 0) {
-        spawn_envp = envp;
+        peak_exec_env_clear(&built_env);
         errno = entry_errno;
+        return fn(pid, path, file_actions, attrp, argv, envp);
     } else {
         spawn_envp = peak_exec_env_to_use(&built_env, envp);
     }
+    errno = entry_errno;
     peak_exec_spawn_depth++;
     result = fn(pid,
                 path,
@@ -2216,9 +2218,10 @@ posix_spawn(pid_t* pid,
                 attrp,
                 argv,
                 (char* const*)spawn_envp);
+    spawn_errno = errno;
     peak_exec_spawn_depth--;
     peak_exec_env_clear(&built_env);
-    errno = entry_errno;
+    errno = spawn_errno;
     return result;
 }
 
@@ -2230,11 +2233,19 @@ posix_spawnp(pid_t* pid,
              char* const argv[],
              char* const envp[])
 {
+    int entry_errno = errno;
     peak_posix_spawnp_fn fn = peak_real_posix_spawnp();
     PeakExecEnv built_env = {0};
     char* const* spawn_envp;
     int result;
-    int entry_errno = errno;
+    int spawn_errno;
+
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (getenv("PEAK_TEST_EXEC_SPAWN_RESOLVER_NULL") != NULL) {
+        errno = EIO;
+        fn = NULL;
+    }
+#endif
 
     if (fn == NULL) {
         errno = entry_errno;
@@ -2243,23 +2254,17 @@ posix_spawnp(pid_t* pid,
     PeakExecPreflightResult preflight_result =
         peak_exec_args_readable(file, argv, envp);
     if (preflight_result != PEAK_EXEC_PREFLIGHT_VALID) {
-        int preflight_errno = errno;
-
-        if (preflight_result == PEAK_EXEC_PREFLIGHT_INVALID &&
-            preflight_errno == EFAULT) {
-            errno = entry_errno;
-            return EFAULT;
-        }
-        result = fn(pid, file, file_actions, attrp, argv, envp);
         errno = entry_errno;
-        return result;
+        return fn(pid, file, file_actions, attrp, argv, envp);
     }
     if (peak_exec_prepare(file, argv, envp, &built_env, 0) != 0) {
-        spawn_envp = envp;
+        peak_exec_env_clear(&built_env);
         errno = entry_errno;
+        return fn(pid, file, file_actions, attrp, argv, envp);
     } else {
         spawn_envp = peak_exec_env_to_use(&built_env, envp);
     }
+    errno = entry_errno;
     peak_exec_spawn_depth++;
     result = fn(pid,
                 file,
@@ -2267,8 +2272,9 @@ posix_spawnp(pid_t* pid,
                 attrp,
                 argv,
                 (char* const*)spawn_envp);
+    spawn_errno = errno;
     peak_exec_spawn_depth--;
     peak_exec_env_clear(&built_env);
-    errno = entry_errno;
+    errno = spawn_errno;
     return result;
 }

--- a/src/exec_memory.c
+++ b/src/exec_memory.c
@@ -1,0 +1,424 @@
+#define _GNU_SOURCE
+#include "internal/exec_memory.h"
+#include "internal/exec_raw_syscall.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static int
+peak_exec_test_hook_enabled(const char* name)
+{
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    const char* value = getenv(name);
+
+    return value != NULL && value[0] != '\0' && strcmp(value, "0") != 0;
+#else
+    (void)name;
+    return 0;
+#endif
+}
+
+static int
+peak_exec_hex_value(char ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return ch - '0';
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return ch - 'a' + 10;
+    }
+    if (ch >= 'A' && ch <= 'F') {
+        return ch - 'A' + 10;
+    }
+    return -1;
+}
+
+static const char*
+peak_exec_parse_maps_hex(const char* cursor,
+                         const char* end,
+                         uintptr_t* value_out)
+{
+    uintptr_t value = 0;
+    int digits = 0;
+
+    while (cursor < end) {
+        int digit = peak_exec_hex_value(*cursor);
+
+        if (digit < 0) {
+            break;
+        }
+        if (value > (UINTPTR_MAX - (uintptr_t)digit) / 16U) {
+            return NULL;
+        }
+        value = value * 16U + (uintptr_t)digit;
+        digits++;
+        cursor++;
+    }
+    if (digits == 0) {
+        return NULL;
+    }
+    *value_out = value;
+    return cursor;
+}
+
+static int
+peak_exec_parse_maps_line(const char* line,
+                          size_t length,
+                          uintptr_t* start_out,
+                          uintptr_t* end_out,
+                          int* readable_out)
+{
+    const char* cursor = line;
+    const char* end = line + length;
+    uintptr_t start = 0;
+    uintptr_t stop = 0;
+
+    cursor = peak_exec_parse_maps_hex(cursor, end, &start);
+    if (cursor == NULL || cursor >= end || *cursor != '-') {
+        return -1;
+    }
+    cursor = peak_exec_parse_maps_hex(cursor + 1, end, &stop);
+    if (cursor == NULL || cursor >= end || *cursor != ' ') {
+        return -1;
+    }
+    cursor++;
+    if (cursor >= end || stop <= start) {
+        return -1;
+    }
+
+    *start_out = start;
+    *end_out = stop;
+    *readable_out = *cursor == 'r';
+    return 0;
+}
+
+static PeakExecPreflightResult
+peak_exec_maps_range_readable(const void* remote, size_t length)
+{
+#if defined(__linux__) && defined(SYS_openat) && defined(SYS_read) && \
+    defined(SYS_close)
+    uintptr_t start = (uintptr_t)remote;
+    uintptr_t stop;
+    uintptr_t covered;
+    char read_buffer[4096] = {0};
+    char line[1024];
+    size_t line_length = 0;
+    int skipping_long_line = 0;
+    long fd;
+
+    if (length == 0) {
+        return PEAK_EXEC_PREFLIGHT_VALID;
+    }
+    if (remote == NULL || start > UINTPTR_MAX - length) {
+        return PEAK_EXEC_PREFLIGHT_INVALID;
+    }
+    stop = start + length;
+    covered = start;
+
+    if (peak_exec_test_hook_enabled(
+            "PEAK_TEST_EXEC_PREFLIGHT_MAPS_UNAVAILABLE")) {
+        return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+    }
+    fd = peak_exec_raw_syscall6(SYS_openat,
+                                AT_FDCWD,
+                                (long)"/proc/self/maps",
+                                O_RDONLY | O_CLOEXEC,
+                                0,
+                                0,
+                                0);
+    if (fd < 0) {
+        return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+    }
+
+    while (covered < stop) {
+        long bytes_read = peak_exec_raw_syscall6(SYS_read,
+                                                 fd,
+                                                 (long)read_buffer,
+                                                 sizeof(read_buffer),
+                                                 0,
+                                                 0,
+                                                 0);
+        if (bytes_read < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        if (bytes_read == 0) {
+            break;
+        }
+
+        for (long i = 0; i < bytes_read; i++) {
+            char ch = read_buffer[i];
+
+            if (skipping_long_line) {
+                if (ch == '\n') {
+                    skipping_long_line = 0;
+                    line_length = 0;
+                }
+                continue;
+            }
+            if (ch != '\n' && line_length + 1 < sizeof(line)) {
+                line[line_length++] = ch;
+                continue;
+            }
+            if (ch != '\n') {
+                skipping_long_line = 1;
+                line_length = 0;
+                continue;
+            }
+
+            uintptr_t map_start = 0;
+            uintptr_t map_end = 0;
+            int readable = 0;
+
+            if (peak_exec_parse_maps_line(line,
+                                          line_length,
+                                          &map_start,
+                                          &map_end,
+                                          &readable) == 0 &&
+                map_end > covered) {
+                if (map_start > covered || !readable) {
+                    (void)peak_exec_raw_syscall6(SYS_close,
+                                                 fd,
+                                                 0,
+                                                 0,
+                                                 0,
+                                                 0,
+                                                 0);
+                    return PEAK_EXEC_PREFLIGHT_INVALID;
+                }
+                covered = map_end < stop ? map_end : stop;
+                if (covered >= stop) {
+                    (void)peak_exec_raw_syscall6(SYS_close,
+                                                 fd,
+                                                 0,
+                                                 0,
+                                                 0,
+                                                 0,
+                                                 0);
+                    return PEAK_EXEC_PREFLIGHT_VALID;
+                }
+            }
+            line_length = 0;
+        }
+    }
+
+    (void)peak_exec_raw_syscall6(SYS_close, fd, 0, 0, 0, 0, 0);
+    return PEAK_EXEC_PREFLIGHT_INVALID;
+#else
+    (void)remote;
+    (void)length;
+    return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+#endif
+}
+
+static PeakExecPreflightResult
+peak_exec_user_read_bytes(const void* remote, void* local, size_t length)
+{
+    if (length == 0) {
+        return PEAK_EXEC_PREFLIGHT_VALID;
+    }
+    if (remote == NULL || local == NULL) {
+        errno = EFAULT;
+        return PEAK_EXEC_PREFLIGHT_INVALID;
+    }
+
+#if defined(__linux__) && defined(SYS_process_vm_readv)
+    struct iovec local_iov = { .iov_base = local, .iov_len = length };
+    struct iovec remote_iov = {
+        .iov_base = (void*)remote,
+        .iov_len = length
+    };
+    long bytes_read;
+
+    if (peak_exec_test_hook_enabled("PEAK_TEST_EXEC_PREFLIGHT_UNAVAILABLE")) {
+        bytes_read = -1;
+        errno = EPERM;
+    } else {
+        bytes_read = peak_exec_raw_syscall6(SYS_process_vm_readv,
+                                            (long)getpid(),
+                                            (long)&local_iov,
+                                            1,
+                                            (long)&remote_iov,
+                                            1,
+                                            0);
+    }
+    if (bytes_read == (long)length) {
+        return PEAK_EXEC_PREFLIGHT_VALID;
+    }
+    if (bytes_read >= 0) {
+        errno = EFAULT;
+        return PEAK_EXEC_PREFLIGHT_INVALID;
+    }
+
+    PeakExecPreflightResult maps_result =
+        peak_exec_maps_range_readable(remote, length);
+    if (maps_result == PEAK_EXEC_PREFLIGHT_INVALID) {
+        errno = EFAULT;
+        return PEAK_EXEC_PREFLIGHT_INVALID;
+    }
+    if (maps_result == PEAK_EXEC_PREFLIGHT_UNKNOWN) {
+        return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+    }
+
+#if defined(SYS_openat) && defined(SYS_pread64) && defined(SYS_close)
+    if (!peak_exec_test_hook_enabled("PEAK_TEST_EXEC_PREFLIGHT_NO_PROC_MEM")) {
+        long fd = peak_exec_raw_syscall6(SYS_openat,
+                                         AT_FDCWD,
+                                         (long)"/proc/self/mem",
+                                         O_RDONLY | O_CLOEXEC,
+                                         0,
+                                         0,
+                                         0);
+        if (fd >= 0) {
+            long mem_read = peak_exec_raw_syscall6(
+                SYS_pread64,
+                fd,
+                (long)local,
+                (long)length,
+                (long)(uintptr_t)remote,
+                0,
+                0);
+            int read_errno = errno;
+
+            (void)peak_exec_raw_syscall6(SYS_close, fd, 0, 0, 0, 0, 0);
+            if (mem_read == (long)length) {
+                return PEAK_EXEC_PREFLIGHT_VALID;
+            }
+            if (mem_read >= 0 || read_errno == EIO) {
+                errno = EFAULT;
+                return PEAK_EXEC_PREFLIGHT_INVALID;
+            }
+        }
+    }
+#endif
+    return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+#else
+    return PEAK_EXEC_PREFLIGHT_UNKNOWN;
+#endif
+}
+
+static PeakExecPreflightResult
+peak_exec_user_cstr_readable(const char* value, size_t max_length)
+{
+    char buffer[256];
+    size_t offset = 0;
+    const size_t page_size = 4096U;
+    uintptr_t base = (uintptr_t)value;
+
+    if (value == NULL) {
+        errno = EFAULT;
+        return PEAK_EXEC_PREFLIGHT_INVALID;
+    }
+    while (offset < max_length) {
+        uintptr_t address;
+        size_t chunk = sizeof(buffer);
+        size_t page_remaining;
+
+        if (base > UINTPTR_MAX - offset) {
+            errno = EFAULT;
+            return PEAK_EXEC_PREFLIGHT_INVALID;
+        }
+        address = base + offset;
+        page_remaining = page_size - (address % page_size);
+        if (chunk > max_length - offset) {
+            chunk = max_length - offset;
+        }
+        if (chunk > page_remaining) {
+            chunk = page_remaining;
+        }
+        PeakExecPreflightResult read_result =
+            peak_exec_user_read_bytes((const void*)address, buffer, chunk);
+        if (read_result != PEAK_EXEC_PREFLIGHT_VALID) {
+            return read_result;
+        }
+        if (memchr(buffer, '\0', chunk) != NULL) {
+            return PEAK_EXEC_PREFLIGHT_VALID;
+        }
+        offset += chunk;
+    }
+
+    errno = ENAMETOOLONG;
+    return PEAK_EXEC_PREFLIGHT_INVALID;
+}
+
+static PeakExecPreflightResult
+peak_exec_user_cstr_array_readable(char* const values[],
+                                   size_t max_entries,
+                                   size_t max_string_length)
+{
+    uintptr_t base = (uintptr_t)values;
+
+    if (values == NULL) {
+        return PEAK_EXEC_PREFLIGHT_VALID;
+    }
+    for (size_t i = 0; i < max_entries; i++) {
+        char* entry = NULL;
+        uintptr_t slot;
+
+        if (i > (UINTPTR_MAX - base) / sizeof(entry)) {
+            errno = EFAULT;
+            return PEAK_EXEC_PREFLIGHT_INVALID;
+        }
+        slot = base + i * sizeof(entry);
+        PeakExecPreflightResult read_result =
+            peak_exec_user_read_bytes((const void*)slot,
+                                      &entry,
+                                      sizeof(entry));
+        if (read_result != PEAK_EXEC_PREFLIGHT_VALID) {
+            return read_result;
+        }
+        if (entry == NULL) {
+            return PEAK_EXEC_PREFLIGHT_VALID;
+        }
+        read_result = peak_exec_user_cstr_readable(entry, max_string_length);
+        if (read_result != PEAK_EXEC_PREFLIGHT_VALID) {
+            return read_result;
+        }
+    }
+
+    errno = E2BIG;
+    return PEAK_EXEC_PREFLIGHT_INVALID;
+}
+
+PeakExecPreflightResult
+peak_exec_args_readable(const char* path,
+                        char* const argv[],
+                        char* const envp[])
+{
+    PeakExecPreflightResult result =
+        peak_exec_user_cstr_readable(path, PATH_MAX);
+
+    if (result != PEAK_EXEC_PREFLIGHT_VALID) {
+        return result;
+    }
+    return peak_exec_argv_envp_readable(argv, envp);
+}
+
+PeakExecPreflightResult
+peak_exec_argv_envp_readable(char* const argv[], char* const envp[])
+{
+    PeakExecPreflightResult result =
+        peak_exec_user_cstr_array_readable(argv,
+                                           PEAK_EXEC_MAX_ENV_ENTRIES,
+                                           PEAK_EXEC_USER_STRING_MAX);
+
+    if (result != PEAK_EXEC_PREFLIGHT_VALID) {
+        return result;
+    }
+    return peak_exec_user_cstr_array_readable(envp,
+                                              PEAK_EXEC_MAX_ENV_ENTRIES,
+                                              PEAK_EXEC_USER_STRING_MAX);
+}

--- a/src/exec_memory.c
+++ b/src/exec_memory.c
@@ -398,6 +398,11 @@ peak_exec_args_readable(const char* path,
                         char* const argv[],
                         char* const envp[])
 {
+#if defined(PEAK_ENABLE_TEST_HOOKS)
+    if (peak_exec_test_hook_enabled("PEAK_TEST_EXEC_PREFLIGHT_TRAP")) {
+        _exit(97);
+    }
+#endif
     PeakExecPreflightResult result =
         peak_exec_user_cstr_readable(path, PATH_MAX);
 

--- a/src/exec_raw_syscall.c
+++ b/src/exec_raw_syscall.c
@@ -1,0 +1,87 @@
+#define _GNU_SOURCE
+#include "internal/exec_raw_syscall.h"
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
+
+/* Standalone detach tests link signal_policy without the exec interceptor. */
+#if defined(PEAK_EXEC_RAW_SYSCALL_STANDALONE)
+extern int peak_exec_raw_syscall_execve(const char*, char* const[], char* const[])
+    __attribute__((weak));
+#if defined(__linux__)
+extern int peak_exec_raw_syscall_execveat(int,
+                                          const char*,
+                                          char* const[],
+                                          char* const[],
+                                          int) __attribute__((weak));
+#endif
+#endif
+
+int
+peak_exec_raw_syscall_handle(long number,
+                             long arg1,
+                             long arg2,
+                             long arg3,
+                             long arg4,
+                             long arg5,
+                             long arg6,
+                             long* result)
+{
+    (void)arg6;
+    if (result == NULL) {
+        return 0;
+    }
+
+#if defined(__linux__) && defined(SYS_execve)
+    if (number == SYS_execve) {
+#if !defined(PEAK_EXEC_RAW_SYSCALL_STANDALONE)
+        *result = peak_exec_raw_syscall_execve(
+            (const char*)(uintptr_t)arg1,
+            (char* const*)(uintptr_t)arg2,
+            (char* const*)(uintptr_t)arg3);
+#else
+        if (peak_exec_raw_syscall_execve != NULL) {
+            *result = peak_exec_raw_syscall_execve(
+                (const char*)(uintptr_t)arg1,
+                (char* const*)(uintptr_t)arg2,
+                (char* const*)(uintptr_t)arg3);
+        } else {
+            *result = peak_exec_raw_syscall6(number,
+                                             arg1, arg2, arg3, 0, 0, 0);
+        }
+#endif
+        return 1;
+    }
+#endif
+#if defined(__linux__) && defined(SYS_execveat)
+    if (number == SYS_execveat) {
+#if !defined(PEAK_EXEC_RAW_SYSCALL_STANDALONE)
+        *result = peak_exec_raw_syscall_execveat(
+            (int)arg1,
+            (const char*)(uintptr_t)arg2,
+            (char* const*)(uintptr_t)arg3,
+            (char* const*)(uintptr_t)arg4,
+            (int)arg5);
+#else
+        if (peak_exec_raw_syscall_execveat != NULL) {
+            *result = peak_exec_raw_syscall_execveat(
+                (int)arg1,
+                (const char*)(uintptr_t)arg2,
+                (char* const*)(uintptr_t)arg3,
+                (char* const*)(uintptr_t)arg4,
+                (int)arg5);
+        } else {
+            *result = peak_exec_raw_syscall6(number,
+                                             arg1, arg2, arg3, arg4, arg5, 0);
+        }
+#endif
+        return 1;
+    }
+#endif
+    return 0;
+}

--- a/src/exec_raw_syscall_trampoline.S
+++ b/src/exec_raw_syscall_trampoline.S
@@ -1,0 +1,17 @@
+#if defined(__x86_64__)
+    .text
+    .globl syscall
+    .type syscall, @function
+    .hidden peak_signal_policy_syscall_dispatch
+syscall:
+    jmp peak_signal_policy_syscall_dispatch
+    .size syscall, .-syscall
+#elif defined(__aarch64__)
+    .text
+    .globl syscall
+    .type syscall, %function
+    .hidden peak_signal_policy_syscall_dispatch
+syscall:
+    b peak_signal_policy_syscall_dispatch
+    .size syscall, .-syscall
+#endif

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -27,6 +27,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+extern int peak_exec_checkpoint_enabled_at_startup(void) __attribute__((weak));
+#endif
+
 #undef g_printerr
 #define g_printerr(...) peak_log_warn(__VA_ARGS__)
 

--- a/src/general_listener/callback_runtime.inc
+++ b/src/general_listener/callback_runtime.inc
@@ -14,6 +14,169 @@ peak_general_listener_note_mpi_finalize_requested(void)
                           memory_order_release);
 }
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic int peak_checkpoint_test_mutation_contender_invalidated;
+#endif
+
+static void
+peak_general_listener_checkpoint_shadow_update(
+    PeakGeneralListenerCheckpointShadow* shadow,
+    gdouble duration,
+    gdouble exclusive_duration)
+{
+    if (atomic_load_explicit(&shadow->invalid, memory_order_relaxed)) {
+        return;
+    }
+    gulong observed = atomic_load_explicit(&shadow->sequence,
+                                           memory_order_acquire);
+
+    for (unsigned int attempt = 0; attempt < 2; attempt++) {
+        if (atomic_load_explicit(&shadow->invalid, memory_order_relaxed)) {
+            return;
+        }
+        if ((observed & 1UL) != 0) {
+            break;
+        }
+        if (atomic_compare_exchange_strong_explicit(&shadow->sequence,
+                                                    &observed,
+                                                    observed + 1UL,
+                                                    memory_order_acquire,
+                                                    memory_order_relaxed)) {
+            shadow->completed_calls++;
+            shadow->total_time += duration;
+            shadow->exclusive_time += exclusive_duration;
+            if (shadow->completed_calls == 1) {
+                shadow->max_time = (gfloat)duration;
+                shadow->min_time = (gfloat)duration;
+            } else {
+                if (duration > shadow->max_time) {
+                    shadow->max_time = (gfloat)duration;
+                }
+                if (duration < shadow->min_time) {
+                    shadow->min_time = (gfloat)duration;
+                }
+            }
+            atomic_store_explicit(&shadow->sequence,
+                                  observed + 2UL,
+                                  memory_order_release);
+            return;
+        }
+        if ((observed & 1UL) != 0) {
+            break;
+        }
+    }
+    int expected_invalid = 0;
+    if (!atomic_compare_exchange_strong_explicit(&shadow->invalid,
+                                                 &expected_invalid,
+                                                 1,
+                                                 memory_order_release,
+                                                 memory_order_relaxed)) {
+        return;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_store_explicit(&peak_checkpoint_test_mutation_contender_invalidated,
+                          1,
+                          memory_order_release);
+#endif
+}
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static PeakGeneralListener* peak_checkpoint_test_mutation_listener;
+static size_t peak_checkpoint_test_mutation_index;
+static gulong peak_checkpoint_test_mutation_sequence;
+
+PEAK_API int
+peak_general_listener_test_checkpoint_mutation_begin(void)
+{
+    PeakGeneralListener* listener;
+    PeakGeneralListenerCheckpointShadow* shadow;
+
+    if (array_listener == NULL || peak_hook_address_count == 0 ||
+        array_listener[0] == NULL || peak_max_num_threads == 0 ||
+        peak_checkpoint_test_mutation_listener != NULL) {
+        return EINVAL;
+    }
+    listener = PEAKGENERAL_LISTENER(array_listener[0]);
+    for (size_t index = 0; index < peak_max_num_threads; index++) {
+        if (peak_general_listener_num_calls_load(&listener->num_calls[index]) != 0) {
+            peak_checkpoint_test_mutation_index = index;
+            break;
+        }
+    }
+    if (peak_general_listener_num_calls_load(
+            &listener->num_calls[peak_checkpoint_test_mutation_index]) == 0) {
+        return EINVAL;
+    }
+    if (listener->checkpoint_shadow == NULL) {
+        return EINVAL;
+    }
+    for (size_t index = 0; index < peak_max_num_threads; index++) {
+        PeakGeneralListenerCheckpointShadow* current =
+            &listener->checkpoint_shadow[index];
+
+        atomic_store_explicit(&current->sequence, 0, memory_order_relaxed);
+        atomic_store_explicit(&current->invalid, 0, memory_order_relaxed);
+        current->completed_calls = 0;
+        current->total_time = 0.0;
+        current->exclusive_time = 0.0;
+        current->max_time = 0.0f;
+        current->min_time = 0.0f;
+    }
+    shadow = &listener->checkpoint_shadow[peak_checkpoint_test_mutation_index];
+    peak_checkpoint_test_mutation_sequence = 0;
+    if (!atomic_compare_exchange_strong_explicit(&shadow->sequence,
+                                                 &peak_checkpoint_test_mutation_sequence,
+                                                 1,
+                                                 memory_order_acquire,
+                                                 memory_order_relaxed)) {
+        return EAGAIN;
+    }
+    shadow->total_time = 170.0;
+    shadow->exclusive_time = 85.0;
+    shadow->max_time = 10.0f;
+    shadow->min_time = 10.0f;
+    shadow->completed_calls = 1;
+    peak_checkpoint_test_mutation_listener = listener;
+    atomic_store_explicit(&peak_checkpoint_test_mutation_contender_invalidated,
+                          0,
+                          memory_order_release);
+    return 0;
+}
+
+PEAK_API void
+peak_general_listener_test_checkpoint_mutation_release(void)
+{
+    if (peak_checkpoint_test_mutation_listener != NULL) {
+        atomic_store_explicit(
+            &peak_checkpoint_test_mutation_listener->checkpoint_shadow[
+                peak_checkpoint_test_mutation_index].sequence,
+            peak_checkpoint_test_mutation_sequence + 2UL,
+            memory_order_release);
+        peak_checkpoint_test_mutation_listener = NULL;
+    }
+}
+
+PEAK_API int
+peak_general_listener_test_checkpoint_mutation_contend(void)
+{
+    PeakGeneralListener* listener = peak_checkpoint_test_mutation_listener;
+    size_t index = peak_checkpoint_test_mutation_index;
+    if (listener == NULL) {
+        return EINVAL;
+    }
+    peak_general_listener_checkpoint_shadow_update(
+        &listener->checkpoint_shadow[index], 20.0, 10.0);
+    return 0;
+}
+
+PEAK_API int
+peak_general_listener_test_checkpoint_mutation_contender_invalidated(void)
+{
+    return atomic_load_explicit(&peak_checkpoint_test_mutation_contender_invalidated,
+                                memory_order_acquire);
+}
+#endif
+
 static void
 peak_general_listener_abandon_current_invocation(PeakInvocationData* priv,
                                                  gboolean use_pause_guard)
@@ -246,6 +409,12 @@ peak_general_listener_on_leave(GumInvocationListener* listener,
             peak_general_listener_exclusive_duration(
                 end_time,
                 child_duration);
+        if (G_UNLIKELY(self->checkpoint_shadow != NULL)) {
+            peak_general_listener_checkpoint_shadow_update(
+                &self->checkpoint_shadow[index],
+                end_time,
+                peak_general_listener_exclusive_duration(end_time, child_duration));
+        }
         if (thread_data.level == 0) {
             void* tmp_ptr = thread_data.child_time;
             thread_data.child_time = NULL;
@@ -305,6 +474,12 @@ peak_general_listener_on_leave(GumInvocationListener* listener,
             peak_general_listener_exclusive_duration(
                 end_time,
                 child_duration);
+        if (G_UNLIKELY(self->checkpoint_shadow != NULL)) {
+            peak_general_listener_checkpoint_shadow_update(
+                &self->checkpoint_shadow[index],
+                end_time,
+                peak_general_listener_exclusive_duration(end_time, child_duration));
+        }
         if (thread_data.level == 0) {
             void* tmp_ptr = thread_data.child_time;
             thread_data.child_time = NULL;
@@ -342,6 +517,17 @@ peak_general_listener_init(PeakGeneralListener* self)
     self->exclusive_time = g_new0(gdouble, total_count);
     self->max_time = g_new0(gfloat, total_count);
     self->min_time = g_new0(gfloat, total_count);
+    if (peak_exec_checkpoint_enabled_at_startup != NULL &&
+        peak_exec_checkpoint_enabled_at_startup()) {
+        self->checkpoint_shadow = g_aligned_alloc0(
+            total_count,
+            sizeof(*self->checkpoint_shadow),
+            64);
+        for (size_t index = 0; index < total_count; index++) {
+            atomic_init(&self->checkpoint_shadow[index].sequence, 0);
+            atomic_init(&self->checkpoint_shadow[index].invalid, 0);
+        }
+    }
     self->target_thread_called = g_new0(gboolean, total_count);
     // g_print ("total count %lu self->num_calls %lu\n", total_count, self->num_calls[0]);
 }
@@ -354,6 +540,7 @@ peak_general_listener_free(PeakGeneralListener* self)
     g_free(self->exclusive_time);
     g_free(self->max_time);
     g_free(self->min_time);
+    g_aligned_free(self->checkpoint_shadow);
     g_free(self->target_thread_called);
     self->target_thread_called = NULL;
 }

--- a/src/general_listener/output.inc
+++ b/src/general_listener/output.inc
@@ -374,12 +374,64 @@ typedef struct {
 } PeakExecCheckpointRecord;
 
 typedef struct {
-    gulong* num_calls;
-    gdouble* total_time;
-    gdouble* exclusive_time;
-    gfloat* max_time;
-    gfloat* min_time;
+    PeakGeneralListenerCheckpointShadow* shadows;
+    gulong* sequences;
+    int* invalid;
 } PeakExecCheckpointThreadSnapshot;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic int peak_checkpoint_test_busy_pause = 0;
+static _Atomic int peak_checkpoint_test_busy_held = 0;
+static _Atomic int peak_checkpoint_test_busy_released = 0;
+
+PEAK_API void
+peak_general_listener_test_checkpoint_busy_pause_enable(void)
+{
+    atomic_store_explicit(&peak_checkpoint_test_busy_released,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_checkpoint_test_busy_held,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_checkpoint_test_busy_pause,
+                          1,
+                          memory_order_release);
+}
+
+PEAK_API int
+peak_general_listener_test_checkpoint_busy_is_held(void)
+{
+    return atomic_load_explicit(&peak_checkpoint_test_busy_held,
+                                memory_order_acquire);
+}
+
+PEAK_API void
+peak_general_listener_test_checkpoint_busy_release(void)
+{
+    atomic_store_explicit(&peak_checkpoint_test_busy_released,
+                          1,
+                          memory_order_release);
+}
+
+static void
+peak_general_listener_test_checkpoint_busy_pause(void)
+{
+    if (atomic_load_explicit(&peak_checkpoint_test_busy_pause,
+                             memory_order_acquire) == 0) {
+        return;
+    }
+    atomic_store_explicit(&peak_checkpoint_test_busy_held,
+                          1,
+                          memory_order_release);
+    while (atomic_load_explicit(&peak_checkpoint_test_busy_released,
+                                memory_order_acquire) == 0) {
+        sched_yield();
+    }
+    atomic_store_explicit(&peak_checkpoint_test_busy_pause,
+                          0,
+                          memory_order_release);
+}
+#endif
 
 static gboolean
 peak_exec_checkpoint_copy_listener(
@@ -388,33 +440,65 @@ peak_exec_checkpoint_copy_listener(
     size_t thread_count)
 {
 #if defined(__linux__) && defined(SYS_process_vm_readv)
-    struct iovec local[5] = {
-        { snapshot->num_calls, thread_count * sizeof(gulong) },
-        { snapshot->total_time, thread_count * sizeof(gdouble) },
-        { snapshot->exclusive_time, thread_count * sizeof(gdouble) },
-        { snapshot->max_time, thread_count * sizeof(gfloat) },
-        { snapshot->min_time, thread_count * sizeof(gfloat) }
-    };
-    struct iovec remote[5] = {
-        { listener->num_calls, thread_count * sizeof(gulong) },
-        { listener->total_time, thread_count * sizeof(gdouble) },
-        { listener->exclusive_time, thread_count * sizeof(gdouble) },
-        { listener->max_time, thread_count * sizeof(gfloat) },
-        { listener->min_time, thread_count * sizeof(gfloat) }
-    };
-    size_t expected = thread_count *
-        (sizeof(gulong) + sizeof(gdouble) + sizeof(gdouble) +
-         sizeof(gfloat) + sizeof(gfloat));
-    long copied = peak_exec_checkpoint_raw_syscall6(
-        SYS_process_vm_readv,
-        (long)getpid(),
-        (long)local,
-        5,
-        (long)remote,
-        5,
-        0);
+    if (listener->checkpoint_shadow == NULL) {
+        errno = EOPNOTSUPP;
+        return FALSE;
+    }
+    struct iovec local = { snapshot->shadows,
+                           thread_count * sizeof(*snapshot->shadows) };
+    struct iovec remote = { listener->checkpoint_shadow,
+                            thread_count * sizeof(*listener->checkpoint_shadow) };
+    size_t expected = thread_count * sizeof(*snapshot->shadows);
+    for (unsigned int attempt = 0; attempt < 8; attempt++) {
+        gboolean busy = FALSE;
 
-    return copied >= 0 && (size_t)copied == expected;
+        for (size_t index = 0; index < thread_count; index++) {
+            snapshot->sequences[index] = atomic_load_explicit(
+                &listener->checkpoint_shadow[index].sequence, memory_order_acquire);
+            snapshot->invalid[index] = atomic_load_explicit(
+                &listener->checkpoint_shadow[index].invalid, memory_order_acquire);
+            if ((snapshot->sequences[index] & 1UL) != 0 ||
+                snapshot->invalid[index] != 0) {
+                busy = TRUE;
+                break;
+            }
+        }
+        if (busy) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+            peak_general_listener_test_checkpoint_busy_pause();
+#endif
+            continue;
+        }
+
+        long copied = peak_exec_checkpoint_raw_syscall6(
+            SYS_process_vm_readv,
+            (long)getpid(),
+            (long)&local,
+            1,
+            (long)&remote,
+            1,
+            0);
+        if (copied < 0 || (size_t)copied != expected) {
+            return FALSE;
+        }
+        for (size_t index = 0; index < thread_count; index++) {
+            gulong current = atomic_load_explicit(
+                &listener->checkpoint_shadow[index].sequence, memory_order_acquire);
+            int invalid = atomic_load_explicit(
+                &listener->checkpoint_shadow[index].invalid, memory_order_acquire);
+            if (current != snapshot->sequences[index] ||
+                invalid != snapshot->invalid[index] || invalid != 0 ||
+                (current & 1UL) != 0) {
+                busy = TRUE;
+                break;
+            }
+        }
+        if (!busy) {
+            return TRUE;
+        }
+    }
+    errno = EAGAIN;
+    return FALSE;
 #else
     (void)listener;
     (void)snapshot;
@@ -618,7 +702,6 @@ peak_general_listener_checkpoint_for_exec(unsigned long long checkpoint_index)
     size_t hook_count;
     size_t thread_count;
     size_t name_bytes = 0;
-    size_t thread_bytes;
     size_t thread_storage_bytes;
     PeakExecCheckpointRecord* records = NULL;
     size_t* name_lengths = NULL;
@@ -687,7 +770,8 @@ peak_general_listener_checkpoint_for_exec(unsigned long long checkpoint_index)
 
     if (thread_count != 0 &&
         thread_count > SIZE_MAX /
-            (sizeof(gulong) + 2 * sizeof(gdouble) + 2 * sizeof(gfloat))) {
+            (sizeof(PeakGeneralListenerCheckpointShadow) + sizeof(gulong) +
+             sizeof(int))) {
         peak_exec_checkpoint_free_snapshot(records,
                                            name_lengths,
                                            NULL,
@@ -695,27 +779,33 @@ peak_general_listener_checkpoint_for_exec(unsigned long long checkpoint_index)
         errno = EOVERFLOW;
         return FALSE;
     }
-    thread_bytes = thread_count * sizeof(gdouble);
     thread_storage_bytes = thread_count *
-        (sizeof(gulong) + 2 * sizeof(gdouble) + 2 * sizeof(gfloat));
+        (sizeof(PeakGeneralListenerCheckpointShadow) + sizeof(gulong) +
+         sizeof(int));
     names = malloc(name_bytes != 0 ? name_bytes : 1);
-    thread_storage = malloc(thread_storage_bytes != 0 ?
-                                thread_storage_bytes : 1);
-    if (names == NULL || thread_storage == NULL) {
+    int thread_storage_error = posix_memalign(
+        &thread_storage,
+        64,
+        thread_storage_bytes != 0 ? thread_storage_bytes : 1);
+    if (thread_storage_error != 0) {
+        thread_storage = NULL;
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        errno = thread_storage_error;
+        return FALSE;
+    }
+    if (names == NULL) {
         peak_exec_checkpoint_free_snapshot(records,
                                            name_lengths,
                                            names,
                                            thread_storage);
         return FALSE;
     }
-    threads.num_calls = thread_storage;
-    threads.total_time = (gdouble*)((char*)thread_storage +
-                                    thread_count * sizeof(gulong));
-    threads.exclusive_time = (gdouble*)((char*)threads.total_time +
-                                        thread_bytes);
-    threads.max_time = (gfloat*)((char*)threads.exclusive_time +
-                                 thread_bytes);
-    threads.min_time = threads.max_time + thread_count;
+    threads.shadows = thread_storage;
+    threads.sequences = (gulong*)(threads.shadows + thread_count);
+    threads.invalid = (int*)(threads.sequences + thread_count);
 
     if (!peak_general_listener_checkpoint_snapshot_lock()) {
         peak_exec_checkpoint_free_snapshot(records,
@@ -759,26 +849,28 @@ peak_general_listener_checkpoint_for_exec(unsigned long long checkpoint_index)
         name_offset += name_lengths[i];
 
         for (size_t j = 0; j < thread_count; j++) {
-            gulong calls = threads.num_calls[j];
+            const PeakGeneralListenerCheckpointShadow* shadow =
+                &threads.shadows[j];
+            gulong calls = shadow->completed_calls;
 
             records[i].num_calls += calls;
-            records[i].total_time += threads.total_time[j];
-            records[i].exclusive_time += threads.exclusive_time[j];
+            records[i].total_time += shadow->total_time;
+            records[i].exclusive_time += shadow->exclusive_time;
             if (calls != 0) {
                 records[i].threads_seen++;
-                if (threads.total_time[j] > records[i].max_total_time) {
-                    records[i].max_total_time = threads.total_time[j];
+                if (shadow->total_time > records[i].max_total_time) {
+                    records[i].max_total_time = shadow->total_time;
                 }
-                if (threads.total_time[j] < records[i].min_total_time ||
+                if (shadow->total_time < records[i].min_total_time ||
                     records[i].threads_seen == 1) {
-                    records[i].min_total_time = threads.total_time[j];
+                    records[i].min_total_time = shadow->total_time;
                 }
-                if (threads.max_time[j] > records[i].max_time) {
-                    records[i].max_time = threads.max_time[j];
+                if (shadow->max_time > records[i].max_time) {
+                    records[i].max_time = shadow->max_time;
                 }
-                if (threads.min_time[j] < records[i].min_time ||
+                if (shadow->min_time < records[i].min_time ||
                     records[i].threads_seen == 1) {
-                    records[i].min_time = threads.min_time[j];
+                    records[i].min_time = shadow->min_time;
                 }
             }
         }

--- a/src/general_listener/output.inc
+++ b/src/general_listener/output.inc
@@ -1,3 +1,6 @@
+#include <sys/syscall.h>
+#include <sys/uio.h>
+
 static char*
 peak_stats_csv_path(void)
 {
@@ -34,12 +37,818 @@ _Static_assert(sizeof(uint64_t) * CHAR_BIT == 64,
 #endif
 #endif
 
+static long
+peak_exec_checkpoint_raw_syscall6(long number,
+                                  long arg1,
+                                  long arg2,
+                                  long arg3,
+                                  long arg4,
+                                  long arg5,
+                                  long arg6)
+{
+#if defined(__linux__) && defined(__x86_64__)
+    long result;
+    register long r10 __asm__("r10") = arg4;
+    register long r8 __asm__("r8") = arg5;
+    register long r9 __asm__("r9") = arg6;
+
+    __asm__ volatile("syscall"
+                     : "=a"(result)
+                     : "a"(number),
+                       "D"(arg1),
+                       "S"(arg2),
+                       "d"(arg3),
+                       "r"(r10),
+                       "r"(r8),
+                       "r"(r9)
+                     : "rcx", "r11", "memory");
+    if (result < 0 && result >= -4095) {
+        errno = (int)-result;
+        return -1;
+    }
+    return result;
+#elif defined(__linux__) && defined(__aarch64__)
+    register long x0 __asm__("x0") = arg1;
+    register long x1 __asm__("x1") = arg2;
+    register long x2 __asm__("x2") = arg3;
+    register long x3 __asm__("x3") = arg4;
+    register long x4 __asm__("x4") = arg5;
+    register long x5 __asm__("x5") = arg6;
+    register long x8 __asm__("x8") = number;
+
+    __asm__ volatile("svc #0"
+                     : "+r"(x0)
+                     : "r"(x1),
+                       "r"(x2),
+                       "r"(x3),
+                       "r"(x4),
+                       "r"(x5),
+                       "r"(x8)
+                     : "cc", "memory");
+    if (x0 < 0 && x0 >= -4095) {
+        errno = (int)-x0;
+        return -1;
+    }
+    return x0;
+#else
+    (void)number;
+    (void)arg1;
+    (void)arg2;
+    (void)arg3;
+    (void)arg4;
+    (void)arg5;
+    (void)arg6;
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+static gboolean
+peak_exec_checkpoint_append_char(char* buffer,
+                                 size_t buffer_size,
+                                 size_t* out,
+                                 char value)
+{
+    if (*out + 1 >= buffer_size) {
+        errno = ENAMETOOLONG;
+        return FALSE;
+    }
+    buffer[(*out)++] = value;
+    buffer[*out] = '\0';
+    return TRUE;
+}
+
+static gboolean
+peak_exec_checkpoint_append_literal(char* buffer,
+                                    size_t buffer_size,
+                                    size_t* out,
+                                    const char* value)
+{
+    while (value != NULL && *value != '\0') {
+        if (!peak_exec_checkpoint_append_char(buffer,
+                                              buffer_size,
+                                              out,
+                                              *value++)) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static gboolean
+peak_exec_checkpoint_append_u64(char* buffer,
+                                size_t buffer_size,
+                                size_t* out,
+                                unsigned long long value)
+{
+    char digits[32];
+    size_t count = 0;
+
+    do {
+        digits[count++] = (char)('0' + (value % 10ULL));
+        value /= 10ULL;
+    } while (value != 0ULL);
+
+    while (count != 0) {
+        if (!peak_exec_checkpoint_append_char(buffer,
+                                              buffer_size,
+                                              out,
+                                              digits[--count])) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static gboolean
+peak_exec_checkpoint_append_padded_u64(char* buffer,
+                                       size_t buffer_size,
+                                       size_t* out,
+                                       unsigned long long value,
+                                       unsigned int width)
+{
+    char digits[32];
+    size_t count = 0;
+
+    do {
+        digits[count++] = (char)('0' + (value % 10ULL));
+        value /= 10ULL;
+    } while (value != 0ULL);
+    while (count < width && count < sizeof(digits)) {
+        digits[count++] = '0';
+    }
+    while (count != 0) {
+        if (!peak_exec_checkpoint_append_char(buffer,
+                                              buffer_size,
+                                              out,
+                                              digits[--count])) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static int
+peak_stats_exec_checkpoint_path(char* buffer,
+                                size_t buffer_size,
+                                unsigned long long checkpoint_index)
+{
+    const char* base = getenv("PEAK_STATSLOG_PATH");
+    size_t out = 0;
+
+    if (buffer == NULL || buffer_size == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    buffer[0] = '\0';
+    if (base == NULL || base[0] == '\0') {
+        base = "./peak_statslog";
+    }
+
+    if (!peak_exec_checkpoint_append_literal(buffer, buffer_size, &out, base) ||
+        !peak_exec_checkpoint_append_literal(buffer, buffer_size, &out, "-p") ||
+        !peak_exec_checkpoint_append_u64(buffer,
+                                         buffer_size,
+                                         &out,
+                                         (unsigned long long)getpid()) ||
+        !peak_exec_checkpoint_append_literal(buffer,
+                                             buffer_size,
+                                             &out,
+                                             "-exec") ||
+        !peak_exec_checkpoint_append_u64(buffer,
+                                         buffer_size,
+                                         &out,
+                                         checkpoint_index) ||
+        !peak_exec_checkpoint_append_literal(buffer,
+                                             buffer_size,
+                                             &out,
+                                             ".csv")) {
+        return -1;
+    }
+    return 0;
+}
+
 static void
 peak_stats_csv_unlink(void)
 {
     char* out_csv = peak_stats_csv_path();
     (void)unlink(out_csv);
     g_free(out_csv);
+}
+
+static gboolean
+peak_exec_checkpoint_write_all(int fd, const char* data, size_t length)
+{
+    size_t written = 0;
+
+    while (written < length) {
+        ssize_t rc = (ssize_t)peak_exec_checkpoint_raw_syscall6(SYS_write,
+                                                                fd,
+                                                                (long)(data + written),
+                                                                (long)(length - written),
+                                                                0,
+                                                                0,
+                                                                0);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return FALSE;
+        }
+        if (rc == 0) {
+            errno = EIO;
+            return FALSE;
+        }
+        written += (size_t)rc;
+    }
+    return TRUE;
+}
+
+static int
+peak_exec_checkpoint_open_exclusive(const char* path)
+{
+    return (int)peak_exec_checkpoint_raw_syscall6(SYS_openat,
+                                                  AT_FDCWD,
+                                                  (long)path,
+                                                  O_WRONLY | O_CREAT |
+                                                      O_EXCL | O_CLOEXEC,
+                                                  0600,
+                                                  0,
+                                                  0);
+}
+
+static gboolean
+peak_exec_checkpoint_close_fd(int fd)
+{
+    return peak_exec_checkpoint_raw_syscall6(SYS_close,
+                                             fd,
+                                             0,
+                                             0,
+                                             0,
+                                             0,
+                                             0) == 0;
+}
+
+static void
+peak_exec_checkpoint_unlink_path(const char* path)
+{
+    (void)peak_exec_checkpoint_raw_syscall6(SYS_unlinkat,
+                                            AT_FDCWD,
+                                            (long)path,
+                                            0,
+                                            0,
+                                            0,
+                                            0);
+}
+
+static gboolean
+peak_exec_checkpoint_write_csv_name(int fd, const char* name)
+{
+    const char* start;
+    const char* cursor;
+
+    if (!peak_exec_checkpoint_write_all(fd, "\"", 1)) {
+        return FALSE;
+    }
+    if (name == NULL) {
+        return peak_exec_checkpoint_write_all(fd, "\"", 1);
+    }
+
+    start = name;
+    cursor = name;
+    while (*cursor != '\0') {
+        if (*cursor == '"') {
+            if (cursor > start &&
+                !peak_exec_checkpoint_write_all(
+                    fd,
+                    start,
+                    (size_t)(cursor - start))) {
+                return FALSE;
+            }
+            if (!peak_exec_checkpoint_write_all(fd, "\"\"", 2)) {
+                return FALSE;
+            }
+            start = cursor + 1;
+        }
+        cursor++;
+    }
+    if (cursor > start &&
+        !peak_exec_checkpoint_write_all(fd,
+                                        start,
+                                        (size_t)(cursor - start))) {
+        return FALSE;
+    }
+    return peak_exec_checkpoint_write_all(fd, "\"", 1);
+}
+
+static gboolean
+peak_general_listener_checkpoint_snapshot_lock(void)
+{
+    return pthread_mutex_trylock(&lock) == 0;
+}
+
+typedef struct {
+    char* name;
+    gulong num_calls;
+    gulong threads_seen;
+    gdouble total_time;
+    gdouble max_total_time;
+    gdouble min_total_time;
+    gdouble exclusive_time;
+    gfloat max_time;
+    gfloat min_time;
+} PeakExecCheckpointRecord;
+
+typedef struct {
+    gulong* num_calls;
+    gdouble* total_time;
+    gdouble* exclusive_time;
+    gfloat* max_time;
+    gfloat* min_time;
+} PeakExecCheckpointThreadSnapshot;
+
+static gboolean
+peak_exec_checkpoint_copy_listener(
+    const PeakGeneralListener* listener,
+    PeakExecCheckpointThreadSnapshot* snapshot,
+    size_t thread_count)
+{
+#if defined(__linux__) && defined(SYS_process_vm_readv)
+    struct iovec local[5] = {
+        { snapshot->num_calls, thread_count * sizeof(gulong) },
+        { snapshot->total_time, thread_count * sizeof(gdouble) },
+        { snapshot->exclusive_time, thread_count * sizeof(gdouble) },
+        { snapshot->max_time, thread_count * sizeof(gfloat) },
+        { snapshot->min_time, thread_count * sizeof(gfloat) }
+    };
+    struct iovec remote[5] = {
+        { listener->num_calls, thread_count * sizeof(gulong) },
+        { listener->total_time, thread_count * sizeof(gdouble) },
+        { listener->exclusive_time, thread_count * sizeof(gdouble) },
+        { listener->max_time, thread_count * sizeof(gfloat) },
+        { listener->min_time, thread_count * sizeof(gfloat) }
+    };
+    size_t expected = thread_count *
+        (sizeof(gulong) + sizeof(gdouble) + sizeof(gdouble) +
+         sizeof(gfloat) + sizeof(gfloat));
+    long copied = peak_exec_checkpoint_raw_syscall6(
+        SYS_process_vm_readv,
+        (long)getpid(),
+        (long)local,
+        5,
+        (long)remote,
+        5,
+        0);
+
+    return copied >= 0 && (size_t)copied == expected;
+#else
+    (void)listener;
+    (void)snapshot;
+    (void)thread_count;
+    errno = ENOSYS;
+    return FALSE;
+#endif
+}
+
+static void
+peak_exec_checkpoint_free_snapshot(PeakExecCheckpointRecord* records,
+                                   size_t* name_lengths,
+                                   char* names,
+                                   void* thread_storage)
+{
+    free(thread_storage);
+    free(names);
+    free(name_lengths);
+    free(records);
+}
+
+static gboolean
+peak_exec_checkpoint_append_double(char* buffer,
+                                   size_t buffer_size,
+                                   size_t* out,
+                                   double value)
+{
+    int exponent = 0;
+    unsigned long long scaled;
+    unsigned long long digit;
+    unsigned long long frac;
+
+    if (value != value) {
+        return peak_exec_checkpoint_append_literal(buffer,
+                                                   buffer_size,
+                                                   out,
+                                                   "nan");
+    }
+    if (value < 0.0) {
+        if (!peak_exec_checkpoint_append_char(buffer,
+                                              buffer_size,
+                                              out,
+                                              '-')) {
+            return FALSE;
+        }
+        value = -value;
+    }
+    if (value > DBL_MAX) {
+        return peak_exec_checkpoint_append_literal(buffer,
+                                                   buffer_size,
+                                                   out,
+                                                   "inf");
+    }
+    if (value == 0.0) {
+        return peak_exec_checkpoint_append_literal(buffer,
+                                                   buffer_size,
+                                                   out,
+                                                   "0.000000000e+00");
+    }
+    while (value >= 10.0 && exponent < 308) {
+        value /= 10.0;
+        exponent++;
+    }
+    while (value < 1.0 && exponent > -308) {
+        value *= 10.0;
+        exponent--;
+    }
+    scaled = (unsigned long long)(value * 1000000000.0 + 0.5);
+    if (scaled >= 10000000000ULL) {
+        scaled /= 10ULL;
+        exponent++;
+    }
+    digit = scaled / 1000000000ULL;
+    frac = scaled % 1000000000ULL;
+    if (!peak_exec_checkpoint_append_u64(buffer,
+                                         buffer_size,
+                                         out,
+                                         digit) ||
+        !peak_exec_checkpoint_append_char(buffer, buffer_size, out, '.') ||
+        !peak_exec_checkpoint_append_padded_u64(buffer,
+                                               buffer_size,
+                                               out,
+                                               frac,
+                                               9) ||
+        !peak_exec_checkpoint_append_char(buffer, buffer_size, out, 'e')) {
+        return FALSE;
+    }
+    if (exponent < 0) {
+        if (!peak_exec_checkpoint_append_char(buffer,
+                                              buffer_size,
+                                              out,
+                                              '-')) {
+            return FALSE;
+        }
+        exponent = -exponent;
+    } else if (!peak_exec_checkpoint_append_char(buffer,
+                                                  buffer_size,
+                                                  out,
+                                                  '+')) {
+        return FALSE;
+    }
+    return peak_exec_checkpoint_append_padded_u64(buffer,
+                                                 buffer_size,
+                                                 out,
+                                                 (unsigned long long)exponent,
+                                                 2);
+}
+
+static gboolean
+peak_exec_checkpoint_write_row(int fd,
+                               const char* name,
+                               gulong num_calls,
+                               gulong threads_seen,
+                               gdouble total_time,
+                               gdouble max_total_time,
+                               gdouble min_total_time,
+                               gdouble exclusive_time,
+                               gfloat max_time,
+                               gfloat min_time)
+{
+    char row[512];
+    size_t out = 0;
+    gulong safe_thread_count = threads_seen != 0 ? threads_seen : 1;
+    gulong per_thread =
+        num_calls / safe_thread_count +
+        ((num_calls % safe_thread_count != 0) ? 1 : 0);
+
+    if (exclusive_time < 0.0) {
+        exclusive_time = 0.0;
+    }
+    if (total_time >= 0.0 && exclusive_time > total_time) {
+        exclusive_time = total_time;
+    }
+
+    if (!peak_exec_checkpoint_write_csv_name(fd, name)) {
+        return FALSE;
+    }
+
+    if (!peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_u64(row,
+                                         sizeof(row),
+                                         &out,
+                                         (unsigned long long)num_calls) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_u64(row,
+                                         sizeof(row),
+                                         &out,
+                                         (unsigned long long)per_thread) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_u64(row,
+                                         sizeof(row),
+                                         &out,
+                                         (unsigned long long)num_calls) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)max_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)min_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)total_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)exclusive_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)max_total_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(row,
+                                            sizeof(row),
+                                            &out,
+                                            (double)min_total_time) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, ',') ||
+        !peak_exec_checkpoint_append_double(
+            row,
+            sizeof(row),
+            &out,
+            (double)num_calls * peak_general_overhead) ||
+        !peak_exec_checkpoint_append_char(row, sizeof(row), &out, '\n')) {
+        return FALSE;
+    }
+    return peak_exec_checkpoint_write_all(fd, row, out);
+}
+
+gboolean
+peak_general_listener_checkpoint_for_exec(unsigned long long checkpoint_index)
+{
+    char path[PATH_MAX];
+    int fd = -1;
+    size_t hook_count;
+    size_t thread_count;
+    size_t name_bytes = 0;
+    size_t thread_bytes;
+    size_t thread_storage_bytes;
+    PeakExecCheckpointRecord* records = NULL;
+    size_t* name_lengths = NULL;
+    char* names = NULL;
+    void* thread_storage = NULL;
+    PeakExecCheckpointThreadSnapshot threads = {0};
+    static const char header[] =
+        "function,"
+        "count,per_thread,per_rank,call_max_s,call_min_s,"
+        "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s\n";
+
+    if (!peak_general_listener_checkpoint_snapshot_lock()) {
+        return FALSE;
+    }
+    hook_count = peak_hook_address_count;
+    thread_count = peak_max_num_threads;
+    pthread_mutex_unlock(&lock);
+
+    if (hook_count > SIZE_MAX / sizeof(*records) ||
+        hook_count > SIZE_MAX / sizeof(*name_lengths) ||
+        thread_count > SIZE_MAX / sizeof(gdouble)) {
+        errno = EOVERFLOW;
+        return FALSE;
+    }
+    records = calloc(hook_count != 0 ? hook_count : 1, sizeof(*records));
+    name_lengths = calloc(hook_count != 0 ? hook_count : 1,
+                          sizeof(*name_lengths));
+    if (records == NULL || name_lengths == NULL) {
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           NULL,
+                                           NULL);
+        return FALSE;
+    }
+
+    if (!peak_general_listener_checkpoint_snapshot_lock()) {
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           NULL,
+                                           NULL);
+        return FALSE;
+    }
+    for (size_t i = 0; i < hook_count; i++) {
+        const char* name =
+            (peak_demangled_strings != NULL &&
+             peak_demangled_strings[i] != NULL) ?
+                peak_demangled_strings[i] :
+            (peak_hook_strings != NULL && peak_hook_strings[i] != NULL) ?
+                peak_hook_strings[i] :
+                "";
+        size_t length = strlen(name) + 1;
+
+        if (length > SIZE_MAX - name_bytes) {
+            pthread_mutex_unlock(&lock);
+            peak_exec_checkpoint_free_snapshot(records,
+                                               name_lengths,
+                                               NULL,
+                                               NULL);
+            errno = EOVERFLOW;
+            return FALSE;
+        }
+        name_lengths[i] = length;
+        name_bytes += length;
+    }
+    pthread_mutex_unlock(&lock);
+
+    if (thread_count != 0 &&
+        thread_count > SIZE_MAX /
+            (sizeof(gulong) + 2 * sizeof(gdouble) + 2 * sizeof(gfloat))) {
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           NULL,
+                                           NULL);
+        errno = EOVERFLOW;
+        return FALSE;
+    }
+    thread_bytes = thread_count * sizeof(gdouble);
+    thread_storage_bytes = thread_count *
+        (sizeof(gulong) + 2 * sizeof(gdouble) + 2 * sizeof(gfloat));
+    names = malloc(name_bytes != 0 ? name_bytes : 1);
+    thread_storage = malloc(thread_storage_bytes != 0 ?
+                                thread_storage_bytes : 1);
+    if (names == NULL || thread_storage == NULL) {
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        return FALSE;
+    }
+    threads.num_calls = thread_storage;
+    threads.total_time = (gdouble*)((char*)thread_storage +
+                                    thread_count * sizeof(gulong));
+    threads.exclusive_time = (gdouble*)((char*)threads.total_time +
+                                        thread_bytes);
+    threads.max_time = (gfloat*)((char*)threads.exclusive_time +
+                                 thread_bytes);
+    threads.min_time = threads.max_time + thread_count;
+
+    if (!peak_general_listener_checkpoint_snapshot_lock()) {
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        return FALSE;
+    }
+    size_t name_offset = 0;
+    for (size_t i = 0; i < hook_count; i++) {
+        const char* name;
+        size_t current_length;
+
+        if (i >= peak_hook_address_count || hook_address == NULL ||
+            array_listener == NULL || hook_address[i] == NULL ||
+            array_listener[i] == NULL) {
+            continue;
+        }
+        name =
+            (peak_demangled_strings != NULL &&
+             peak_demangled_strings[i] != NULL) ?
+                peak_demangled_strings[i] :
+            (peak_hook_strings != NULL && peak_hook_strings[i] != NULL) ?
+                peak_hook_strings[i] :
+                "";
+        current_length = strlen(name) + 1;
+        if (current_length > name_lengths[i] ||
+            !peak_exec_checkpoint_copy_listener(
+                PEAKGENERAL_LISTENER(array_listener[i]),
+                &threads,
+                thread_count)) {
+            pthread_mutex_unlock(&lock);
+            peak_exec_checkpoint_free_snapshot(records,
+                                               name_lengths,
+                                               names,
+                                               thread_storage);
+            return FALSE;
+        }
+        records[i].name = names + name_offset;
+        memcpy(records[i].name, name, current_length);
+        name_offset += name_lengths[i];
+
+        for (size_t j = 0; j < thread_count; j++) {
+            gulong calls = threads.num_calls[j];
+
+            records[i].num_calls += calls;
+            records[i].total_time += threads.total_time[j];
+            records[i].exclusive_time += threads.exclusive_time[j];
+            if (calls != 0) {
+                records[i].threads_seen++;
+                if (threads.total_time[j] > records[i].max_total_time) {
+                    records[i].max_total_time = threads.total_time[j];
+                }
+                if (threads.total_time[j] < records[i].min_total_time ||
+                    records[i].threads_seen == 1) {
+                    records[i].min_total_time = threads.total_time[j];
+                }
+                if (threads.max_time[j] > records[i].max_time) {
+                    records[i].max_time = threads.max_time[j];
+                }
+                if (threads.min_time[j] < records[i].min_time ||
+                    records[i].threads_seen == 1) {
+                    records[i].min_time = threads.min_time[j];
+                }
+            }
+        }
+    }
+    pthread_mutex_unlock(&lock);
+
+    for (unsigned int attempt = 0; attempt < 1024; attempt++) {
+        if (peak_stats_exec_checkpoint_path(path,
+                                            sizeof(path),
+                                            checkpoint_index + attempt) != 0) {
+            peak_exec_checkpoint_free_snapshot(records,
+                                               name_lengths,
+                                               names,
+                                               thread_storage);
+            return FALSE;
+        }
+        fd = peak_exec_checkpoint_open_exclusive(path);
+        if (fd >= 0) {
+            break;
+        }
+        if (errno != EEXIST) {
+            peak_exec_checkpoint_free_snapshot(records,
+                                               name_lengths,
+                                               names,
+                                               thread_storage);
+            return FALSE;
+        }
+    }
+    if (fd < 0) {
+        errno = EEXIST;
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        return FALSE;
+    }
+
+    if (!peak_exec_checkpoint_write_all(fd, header, sizeof(header) - 1)) {
+        peak_exec_checkpoint_close_fd(fd);
+        peak_exec_checkpoint_unlink_path(path);
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        return FALSE;
+    }
+
+    for (size_t i = 0; i < hook_count; i++) {
+        if (records[i].num_calls == 0 || records[i].name == NULL) {
+            continue;
+        }
+        if (!peak_exec_checkpoint_write_row(fd,
+                                            records[i].name,
+                                            records[i].num_calls,
+                                            records[i].threads_seen,
+                                            records[i].total_time,
+                                            records[i].max_total_time,
+                                            records[i].min_total_time,
+                                            records[i].exclusive_time,
+                                            records[i].max_time,
+                                            records[i].min_time)) {
+            peak_exec_checkpoint_close_fd(fd);
+            peak_exec_checkpoint_unlink_path(path);
+            peak_exec_checkpoint_free_snapshot(records,
+                                               name_lengths,
+                                               names,
+                                               thread_storage);
+            return FALSE;
+        }
+    }
+
+    if (!peak_exec_checkpoint_close_fd(fd)) {
+        peak_exec_checkpoint_unlink_path(path);
+        peak_exec_checkpoint_free_snapshot(records,
+                                           name_lengths,
+                                           names,
+                                           thread_storage);
+        return FALSE;
+    }
+    peak_exec_checkpoint_free_snapshot(records,
+                                       name_lengths,
+                                       names,
+                                       thread_storage);
+    return TRUE;
 }
 
 static FILE* peak_stats_csv_open(void) {

--- a/src/general_listener/output.inc
+++ b/src/general_listener/output.inc
@@ -341,6 +341,20 @@ peak_exec_checkpoint_write_csv_name(int fd, const char* name)
     return peak_exec_checkpoint_write_all(fd, "\"", 1);
 }
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+PEAK_API int
+peak_general_listener_test_checkpoint_snapshot_lock_hold(void)
+{
+    return pthread_mutex_lock(&lock);
+}
+
+PEAK_API int
+peak_general_listener_test_checkpoint_snapshot_lock_release(void)
+{
+    return pthread_mutex_unlock(&lock);
+}
+#endif
+
 static gboolean
 peak_general_listener_checkpoint_snapshot_lock(void)
 {

--- a/src/peak.c
+++ b/src/peak.c
@@ -17,6 +17,7 @@
 #include "general_listener.h"
 #include "detach_controller.h"
 #include "exec_interceptor.h"
+#include "internal/exec_interceptor_internal.h"
 #include "internal/general_listener_internal.h"
 #include "internal/jit_provider.h"
 #include "logging.h"
@@ -912,7 +913,8 @@ peak_checkpoint_for_exec(const char* path, char* const argv[])
     (void)path;
     (void)argv;
 
-    if (!peak_runtime_is_active_for_checkpoint()) {
+    if (!peak_exec_checkpoint_enabled_at_startup() ||
+        !peak_runtime_is_active_for_checkpoint()) {
         errno = saved_errno;
         return -1;
     }

--- a/src/peak.c
+++ b/src/peak.c
@@ -16,6 +16,8 @@
 
 #include "general_listener.h"
 #include "detach_controller.h"
+#include "exec_interceptor.h"
+#include "internal/general_listener_internal.h"
 #include "internal/jit_provider.h"
 #include "logging.h"
 #include "pthread_listener.h"
@@ -110,6 +112,11 @@ static int found_MPI;
 static _Atomic int peak_exit_status_known = 0;
 static _Atomic int peak_exit_status_value = 0;
 static _Atomic int peak_runtime_active = 0;
+static _Atomic unsigned long long peak_exec_checkpoint_counter = 0;
+static _Atomic unsigned int peak_exec_checkpoint_gate = 0;
+#define PEAK_EXEC_CHECKPOINT_GATE_CLOSING (1U << 31)
+#define PEAK_EXEC_CHECKPOINT_GATE_READERS \
+    (PEAK_EXEC_CHECKPOINT_GATE_CLOSING - 1U)
 typedef enum {
     PEAK_FINI_NOT_STARTED = 0,
     PEAK_FINI_IN_PROGRESS = 1,
@@ -117,6 +124,109 @@ typedef enum {
 } PeakFiniState;
 
 static _Atomic int peak_fini_state = PEAK_FINI_NOT_STARTED;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic int peak_test_checkpoint_reader_pause = 0;
+static _Atomic int peak_test_checkpoint_reader_held = 0;
+static _Atomic int peak_test_checkpoint_reader_released = 0;
+static _Atomic int peak_test_fini_waiting_for_reader = 0;
+
+void peak_fini(void);
+
+PEAK_EXEC_API void
+peak_test_fini(void)
+{
+    peak_fini();
+}
+
+PEAK_EXEC_API void
+peak_test_checkpoint_reader_pause_enable(void)
+{
+    atomic_store_explicit(&peak_test_checkpoint_reader_released,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_checkpoint_reader_held,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_fini_waiting_for_reader,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_checkpoint_reader_pause,
+                          1,
+                          memory_order_release);
+}
+
+PEAK_EXEC_API int
+peak_test_checkpoint_reader_is_held(void)
+{
+    return atomic_load_explicit(&peak_test_checkpoint_reader_held,
+                                memory_order_acquire);
+}
+
+PEAK_EXEC_API void
+peak_test_checkpoint_reader_release(void)
+{
+    atomic_store_explicit(&peak_test_checkpoint_reader_released,
+                          1,
+                          memory_order_release);
+}
+
+PEAK_EXEC_API int
+peak_test_fini_waiting_for_checkpoint_reader(void)
+{
+    return atomic_load_explicit(&peak_test_fini_waiting_for_reader,
+                                memory_order_acquire);
+}
+
+static void
+peak_test_checkpoint_reader_pause_after_acquire(void)
+{
+    if (atomic_load_explicit(&peak_test_checkpoint_reader_pause,
+                             memory_order_acquire) == 0) {
+        return;
+    }
+
+    atomic_store_explicit(&peak_test_checkpoint_reader_held,
+                          1,
+                          memory_order_release);
+    while (atomic_load_explicit(&peak_test_checkpoint_reader_released,
+                                memory_order_acquire) == 0) {
+        sched_yield();
+    }
+}
+#endif
+
+static int
+peak_exec_checkpoint_reader_acquire(void)
+{
+    unsigned int observed =
+        atomic_load_explicit(&peak_exec_checkpoint_gate,
+                             memory_order_acquire);
+
+    for (;;) {
+        if ((observed & PEAK_EXEC_CHECKPOINT_GATE_CLOSING) != 0 ||
+            (observed & PEAK_EXEC_CHECKPOINT_GATE_READERS) ==
+                PEAK_EXEC_CHECKPOINT_GATE_READERS) {
+            return 0;
+        }
+        if (atomic_compare_exchange_weak_explicit(
+                &peak_exec_checkpoint_gate,
+                &observed,
+                observed + 1U,
+                memory_order_acq_rel,
+                memory_order_acquire)) {
+            return 1;
+        }
+    }
+}
+
+static void
+peak_exec_checkpoint_reader_release(void)
+{
+    atomic_fetch_sub_explicit(&peak_exec_checkpoint_gate,
+                              1U,
+                              memory_order_release);
+}
 
 static gboolean
 peak_env_value_truthy(const char* value)
@@ -742,6 +852,19 @@ void peak_fini()
             PEAK_FINI_IN_PROGRESS,
             memory_order_acq_rel,
             memory_order_acquire)) {
+        atomic_fetch_or_explicit(&peak_exec_checkpoint_gate,
+                                 PEAK_EXEC_CHECKPOINT_GATE_CLOSING,
+                                 memory_order_acq_rel);
+        while ((atomic_load_explicit(&peak_exec_checkpoint_gate,
+                                     memory_order_acquire) &
+                PEAK_EXEC_CHECKPOINT_GATE_READERS) != 0) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+            atomic_store_explicit(&peak_test_fini_waiting_for_reader,
+                                  1,
+                                  memory_order_release);
+#endif
+            sched_yield();
+        }
         peak_fini_impl();
         atomic_store_explicit(&peak_fini_state,
                               PEAK_FINI_DONE,
@@ -753,6 +876,53 @@ void peak_fini()
            PEAK_FINI_IN_PROGRESS) {
         sched_yield();
     }
+}
+
+PEAK_EXEC_API int
+peak_runtime_is_active_for_checkpoint(void)
+{
+    return atomic_load_explicit(&peak_runtime_active,
+                                memory_order_acquire) != 0 &&
+           atomic_load_explicit(&peak_fini_state,
+                                memory_order_acquire) == PEAK_FINI_NOT_STARTED;
+}
+
+PEAK_EXEC_API int
+peak_checkpoint_for_exec(const char* path, char* const argv[])
+{
+    int saved_errno = errno;
+    unsigned long long checkpoint_index;
+    gboolean wrote;
+
+    (void)path;
+    (void)argv;
+
+    if (!peak_runtime_is_active_for_checkpoint()) {
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (!peak_exec_checkpoint_reader_acquire()) {
+        errno = saved_errno;
+        return -1;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_test_checkpoint_reader_pause_after_acquire();
+#endif
+    if (!peak_runtime_is_active_for_checkpoint()) {
+        peak_exec_checkpoint_reader_release();
+        errno = saved_errno;
+        return -1;
+    }
+
+    checkpoint_index =
+        atomic_fetch_add_explicit(&peak_exec_checkpoint_counter,
+                                  1,
+                                  memory_order_acq_rel) + 1;
+    wrote = peak_general_listener_checkpoint_for_exec(checkpoint_index);
+    peak_exec_checkpoint_reader_release();
+    errno = saved_errno;
+    return wrote ? 0 : -1;
 }
 
 #if defined(__APPLE__)

--- a/src/peak.c
+++ b/src/peak.c
@@ -112,6 +112,7 @@ static int found_MPI;
 static _Atomic int peak_exit_status_known = 0;
 static _Atomic int peak_exit_status_value = 0;
 static _Atomic int peak_runtime_active = 0;
+static _Atomic pid_t peak_runtime_owner_pid = 0;
 static _Atomic unsigned long long peak_exec_checkpoint_counter = 0;
 static _Atomic unsigned int peak_exec_checkpoint_gate = 0;
 #define PEAK_EXEC_CHECKPOINT_GATE_CLOSING (1U << 31)
@@ -124,6 +125,15 @@ typedef enum {
 } PeakFiniState;
 
 static _Atomic int peak_fini_state = PEAK_FINI_NOT_STARTED;
+
+static int
+peak_runtime_is_fork_child(void)
+{
+    pid_t owner = atomic_load_explicit(&peak_runtime_owner_pid,
+                                       memory_order_acquire);
+
+    return owner > 0 && getpid() != owner;
+}
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic int peak_test_checkpoint_reader_pause = 0;
@@ -439,6 +449,9 @@ void peak_init()
     if (!has_requested_work) {
         return;
     }
+    atomic_store_explicit(&peak_runtime_owner_pid,
+                          getpid(),
+                          memory_order_release);
     atomic_store_explicit(&peak_runtime_active, 1, memory_order_release);
 
     //gum_init_embedded();
@@ -842,7 +855,8 @@ void peak_fini()
 {
     int expected = PEAK_FINI_NOT_STARTED;
 
-    if (atomic_load_explicit(&peak_runtime_active, memory_order_acquire) == 0) {
+    if (atomic_load_explicit(&peak_runtime_active, memory_order_acquire) == 0 ||
+        peak_runtime_is_fork_child()) {
         return;
     }
 
@@ -883,6 +897,7 @@ peak_runtime_is_active_for_checkpoint(void)
 {
     return atomic_load_explicit(&peak_runtime_active,
                                 memory_order_acquire) != 0 &&
+           !peak_runtime_is_fork_child() &&
            atomic_load_explicit(&peak_fini_state,
                                 memory_order_acquire) == PEAK_FINI_NOT_STARTED;
 }
@@ -955,9 +970,14 @@ static void
 peak_exit(int status) {
     //g_printerr("Custom exit called with status: %d\n", status);
 
+    if (peak_runtime_is_fork_child()) {
+        original_exit(status);
+        __builtin_unreachable();
+    }
+
     if (atomic_load_explicit(&peak_runtime_active, memory_order_acquire) == 0) {
         original_exit(status);
-        return;
+        __builtin_unreachable();
     }
 
     int expected = 0;
@@ -979,10 +999,13 @@ peak_exit(int status) {
         }
     }
     peak_fini();
-    atexit(exit_interceptor_detach);
+    if (atexit(exit_interceptor_detach) != 0) {
+        peak_log_warn("[peak] failed to register deferred exit interceptor teardown\n");
+    }
 
     // Call the original `exit` function to terminate the process
     original_exit(status);
+    __builtin_unreachable();
 }
 
 /**

--- a/src/signal_policy.c
+++ b/src/signal_policy.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include "internal/exec_raw_syscall.h"
 #include "internal/signal_policy_internal.h"
 #include "utils/utils.h"
 
@@ -1913,24 +1914,42 @@ peak_signal_policy_forward_syscall(long number,
     return real_syscall_fn(number, a1, a2, a3, a4, a5, a6);
 }
 
+/*
+ * The exported syscall symbol is an architecture trampoline.  libc exposes
+ * it as variadic, so a C definition with six mandatory arguments is invalid
+ * for callers such as syscall(SYS_getpid).  The trampoline preserves the
+ * platform call frame/register layout and enters this fixed-width dispatcher.
+ */
 __attribute__((visibility("default"))) long
-peak_signal_policy_syscall(long number,
-                           long a1,
-                           long a2,
-                           long a3,
-                           long a4,
-                           long a5,
-                           long a6) __asm__("syscall");
+peak_signal_policy_syscall_dispatch(long number,
+                                    long a1,
+                                    long a2,
+                                    long a3,
+                                    long a4,
+                                    long a5,
+                                    long a6);
 
 __attribute__((visibility("default"))) long
-peak_signal_policy_syscall(long number,
-                           long a1,
-                           long a2,
-                           long a3,
-                           long a4,
-                           long a5,
-                           long a6)
+peak_signal_policy_syscall_dispatch(long number,
+                                    long a1,
+                                    long a2,
+                                    long a3,
+                                    long a4,
+                                    long a5,
+                                    long a6)
 {
+    long exec_result;
+
+    if (peak_exec_raw_syscall_handle(number,
+                                     a1,
+                                     a2,
+                                     a3,
+                                     a4,
+                                     a5,
+                                     a6,
+                                     &exec_result)) {
+        return exec_result;
+    }
     peak_signal_policy_ensure_real_symbols();
     if (real_syscall_fn == NULL) {
         errno = ENOSYS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -356,11 +356,12 @@ if(BUILD_TESTING)
                     --threads 8
                     --seconds 3
                     --spawn-transient-threads
-                    --spawner-threads 4)
+                    --spawner-threads 4
+                    --require-detach-during-churn)
         set_tests_properties(test_detach_hotloop_signal_thread_spawn_strict
             PROPERTIES
                 ENVIRONMENT "PEAK_TARGET=peak_detach_hot_target;PEAK_MAX_NUM_THREADS=256;PEAK_ENABLE_PER_TARGET_HEARTBEAT=1;PEAK_ENABLE_GLOBAL_HEARTBEAT=0;PEAK_ENABLE_REATTACH=0;PEAK_COST=0.000000000001;PEAK_DETACH_COUNT=1;PEAK_OVERHEAD_RATIO=0.000001;PEAK_HEARTBEAT_INTERVAL=0.001;PEAK_HIBERNATION_CYCLE=1;PEAK_REQUIRE_SAFE_DETACH=1;PEAK_SAFE_DETACH_MODE=signal;PEAK_DETACH_BACKEND=signal;PEAK_DETACH_HELPER=/no/such/peak_detach_helper;PEAK_DETACH_TRACE_PATH=${PROJECT_BINARY_DIR}/test/detach_runtime/signal-thread-spawn-trace.csv;${PRELOAD_VAR}"
-                PASS_REGULAR_EXPRESSION "spawned_threads=[1-9][0-9]*.*trace_detach_success=1"
+                PASS_REGULAR_EXPRESSION "pre_detach_spawn_started=[1-9][0-9]*.*detach_during_churn=1.*detach_observed_spawned_threads=[1-9][0-9]*.*post_detach_spawn=1.*spawned_threads=[1-9][0-9]*.*trace_detach_success=1"
                 FAIL_REGULAR_EXPRESSION "not proven safe|leaving listener state alive|fatal|tracked thread snapshot exceeded|thread id .* exceeds|detach helper shutdown failed|timed out draining pending target hook detach/reattach requests|Gum .* failed"
                 TIMEOUT 60)
 
@@ -600,7 +601,7 @@ if(BUILD_TESTING)
                         TIMEOUT 30)
             endforeach()
         endif()
-        add_test(NAME test_detach_hotloop_batch_reattach_strict
+        add_test(NAME test_detach_hotloop_batch_detach_strict
             COMMAND ${Python3_EXECUTABLE}
                     ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py
                     --exe ${PROJECT_BINARY_DIR}/test/detach_runtime/test_detach_hotloop
@@ -614,10 +615,9 @@ if(BUILD_TESTING)
                     --overhead-ratio 0.000001
                     --enable-global-heartbeat
                     --global-overhead-ratio 2.00
-                    --trace-prefix ${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-batch-reattach-trace
-                    --require-detach-batch-size 2
-                    --require-reattach-batch-size 2)
-        set_tests_properties(test_detach_hotloop_batch_reattach_strict
+                    --trace-prefix ${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-batch-detach-trace
+                    --require-detach-batch-size 2)
+        set_tests_properties(test_detach_hotloop_batch_detach_strict
             PROPERTIES
                 TIMEOUT 60
                 PASS_REGULAR_EXPRESSION "hotloop_trace_check_ok")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -127,6 +127,7 @@ if(BUILD_TESTING)
     set(PEAK_TARGET_CONFIG_PATH ${PROJECT_BINARY_DIR}/test/data/blas_symbols.conf)
 
     add_subdirectory(utils)
+    add_subdirectory(exec_chain)
     add_subdirectory(detach_controller)
     add_subdirectory(detach_runtime)
     add_subdirectory(dlopen_controller)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -512,6 +512,36 @@ if(BUILD_TESTING)
                     ENVIRONMENT "PEAK_TARGET=peak_detach_hot_target,peak_detach_hot_target_two;PEAK_MAX_NUM_THREADS=16;PEAK_ENABLE_PER_TARGET_HEARTBEAT=0;PEAK_ENABLE_GLOBAL_HEARTBEAT=0;PEAK_ENABLE_REATTACH=0;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;PEAK_HIBERNATION_CYCLE=1;PEAK_REQUIRE_SAFE_DETACH=1;PEAK_SAFE_DETACH_MODE=strict;PEAK_DETACH_BACKEND=helper;PEAK_DETACH_HELPER=$<TARGET_FILE:test_detach_fake_helper>;FAKE_DETACH_HELPER_SCENARIO=synthetic-stop-file-once;FAKE_DETACH_HELPER_STOP_PC_FILE=${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-batch-retry-pc.txt;PEAK_DETACH_TRACE_PATH=${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-batch-retry-trace.csv;${PRELOAD_VAR}"
                     PASS_REGULAR_EXPRESSION "controller_batch_retry_ok"
                     TIMEOUT 30)
+            # Request 0 may be consumed before request 1 is queued.  Validate
+            # each target's exact strict lifecycle without asserting same-batch
+            # timing, which is not a controller state-machine contract.
+            add_test(NAME test_detach_hotloop_two_target_lifecycle_strict
+                COMMAND ${Python3_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py
+                        --exe ${PROJECT_BINARY_DIR}/test/detach_runtime/test_detach_hotloop
+                        --libpeak ${PROJECT_BINARY_DIR}/src/libpeak.so
+                        --controller-two-target-lifecycle-check
+                        --trace-path ${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-two-target-lifecycle-trace.csv
+                        --detach-helper $<TARGET_FILE:test_detach_fake_helper>
+                        --timeout 15)
+            set_tests_properties(test_detach_hotloop_two_target_lifecycle_strict
+                PROPERTIES
+                    PASS_REGULAR_EXPRESSION "controller_two_target_lifecycle_trace_ok"
+                    TIMEOUT 30)
+            add_test(NAME test_detach_hotloop_two_target_lifecycle_unsafe_shutdown_rejected
+                COMMAND ${Python3_EXECUTABLE}
+                        ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py
+                        --exe ${PROJECT_BINARY_DIR}/test/detach_runtime/test_detach_hotloop
+                        --libpeak ${PROJECT_BINARY_DIR}/src/libpeak.so
+                        --controller-two-target-lifecycle-check
+                        --controller-helper-scenario shutdown-missing-response
+                        --trace-path ${PROJECT_BINARY_DIR}/test/detach_runtime/peak-hotloop-two-target-lifecycle-unsafe-shutdown-trace.csv
+                        --detach-helper $<TARGET_FILE:test_detach_fake_helper>
+                        --timeout 15)
+            set_tests_properties(test_detach_hotloop_two_target_lifecycle_unsafe_shutdown_rejected
+                PROPERTIES
+                    PASS_REGULAR_EXPRESSION "controller_two_target_lifecycle_unsafe_shutdown_rejected_ok"
+                    TIMEOUT 30)
             add_test(NAME test_detach_hotloop_no_trace_pending_age_strict
                 COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_detach_hotloop
                         --controller-no-trace-pending-age-check)
@@ -591,6 +621,20 @@ if(BUILD_TESTING)
             PROPERTIES
                 TIMEOUT 60
                 PASS_REGULAR_EXPRESSION "hotloop_trace_check_ok")
+        add_test(NAME test_detach_hotloop_lifecycle_parser
+            COMMAND ${Python3_EXECUTABLE}
+                    ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py
+                    --self-test-lifecycle-parser)
+        set_tests_properties(test_detach_hotloop_lifecycle_parser
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "detach_hotloop_lifecycle_parser_ok")
+        add_test(NAME test_detach_hotloop_controller_output_contract
+            COMMAND ${Python3_EXECUTABLE}
+                    ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py
+                    --self-test-controller-output-contract)
+        set_tests_properties(test_detach_hotloop_controller_output_contract
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "detach_hotloop_controller_output_contract_ok")
         add_test(NAME test_detach_hotloop_reattach_cooldown_strict
             COMMAND ${Python3_EXECUTABLE}
                     ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_hotloop_trace_check.py

--- a/test/detach_controller/CMakeLists.txt
+++ b/test/detach_controller/CMakeLists.txt
@@ -4,7 +4,6 @@ add_executable(test_detach_controller
   ${PROJECT_SOURCE_DIR}/src/logging.c
   ${PROJECT_SOURCE_DIR}/src/signal_policy.c
   ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall.c
-  ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S
   $<TARGET_OBJECTS:utils_c>
 )
 add_executable(test_detach_fake_helper test_detach_fake_helper.c)
@@ -20,10 +19,18 @@ if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)
     ${PROJECT_SOURCE_DIR}/src/detach_controller.c
     ${PROJECT_SOURCE_DIR}/src/signal_policy.c
     ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall.c
-    ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S
     $<TARGET_OBJECTS:utils_c>
     $<TARGET_OBJECTS:utils_cxx>
   )
+endif()
+
+if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+  target_sources(test_detach_controller PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S)
+  if(TARGET test_detach_listener_shutdown)
+    target_sources(test_detach_listener_shutdown PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S)
+  endif()
 endif()
 
 target_include_directories(test_detach_fake_helper

--- a/test/detach_controller/CMakeLists.txt
+++ b/test/detach_controller/CMakeLists.txt
@@ -3,6 +3,8 @@ add_executable(test_detach_controller
   ${PROJECT_SOURCE_DIR}/src/detach_controller.c
   ${PROJECT_SOURCE_DIR}/src/logging.c
   ${PROJECT_SOURCE_DIR}/src/signal_policy.c
+  ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall.c
+  ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S
   $<TARGET_OBJECTS:utils_c>
 )
 add_executable(test_detach_fake_helper test_detach_fake_helper.c)
@@ -17,6 +19,8 @@ if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)
     ${PROJECT_SOURCE_DIR}/src/pthread_listener.c
     ${PROJECT_SOURCE_DIR}/src/detach_controller.c
     ${PROJECT_SOURCE_DIR}/src/signal_policy.c
+    ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall.c
+    ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall_trampoline.S
     $<TARGET_OBJECTS:utils_c>
     $<TARGET_OBJECTS:utils_cxx>
   )
@@ -38,6 +42,8 @@ if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)
     PEAK_HAVE_GUM_PEAK_PC_API=1
     PEAK_ENABLE_TEST_HOOKS=1)
 endif()
+target_compile_definitions(test_detach_controller PRIVATE
+  PEAK_EXEC_RAW_SYSCALL_STANDALONE=1)
 if(TARGET test_detach_listener_shutdown)
   target_include_directories(test_detach_listener_shutdown
     PRIVATE
@@ -47,7 +53,8 @@ if(TARGET test_detach_listener_shutdown)
   target_compile_definitions(test_detach_listener_shutdown
     PRIVATE
       PEAK_HAVE_GUM_PEAK_PC_API=1
-      PEAK_ENABLE_TEST_HOOKS=1)
+      PEAK_ENABLE_TEST_HOOKS=1
+      PEAK_EXEC_RAW_SYSCALL_STANDALONE=1)
 endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_options(test_detach_shutdown_preload PRIVATE -Wl,--export-dynamic)

--- a/test/detach_controller/test_detach_fake_helper.c
+++ b/test/detach_controller/test_detach_fake_helper.c
@@ -76,8 +76,13 @@ static int
 environment_is_sanitized(void)
 {
     extern char** environ;
+    int saw_exec_chain_disabled = 0;
 
     for (size_t i = 0; environ != NULL && environ[i] != NULL; i++) {
+        if (strcmp(environ[i], "PEAK_EXEC_CHAIN=0") == 0) {
+            saw_exec_chain_disabled = 1;
+            continue;
+        }
         if (strncmp(environ[i], "PEAK_", 5) == 0 ||
             strncmp(environ[i], "LD_PRELOAD=", 11) == 0 ||
             strncmp(environ[i], "LD_AUDIT=", 9) == 0) {
@@ -85,7 +90,7 @@ environment_is_sanitized(void)
         }
     }
 
-    return 1;
+    return saw_exec_chain_disabled;
 }
 
 static void

--- a/test/detach_runtime/run_detach_hotloop_trace_check.py
+++ b/test/detach_runtime/run_detach_hotloop_trace_check.py
@@ -28,6 +28,9 @@ TRANSITION_SKIP_RE = re.compile(
     r"skipping Gum (detach|reattach)|classify-failed",
     re.IGNORECASE,
 )
+EXPECTED_UNSAFE_SHUTDOWN_RE = re.compile(
+    r"(?m)^\[peak\] detach helper shutdown failed: error; "
+    r"leaving listener state alive$")
 TARGET_SYMBOL = "peak_detach_hot_target"
 PAIRED_TARGET_SYMBOL = "peak_detach_hot_target_two"
 COLD_TARGET_SYMBOL = "peak_detach_cold_target"
@@ -168,6 +171,280 @@ def trace_has_success(args, sample, operation):
                  trace_row_has_diagnostics(fields))):
             return True
     return False
+
+
+def paired_target_lifecycle_rows_ok(rows, require_trace_diagnostics):
+    required_symbols = (TARGET_SYMBOL, PAIRED_TARGET_SYMBOL)
+    lifecycle_events = {symbol: [] for symbol in required_symbols}
+    for fields in rows:
+        if (len(fields) < 7 or fields[2] not in lifecycle_events or
+                fields[3] not in {"detach", "reattach"} or
+                fields[4] != "success"):
+            continue
+        symbol = fields[2]
+        if fields[5] != "1" or fields[6] != "safe":
+            return False, (
+                f"non-strict successful lifecycle transition for {symbol}: "
+                f"{fields[3]} physical={fields[5]} status={fields[6]}"
+            )
+        if (require_trace_diagnostics and
+                not trace_row_has_diagnostics(fields)):
+            return False, f"missing lifecycle diagnostics for {symbol}: {fields}"
+
+        events = lifecycle_events[symbol]
+        expected = "detach" if len(events) % 2 == 0 else "reattach"
+        if fields[3] != expected:
+            return False, (
+                f"invalid lifecycle transition for {symbol}: expected {expected} "
+                f"after {events}, observed {fields[3]}"
+            )
+        events.append(fields[3])
+
+    missing = [symbol for symbol, events in lifecycle_events.items()
+               if len(events) < 3]
+    if missing:
+        return False, (
+            "missing paired target detach/reattach/revisit evidence: "
+            f"{sorted(missing)}"
+        )
+    return True, ""
+
+
+def controller_two_target_lifecycle_rows_ok(rows, require_trace_diagnostics):
+    # The controller may consume request 0 before request 1 is queued.  Batch
+    # identity and size are diagnostics, not a two-target lifecycle contract.
+    expected_events = ("detach", "reattach", "detach")
+    required_symbols = (TARGET_SYMBOL, PAIRED_TARGET_SYMBOL)
+    lifecycle_events = {symbol: [] for symbol in required_symbols}
+    for fields in rows:
+        if (len(fields) < 4 or fields[2] not in lifecycle_events or
+                fields[3] not in {"detach", "reattach"}):
+            continue
+        symbol = fields[2]
+        if (len(fields) < 7 or fields[4] != "success" or fields[5] != "1" or
+                fields[6] != "safe"):
+            return False, f"non-strict lifecycle row for {symbol}: {fields}"
+        if (require_trace_diagnostics and
+                not trace_row_has_diagnostics(fields)):
+            return False, f"missing lifecycle diagnostics for {symbol}: {fields}"
+        lifecycle_events[symbol].append(fields[3])
+
+    for symbol, events in lifecycle_events.items():
+        if tuple(events) != expected_events:
+            return False, (
+                f"invalid controller lifecycle for {symbol}: expected "
+                f"{expected_events}, observed {tuple(events)}"
+            )
+    return True, ""
+
+
+def controller_two_target_lifecycle_output_ok(output):
+    bad_output = BAD_OUTPUT_RE.search(output)
+    if bad_output is not None:
+        return False, f"matched unsafe output: {bad_output.group(0)}"
+    transition_skip = TRANSITION_SKIP_RE.search(output)
+    if transition_skip is not None:
+        return False, f"matched transition skip: {transition_skip.group(0)}"
+    return True, ""
+
+
+def controller_two_target_lifecycle_unsafe_shutdown_output_ok(output):
+    matches = EXPECTED_UNSAFE_SHUTDOWN_RE.findall(output)
+    if len(matches) != 1:
+        return False, "missing or repeated expected shutdown-missing-response diagnostic"
+    return controller_two_target_lifecycle_output_ok(
+        EXPECTED_UNSAFE_SHUTDOWN_RE.sub("", output))
+
+
+def trace_has_paired_target_lifecycle(args, sample):
+    rows = read_trace_rows(args, sample)
+    if rows is None:
+        print("missing paired target lifecycle trace", file=sys.stderr)
+        return False
+
+    ok, reason = paired_target_lifecycle_rows_ok(
+        rows, args.require_trace_diagnostics)
+    if not ok:
+        print(reason, file=sys.stderr)
+    return ok
+
+
+def run_lifecycle_parser_self_test():
+    def row(symbol, operation, batch_id=1, batch_size=2):
+        return ["0", "0", symbol, operation, "success", "1", "safe",
+                "0", "0", str(batch_size), "1", str(batch_id)]
+
+    valid_rows = []
+    for operation in ("detach", "reattach", "detach", "reattach"):
+        valid_rows.extend([
+            row(TARGET_SYMBOL, operation),
+            row(PAIRED_TARGET_SYMBOL, operation),
+        ])
+    cases = (
+        ("valid", valid_rows, True),
+        ("premature-reattach", [
+            row(TARGET_SYMBOL, "reattach"),
+            row(PAIRED_TARGET_SYMBOL, "detach"),
+            row(PAIRED_TARGET_SYMBOL, "reattach"),
+            row(PAIRED_TARGET_SYMBOL, "detach"),
+        ], False),
+        ("duplicate-detach", [
+            row(TARGET_SYMBOL, "detach"),
+            row(TARGET_SYMBOL, "detach"),
+            row(PAIRED_TARGET_SYMBOL, "detach"),
+            row(PAIRED_TARGET_SYMBOL, "reattach"),
+            row(PAIRED_TARGET_SYMBOL, "detach"),
+        ], False),
+    )
+    for name, rows, expected in cases:
+        ok, reason = paired_target_lifecycle_rows_ok(rows, False)
+        if ok != expected:
+            print(f"lifecycle parser self-test failed: {name}: {reason}",
+                  file=sys.stderr)
+            return 1
+    controller_cases = (
+        ("controller-two-target-valid", [
+            row(TARGET_SYMBOL, "detach", 10, 1),
+            row(PAIRED_TARGET_SYMBOL, "detach", 20, 1),
+            row(TARGET_SYMBOL, "reattach", 11, 1),
+            row(PAIRED_TARGET_SYMBOL, "reattach", 21, 1),
+            row(TARGET_SYMBOL, "detach", 12, 1),
+            row(PAIRED_TARGET_SYMBOL, "detach", 22, 1),
+        ], True),
+        ("controller-two-target-extra", [
+            row(TARGET_SYMBOL, "detach", 10),
+            row(PAIRED_TARGET_SYMBOL, "detach", 20),
+            row(TARGET_SYMBOL, "reattach", 21),
+            row(PAIRED_TARGET_SYMBOL, "reattach", 21),
+            row(TARGET_SYMBOL, "detach", 22),
+            row(PAIRED_TARGET_SYMBOL, "detach", 22),
+            row(TARGET_SYMBOL, "reattach", 23),
+        ], False),
+        ("controller-two-target-missing", [
+            row(TARGET_SYMBOL, "detach", 10),
+            row(PAIRED_TARGET_SYMBOL, "detach", 20),
+            row(TARGET_SYMBOL, "reattach", 11),
+            row(PAIRED_TARGET_SYMBOL, "reattach", 21),
+            row(TARGET_SYMBOL, "detach", 12),
+        ], False),
+        ("controller-two-target-truncated-transition", [
+            row(TARGET_SYMBOL, "detach", 10, 1),
+            row(PAIRED_TARGET_SYMBOL, "detach", 20, 1),
+            row(TARGET_SYMBOL, "reattach", 11, 1),
+            row(PAIRED_TARGET_SYMBOL, "reattach", 21, 1),
+            row(TARGET_SYMBOL, "detach", 12, 1),
+            row(PAIRED_TARGET_SYMBOL, "detach", 22, 1),
+            row(PAIRED_TARGET_SYMBOL, "reattach", 23, 1)[:4],
+        ], False),
+    )
+    for name, rows, expected in controller_cases:
+        ok, reason = controller_two_target_lifecycle_rows_ok(rows, False)
+        if ok != expected:
+            print(f"lifecycle parser self-test failed: {name}: {reason}",
+                  file=sys.stderr)
+            return 1
+    print("detach_hotloop_lifecycle_parser_ok")
+    return 0
+
+
+def run_controller_output_contract_self_test():
+    cases = (
+        ("clean", "controller_two_target_lifecycle_ok\n", True),
+        ("unsafe-shutdown",
+         "controller_two_target_lifecycle_ok\n"
+         "detach helper shutdown failed: missing-response; "
+         "leaving listener state alive\n",
+         False),
+        ("transition-skip",
+         "controller_two_target_lifecycle_ok\n"
+         "skipping Gum detach after classify-failed\n",
+         False),
+    )
+    for name, output, expected in cases:
+        ok, reason = controller_two_target_lifecycle_output_ok(output)
+        if ok != expected:
+            print(f"controller output self-test failed: {name}: {reason}",
+                  file=sys.stderr)
+            return 1
+    print("detach_hotloop_controller_output_contract_ok")
+    return 0
+
+
+def controller_two_target_lifecycle_env(args, trace_path):
+    env = os.environ.copy()
+    env.update({
+        "LD_PRELOAD": os.path.realpath(args.libpeak),
+        "PEAK_DETACH_TRACE_PATH": trace_path,
+        "PEAK_TARGET": f"{TARGET_SYMBOL},{PAIRED_TARGET_SYMBOL}",
+        "PEAK_MAX_NUM_THREADS": "16",
+        "PEAK_ENABLE_PER_TARGET_HEARTBEAT": "0",
+        "PEAK_ENABLE_GLOBAL_HEARTBEAT": "0",
+        "PEAK_ENABLE_REATTACH": "0",
+        "PEAK_COST": "0",
+        "PEAK_HEARTBEAT_INTERVAL": "0",
+        "PEAK_HIBERNATION_CYCLE": "1",
+        "PEAK_REQUIRE_SAFE_DETACH": "1",
+        "PEAK_SAFE_DETACH_MODE": "strict",
+        "PEAK_DETACH_BACKEND": "helper",
+        "PEAK_DETACH_HELPER": os.path.realpath(args.detach_helper),
+        "FAKE_DETACH_HELPER_SCENARIO": args.controller_helper_scenario,
+    })
+    return env
+
+
+def run_controller_two_target_lifecycle_check(args):
+    trace_path = f"{args.trace_path}.{os.getpid()}"
+    try:
+        os.unlink(trace_path)
+    except FileNotFoundError:
+        pass
+
+    completed = subprocess.run(
+        [args.exe, "--controller-two-target-lifecycle-check"],
+        env=controller_two_target_lifecycle_env(args, trace_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        timeout=args.timeout,
+        check=False,
+    )
+    try:
+        with open(trace_path, "r", encoding="utf-8") as handle:
+            rows = list(csv.reader(handle))
+    except OSError:
+        rows = None
+    try:
+        os.unlink(trace_path)
+    except FileNotFoundError:
+        pass
+
+    ok = rows is not None
+    reason = "missing two-target lifecycle trace"
+    if ok:
+        ok, reason = controller_two_target_lifecycle_rows_ok(rows, True)
+    if args.controller_helper_scenario == "shutdown-missing-response":
+        output_ok, output_reason = (
+            controller_two_target_lifecycle_unsafe_shutdown_output_ok(
+                completed.stdout))
+        success_marker = "controller_two_target_lifecycle_unsafe_shutdown_rejected_ok"
+    else:
+        output_ok, output_reason = controller_two_target_lifecycle_output_ok(
+            completed.stdout)
+        success_marker = "controller_two_target_lifecycle_trace_ok"
+    if (completed.returncode != 0 or
+            "controller_two_target_lifecycle_ok" not in completed.stdout or
+            not ok or not output_ok):
+        print(f"controller two-target lifecycle check failed rc={completed.returncode}",
+              file=sys.stderr)
+        if not ok:
+            print(reason, file=sys.stderr)
+        if not output_ok:
+            print(output_reason, file=sys.stderr)
+        print(completed.stdout, file=sys.stderr)
+        return 1
+
+    print(success_marker)
+    return 0
 
 
 def read_trace_rows(args, sample):
@@ -456,6 +733,10 @@ def run_sample(args, sample):
         args, sample, "detach", args.require_detach_batch_size)
     trace_reattach_batched = trace_has_required_batch(
         args, sample, "reattach", args.require_reattach_batch_size)
+    paired_target_lifecycle_ok = (
+        not args.require_paired_target_lifecycle or
+        trace_has_paired_target_lifecycle(args, sample)
+    )
     trace_source_ok = trace_has_required_request_source(args, sample)
     trace_transition_ok = trace_transition_limits_ok(args, sample)
     observed_guard_ok = (
@@ -488,6 +769,7 @@ def run_sample(args, sample):
         not trace_detached or
         not trace_detach_batched or
         not trace_reattach_batched or
+        not paired_target_lifecycle_ok or
         not trace_source_ok or
         not trace_transition_ok or
         not observed_guard_ok or
@@ -521,6 +803,9 @@ def run_sample(args, sample):
             print("missing required batched detach trace evidence", file=sys.stderr)
         if not trace_reattach_batched:
             print("missing required batched reattach trace evidence", file=sys.stderr)
+        if not paired_target_lifecycle_ok:
+            print("missing required paired target lifecycle evidence",
+                  file=sys.stderr)
         if not trace_source_ok:
             print("missing required detach request source evidence", file=sys.stderr)
         if not trace_transition_ok:
@@ -558,9 +843,18 @@ def run_sample(args, sample):
 
 
 def main():
+    if sys.argv[1:] == ["--self-test-lifecycle-parser"]:
+        return run_lifecycle_parser_self_test()
+    if sys.argv[1:] == ["--self-test-controller-output-contract"]:
+        return run_controller_output_contract_self_test()
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--exe", required=True)
     parser.add_argument("--libpeak", required=True)
+    parser.add_argument("--controller-two-target-lifecycle-check",
+                        action="store_true")
+    parser.add_argument("--controller-helper-scenario", default="success-zero")
+    parser.add_argument("--trace-path", default="")
     parser.add_argument("--threads", type=int, default=32)
     parser.add_argument("--seconds", type=int, default=1)
     parser.add_argument("--samples", type=int, default=12)
@@ -587,6 +881,8 @@ def main():
     parser.add_argument("--global-detach-factor", default="1.0")
     parser.add_argument("--global-reattach-factor", default="1.0")
     parser.add_argument("--paired-targets", action="store_true")
+    parser.add_argument("--require-paired-target-lifecycle",
+                        action="store_true")
     parser.add_argument("--cold-one-shot-target", action="store_true")
     parser.add_argument("--spawn-transient-threads", action="store_true")
     parser.add_argument("--spawner-threads", type=int, default=2)
@@ -611,6 +907,14 @@ def main():
     parser.set_defaults(enable_reattach=True, enable_per_target_heartbeat=True)
     args = parser.parse_args()
 
+    if args.controller_two_target_lifecycle_check:
+        if not args.trace_path or not args.detach_helper:
+            print("--controller-two-target-lifecycle-check requires --trace-path "
+                  "and --detach-helper",
+                  file=sys.stderr)
+            return 2
+        return run_controller_two_target_lifecycle_check(args)
+
     if (args.threads <= 0 or args.seconds <= 0 or args.samples <= 0 or
             args.spawner_threads <= 0):
         print(
@@ -620,6 +924,12 @@ def main():
         return 2
     if args.require_reattach_batch_size > 0:
         args.require_reattach = True
+    if args.require_paired_target_lifecycle:
+        args.require_reattach = True
+        if not args.paired_targets:
+            print("--require-paired-target-lifecycle requires --paired-targets",
+                  file=sys.stderr)
+            return 2
     if args.require_redetach_after_reattach:
         args.require_reattach = True
 

--- a/test/detach_runtime/run_detach_hotloop_trace_check.py
+++ b/test/detach_runtime/run_detach_hotloop_trace_check.py
@@ -343,6 +343,34 @@ def run_lifecycle_parser_self_test():
             print(f"lifecycle parser self-test failed: {name}: {reason}",
                   file=sys.stderr)
             return 1
+
+    batch_args = argparse.Namespace(
+        paired_targets=True,
+        fail_on_transition_skips=False,
+        require_trace_diagnostics=False,
+    )
+    mixed_operation_batch = [
+        row(TARGET_SYMBOL, "detach", 30, 2),
+        row(PAIRED_TARGET_SYMBOL, "reattach", 30, 2),
+    ]
+    for operation in ("detach", "reattach"):
+        if trace_rows_have_required_batch(
+                batch_args, mixed_operation_batch, operation, 2,
+                report_missing=False):
+            print("lifecycle parser self-test failed: mixed-operation "
+                  f"batch counted as {operation} batch", file=sys.stderr)
+            return 1
+
+    same_operation_batch = [
+        row(TARGET_SYMBOL, "detach", 31, 2),
+        row(PAIRED_TARGET_SYMBOL, "detach", 31, 2),
+    ]
+    if not trace_rows_have_required_batch(
+            batch_args, same_operation_batch, "detach", 2):
+        print("lifecycle parser self-test failed: same-operation detach "
+              "batch was not recognized", file=sys.stderr)
+        return 1
+
     print("detach_hotloop_lifecycle_parser_ok")
     return 0
 
@@ -467,6 +495,14 @@ def trace_has_required_batch(args, sample, operation, required_size):
     if rows is None:
         return False
 
+    return trace_rows_have_required_batch(args, rows, operation, required_size)
+
+
+def trace_rows_have_required_batch(args, rows, operation, required_size,
+                                  report_missing=True):
+    if required_size <= 0:
+        return True
+
     required_symbols = {TARGET_SYMBOL}
     if args.paired_targets:
         required_symbols.add(PAIRED_TARGET_SYMBOL)
@@ -505,14 +541,15 @@ def trace_has_required_batch(args, sample, operation, required_size):
         if required_symbols.issubset(symbols):
             return True
 
-    print(f"missing same-batch {operation} trace rows for "
-          f"{sorted(required_symbols)}",
-          file=sys.stderr)
-    for key, symbols in sorted(batch_groups.items()):
-        missing = required_symbols - symbols
-        if missing:
-            print(f"batch key {key} missing {sorted(missing)}",
+    if report_missing:
+        print(f"missing same-batch {operation} trace rows for "
+              f"{sorted(required_symbols)}",
               file=sys.stderr)
+        for key, symbols in sorted(batch_groups.items()):
+            missing = required_symbols - symbols
+            if missing:
+                print(f"batch key {key} missing {sorted(missing)}",
+                      file=sys.stderr)
     return False
 
 

--- a/test/detach_runtime/test_detach_hotloop.c
+++ b/test/detach_runtime/test_detach_hotloop.c
@@ -28,6 +28,7 @@ static atomic_int unblock_backend_signal_requested;
 static atomic_int user_signal_handler_count;
 static atomic_uint_fast64_t side_effect;
 static atomic_uint_fast64_t spawned_worker_count;
+static atomic_uint_fast64_t spawned_worker_started_count;
 static atomic_uint_fast64_t blocked_signal_thread_count;
 
 #define PEAK_DETACH_HOT_BURST 64
@@ -90,12 +91,19 @@ typedef struct {
 } WorkerState;
 
 typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+} SpawnProgress;
+
+typedef struct {
     unsigned int seed;
+    SpawnProgress* progress;
 } SpawnedWorkerState;
 
 typedef struct {
     unsigned int seed;
     uint64_t created;
+    SpawnProgress* progress;
 } SpawnerState;
 
 typedef struct {
@@ -149,6 +157,49 @@ sleep_for_seconds(long seconds)
         }
         nanosleep(&ts, NULL);
     }
+}
+
+static int
+spawn_progress_init(SpawnProgress* progress)
+{
+    pthread_condattr_t attr;
+    int status;
+
+    if (pthread_mutex_init(&progress->mutex, NULL) != 0) {
+        return -1;
+    }
+    status = pthread_condattr_init(&attr);
+    if (status != 0) {
+        pthread_mutex_destroy(&progress->mutex);
+        return -1;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&progress->cond, &attr);
+    }
+    pthread_condattr_destroy(&attr);
+    if (status != 0) {
+        pthread_mutex_destroy(&progress->mutex);
+        return -1;
+    }
+    return 0;
+}
+
+static void
+spawn_progress_destroy(SpawnProgress* progress)
+{
+    pthread_cond_destroy(&progress->cond);
+    pthread_mutex_destroy(&progress->mutex);
+}
+
+static void
+spawn_progress_publish(SpawnProgress* progress,
+                       atomic_uint_fast64_t* counter)
+{
+    pthread_mutex_lock(&progress->mutex);
+    atomic_fetch_add_explicit(counter, 1, memory_order_relaxed);
+    pthread_cond_broadcast(&progress->cond);
+    pthread_mutex_unlock(&progress->mutex);
 }
 
 static int
@@ -251,6 +302,7 @@ spawned_worker_main(void* arg)
     SpawnedWorkerState* state = (SpawnedWorkerState*)arg;
     unsigned int seed = state->seed;
 
+    spawn_progress_publish(state->progress, &spawned_worker_started_count);
     for (uint64_t i = 0; i < 32; i++) {
         peak_detach_hot_target((uint64_t)(seed + i));
     }
@@ -368,17 +420,15 @@ spawner_main(void* arg)
             break;
         }
         child_state->seed = state->seed + (unsigned int)state->created;
+        child_state->progress = state->progress;
         if (pthread_create(&child, NULL, spawned_worker_main, child_state) != 0) {
             free(child_state);
             break;
         }
         pthread_join(child, NULL);
         state->created++;
+        spawn_progress_publish(state->progress, &spawned_worker_count);
     }
-
-    atomic_fetch_add_explicit(&spawned_worker_count,
-                              state->created,
-                              memory_order_relaxed);
     return NULL;
 }
 
@@ -957,6 +1007,76 @@ trace_has_physical_detach_success(const char* trace_path)
 
     fclose(fp);
     return 0;
+}
+
+static uint64_t
+wait_for_spawn_progress(SpawnProgress* progress,
+                        atomic_uint_fast64_t* counter,
+                        uint64_t observed_count,
+                        double monotonic_deadline)
+{
+    struct timespec timeout = {
+        .tv_sec = (time_t)monotonic_deadline,
+        .tv_nsec = (long)((monotonic_deadline -
+                           (double)(time_t)monotonic_deadline) *
+                          1000000000.0),
+    };
+    uint64_t current_count;
+
+    pthread_mutex_lock(&progress->mutex);
+    current_count = atomic_load_explicit(counter, memory_order_relaxed);
+    while (current_count <= observed_count) {
+        int status;
+
+        if (monotonic_seconds() >= monotonic_deadline) {
+            break;
+        }
+        status = pthread_cond_timedwait(&progress->cond,
+                                        &progress->mutex,
+                                        &timeout);
+        current_count = atomic_load_explicit(counter, memory_order_relaxed);
+        if (status != 0) {
+            break;
+        }
+    }
+    pthread_mutex_unlock(&progress->mutex);
+    return current_count;
+}
+
+static void
+observe_detach_during_spawn_churn(SpawnProgress* progress,
+                                  const char* trace_path,
+                                  double monotonic_deadline,
+                                  int* detach_during_churn,
+                                  uint64_t* detach_observed_spawned_threads,
+                                  int* post_detach_spawn)
+{
+    uint64_t observed_count = atomic_load_explicit(&spawned_worker_count,
+                                                   memory_order_relaxed);
+
+    while (monotonic_seconds() < monotonic_deadline) {
+        uint64_t current_count =
+            wait_for_spawn_progress(progress,
+                                    &spawned_worker_count,
+                                    observed_count,
+                                    monotonic_deadline);
+
+        if (current_count <= observed_count) {
+            continue;
+        }
+        observed_count = current_count;
+        if (!*detach_during_churn &&
+            trace_has_physical_detach_success(trace_path)) {
+            *detach_during_churn = 1;
+            *detach_observed_spawned_threads =
+                atomic_load_explicit(&spawned_worker_count,
+                                     memory_order_relaxed);
+            observed_count = *detach_observed_spawned_threads;
+        } else if (*detach_during_churn &&
+                   current_count > *detach_observed_spawned_threads) {
+            *post_detach_spawn = 1;
+        }
+    }
 }
 
 static int
@@ -3369,13 +3489,23 @@ main(int argc, char** argv)
     int paired_targets = has_flag_arg(argc, argv, "--paired-targets");
     int cold_one_shot_target = has_flag_arg(argc, argv, "--cold-one-shot-target");
     int spawn_transient_threads = has_flag_arg(argc, argv, "--spawn-transient-threads");
+    int require_detach_during_churn =
+        has_flag_arg(argc, argv, "--require-detach-during-churn");
     int block_backend_signal =
         has_flag_arg(argc, argv, "--block-backend-signal");
+    if (require_detach_during_churn &&
+        (!spawn_transient_threads || cold_one_shot_target)) {
+        fprintf(stderr,
+                "--require-detach-during-churn requires transient spawners and no pre-gate cold target\n");
+        return 2;
+    }
     pthread_t* tids = calloc((size_t)threads, sizeof(*tids));
     WorkerState* states = calloc((size_t)threads, sizeof(*states));
     pthread_t* spawner_tids = NULL;
     SpawnerState* spawner_states = NULL;
     StartGate gate;
+    SpawnProgress spawn_progress;
+    int spawn_progress_initialized = 0;
     long created_threads = 0;
     long created_spawners = 0;
     if (spawn_transient_threads) {
@@ -3400,6 +3530,18 @@ main(int argc, char** argv)
         free(spawner_states);
         return 2;
     }
+    if (spawn_transient_threads) {
+        if (spawn_progress_init(&spawn_progress) != 0) {
+            fprintf(stderr, "spawn progress initialization failed\n");
+            start_gate_destroy(&gate);
+            free(tids);
+            free(states);
+            free(spawner_tids);
+            free(spawner_states);
+            return 2;
+        }
+        spawn_progress_initialized = 1;
+    }
 
     atomic_store_explicit(&stop_requested, 0, memory_order_relaxed);
     atomic_store_explicit(&unblock_backend_signal_requested,
@@ -3407,6 +3549,9 @@ main(int argc, char** argv)
                           memory_order_release);
     atomic_store_explicit(&side_effect, 0, memory_order_relaxed);
     atomic_store_explicit(&spawned_worker_count, 0, memory_order_relaxed);
+    atomic_store_explicit(&spawned_worker_started_count,
+                          0,
+                          memory_order_relaxed);
     atomic_store_explicit(&blocked_signal_thread_count, 0, memory_order_relaxed);
     if (cold_one_shot_target) {
         peak_detach_cold_target(0xc01d);
@@ -3424,6 +3569,9 @@ main(int argc, char** argv)
             for (long j = 0; j < created_threads; j++) {
                 pthread_join(tids[j], NULL);
             }
+            if (spawn_progress_initialized) {
+                spawn_progress_destroy(&spawn_progress);
+            }
             start_gate_destroy(&gate);
             free(tids);
             free(states);
@@ -3434,22 +3582,36 @@ main(int argc, char** argv)
         created_threads++;
     }
 
-    start_gate_wait(&gate);
+    int detach_during_churn = 0;
+    uint64_t detach_observed_spawned_threads = 0;
+    int post_detach_spawn = 0;
+    uint64_t pre_detach_spawn_started = 0;
+    double start = 0.0;
+    double deadline = 0.0;
+    if (require_detach_during_churn) {
+        start = monotonic_seconds();
+        deadline = start + (double)seconds;
+    } else {
+        start_gate_wait(&gate);
+    }
     if (spawn_transient_threads) {
         for (long i = 0; i < spawner_threads; i++) {
             spawner_states[i].seed = 0x7f4a7c15u + (unsigned int)i;
+            spawner_states[i].progress = &spawn_progress;
             if (pthread_create(&spawner_tids[i],
                                NULL,
                                spawner_main,
                                &spawner_states[i]) != 0) {
                 perror("pthread_create spawner");
                 atomic_store_explicit(&stop_requested, 1, memory_order_relaxed);
+                start_gate_abort(&gate);
                 for (long j = 0; j < created_spawners; j++) {
                     pthread_join(spawner_tids[j], NULL);
                 }
                 for (long j = 0; j < created_threads; j++) {
                     pthread_join(tids[j], NULL);
                 }
+                spawn_progress_destroy(&spawn_progress);
                 start_gate_destroy(&gate);
                 free(tids);
                 free(states);
@@ -3461,8 +3623,43 @@ main(int argc, char** argv)
         }
     }
 
-    double start = monotonic_seconds();
-    sleep_for_seconds(seconds);
+    if (require_detach_during_churn) {
+        pre_detach_spawn_started =
+            wait_for_spawn_progress(&spawn_progress,
+                                    &spawned_worker_started_count,
+                                    0,
+                                    deadline);
+        if (pre_detach_spawn_started == 0) {
+            fprintf(stderr,
+                    "transient worker did not start before the workload deadline\n");
+            atomic_store_explicit(&stop_requested, 1, memory_order_relaxed);
+            start_gate_abort(&gate);
+            for (long i = 0; i < created_spawners; i++) {
+                pthread_join(spawner_tids[i], NULL);
+            }
+            for (long i = 0; i < created_threads; i++) {
+                pthread_join(tids[i], NULL);
+            }
+            spawn_progress_destroy(&spawn_progress);
+            start_gate_destroy(&gate);
+            free(tids);
+            free(states);
+            free(spawner_tids);
+            free(spawner_states);
+            return 2;
+        }
+        start_gate_wait(&gate);
+        observe_detach_during_spawn_churn(
+            &spawn_progress,
+            getenv("PEAK_DETACH_TRACE_PATH"),
+            deadline,
+            &detach_during_churn,
+            &detach_observed_spawned_threads,
+            &post_detach_spawn);
+    } else {
+        start = monotonic_seconds();
+        sleep_for_seconds(seconds);
+    }
     atomic_store_explicit(&stop_requested, 1, memory_order_relaxed);
 
     for (long i = 0; i < created_spawners; i++) {
@@ -3474,6 +3671,9 @@ main(int argc, char** argv)
         pthread_join(tids[i], NULL);
         calls += states[i].calls;
     }
+    if (spawn_progress_initialized) {
+        spawn_progress_destroy(&spawn_progress);
+    }
     double elapsed = monotonic_seconds() - start;
     int trace_detach_success = 0;
 #ifdef PEAK_HAVE_GUM_PEAK_PC_API
@@ -3481,7 +3681,11 @@ main(int argc, char** argv)
         trace_has_physical_detach_success(getenv("PEAK_DETACH_TRACE_PATH"));
 #endif
 
-    printf("threads=%ld seconds=%ld calls=%lu elapsed=%.6f calls_per_sec=%.3f side_effect=%lu spawned_threads=%lu blocked_signal_threads=%lu trace_detach_success=%d\n",
+    printf("pre_detach_spawn_started=%lu detach_during_churn=%d detach_observed_spawned_threads=%lu post_detach_spawn=%d threads=%ld seconds=%ld calls=%lu elapsed=%.6f calls_per_sec=%.3f side_effect=%lu spawned_threads=%lu blocked_signal_threads=%lu trace_detach_success=%d\n",
+           (unsigned long)pre_detach_spawn_started,
+           detach_during_churn,
+           (unsigned long)detach_observed_spawned_threads,
+           post_detach_spawn,
            threads,
            seconds,
            (unsigned long)calls,

--- a/test/detach_runtime/test_detach_hotloop.c
+++ b/test/detach_runtime/test_detach_hotloop.c
@@ -1161,6 +1161,89 @@ run_controller_batch_retry_check(void)
 }
 
 static int
+run_controller_two_target_lifecycle_check(void)
+{
+    PeakRequestDetachFn request_detach =
+        (PeakRequestDetachFn)required_symbol("peak_general_listener_request_detach");
+    PeakRequestReattachFn request_reattach =
+        (PeakRequestReattachFn)required_symbol("peak_general_listener_request_reattach");
+    PeakControllerDrainFn controller_drain =
+        (PeakControllerDrainFn)required_symbol("peak_general_listener_controller_drain");
+    PeakHookStateFn hook_state =
+        (PeakHookStateFn)required_symbol("peak_general_listener_hook_state");
+    size_t* hook_count = (size_t*)required_symbol("peak_hook_address_count");
+    const char* trace_path = getenv("PEAK_DETACH_TRACE_PATH");
+    const unsigned int drain_deadline_ms = 2000;
+
+    if (request_detach == NULL ||
+        request_reattach == NULL ||
+        controller_drain == NULL ||
+        hook_state == NULL ||
+        hook_count == NULL) {
+        return 2;
+    }
+    if (*hook_count < 2) {
+        fprintf(stderr, "two-target lifecycle check requires two configured hooks\n");
+        return 2;
+    }
+    if (trace_path == NULL || trace_path[0] == '\0') {
+        fprintf(stderr, "PEAK_DETACH_TRACE_PATH is required\n");
+        return 2;
+    }
+    if (hook_state(0) != PEAK_HOOK_ATTACHED ||
+        hook_state(1) != PEAK_HOOK_ATTACHED) {
+        fprintf(stderr, "expected both hooks to start attached\n");
+        return 2;
+    }
+
+    if (!request_detach(0) || !request_detach(1)) {
+        fprintf(stderr, "failed to queue two-target detach requests\n");
+        return 2;
+    }
+    /* The drain deadline only bounds failure; hook states establish success. */
+    if (!controller_drain(drain_deadline_ms)) {
+        fprintf(stderr, "controller did not drain two-target detach requests\n");
+        return 2;
+    }
+    if (hook_state(0) != PEAK_HOOK_DETACHED ||
+        hook_state(1) != PEAK_HOOK_DETACHED) {
+        fprintf(stderr, "expected both hooks detached after two-target detach drain\n");
+        return 2;
+    }
+
+    if (!request_reattach(0) || !request_reattach(1)) {
+        fprintf(stderr, "failed to queue two-target reattach requests\n");
+        return 2;
+    }
+    if (!controller_drain(drain_deadline_ms)) {
+        fprintf(stderr, "controller did not drain two-target reattach requests\n");
+        return 2;
+    }
+    if (hook_state(0) != PEAK_HOOK_ATTACHED ||
+        hook_state(1) != PEAK_HOOK_ATTACHED) {
+        fprintf(stderr, "expected both hooks attached after two-target reattach drain\n");
+        return 2;
+    }
+
+    if (!request_detach(0) || !request_detach(1)) {
+        fprintf(stderr, "failed to queue two-target re-detach requests\n");
+        return 2;
+    }
+    if (!controller_drain(drain_deadline_ms)) {
+        fprintf(stderr, "controller did not drain two-target re-detach requests\n");
+        return 2;
+    }
+    if (hook_state(0) != PEAK_HOOK_DETACHED ||
+        hook_state(1) != PEAK_HOOK_DETACHED) {
+        fprintf(stderr, "expected both hooks detached after two-target re-detach drain\n");
+        return 2;
+    }
+
+    printf("controller_two_target_lifecycle_ok\n");
+    return 0;
+}
+
+static int
 run_controller_no_trace_pending_age_check(void)
 {
     PeakRequestDetachFn request_detach =
@@ -3243,6 +3326,9 @@ main(int argc, char** argv)
 {
     if (has_flag_arg(argc, argv, "--controller-batch-retry-check")) {
         return run_controller_batch_retry_check();
+    }
+    if (has_flag_arg(argc, argv, "--controller-two-target-lifecycle-check")) {
+        return run_controller_two_target_lifecycle_check();
     }
     if (has_flag_arg(argc, argv, "--controller-no-trace-pending-age-check")) {
         return run_controller_no_trace_pending_age_check();

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -1,19 +1,158 @@
+add_test(NAME test_exec_chain_platform_contract
+    COMMAND ${CMAKE_COMMAND}
+            -DPEAK_SOURCE_ROOT=${PROJECT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/test_exec_chain_platform_contract.cmake)
+set_tests_properties(test_exec_chain_platform_contract
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION "exec_chain_platform_contract_ok"
+        TIMEOUT 10)
+
+add_test(NAME test_exec_chain_platform_selection_contract
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_platform_selection_contract.py
+            --cmake ${CMAKE_COMMAND}
+            --c-compiler ${CMAKE_C_COMPILER}
+            --source-root ${PROJECT_SOURCE_DIR}
+            --probe-source ${CMAKE_CURRENT_SOURCE_DIR}/platform_probe)
+set_tests_properties(test_exec_chain_platform_selection_contract
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION
+            "exec_chain_platform_selection_contract_ok"
+        FAIL_REGULAR_EXPRESSION "Traceback|AssertionError"
+        TIMEOUT 60)
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_executable(test_exec_chain test_exec_chain.c)
-    target_link_options(test_exec_chain PRIVATE -Wl,--export-dynamic)
+    target_link_options(test_exec_chain PRIVATE -Wl,--export-dynamic -Wl,--as-needed)
     target_link_libraries(test_exec_chain PRIVATE pthread ${CMAKE_DL_LIBS})
+
+    add_library(test_execve_observer SHARED test_execve_observer.c)
+    target_link_options(test_execve_observer PRIVATE -Wl,--as-needed)
+    target_link_libraries(test_execve_observer PRIVATE ${CMAKE_DL_LIBS})
+
+    add_executable(test_exec_preinit test_exec_preinit.c)
+    target_link_options(test_exec_preinit PRIVATE -Wl,--export-dynamic)
+    target_link_libraries(test_exec_preinit PRIVATE pthread)
 
     include(CheckSymbolExists)
     set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    check_symbol_exists(execvpe "unistd.h" PEAK_TEST_HAVE_EXECVPE)
+    check_symbol_exists(fexecve "unistd.h" PEAK_TEST_HAVE_FEXECVE)
     check_symbol_exists(execveat "unistd.h" PEAK_TEST_HAVE_EXECVEAT)
+    check_symbol_exists(SYS_clone "sys/syscall.h" PEAK_TEST_HAVE_SYS_CLONE)
+    check_symbol_exists(SYS_clone3 "sys/syscall.h" PEAK_TEST_HAVE_SYS_CLONE3)
     check_symbol_exists(POSIX_SPAWN_USEVFORK "spawn.h" PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
     unset(CMAKE_REQUIRED_DEFINITIONS)
 
+    if(PEAK_TEST_HAVE_SYS_CLONE)
+        add_executable(test_exec_preinit_clone test_exec_preinit.c)
+        target_link_options(test_exec_preinit_clone PRIVATE -Wl,--export-dynamic)
+        target_link_libraries(test_exec_preinit_clone PRIVATE pthread)
+        target_compile_definitions(test_exec_preinit_clone
+            PRIVATE PEAK_TEST_FORCE_CLONE_RAW_FORK=1)
+    endif()
+
     if(PEAK_TEST_HAVE_EXECVEAT)
-        target_compile_definitions(test_exec_chain PRIVATE PEAK_TEST_HAVE_EXECVEAT=1)
+        target_compile_definitions(test_exec_chain
+            PRIVATE PEAK_TEST_HAVE_EXECVEAT=1)
+        target_compile_definitions(test_exec_preinit
+            PRIVATE PEAK_TEST_HAVE_EXECVEAT=1)
+        if(TARGET test_exec_preinit_clone)
+            target_compile_definitions(test_exec_preinit_clone
+                PRIVATE PEAK_TEST_HAVE_EXECVEAT=1)
+        endif()
+    endif()
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        target_compile_definitions(test_exec_chain
+            PRIVATE PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED=1)
+        target_compile_definitions(test_exec_preinit
+            PRIVATE PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED=1)
+        if(TARGET test_exec_preinit_clone)
+            target_compile_definitions(test_exec_preinit_clone
+                PRIVATE PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED=1)
+        endif()
+    endif()
+    if(PEAK_TEST_HAVE_EXECVPE)
+        target_compile_definitions(test_exec_preinit
+            PRIVATE PEAK_TEST_HAVE_EXECVPE=1)
+        if(TARGET test_exec_preinit_clone)
+            target_compile_definitions(test_exec_preinit_clone
+                PRIVATE PEAK_TEST_HAVE_EXECVPE=1)
+        endif()
+    endif()
+    if(PEAK_TEST_HAVE_FEXECVE)
+        target_compile_definitions(test_exec_preinit
+            PRIVATE PEAK_TEST_HAVE_FEXECVE=1)
+        if(TARGET test_exec_preinit_clone)
+            target_compile_definitions(test_exec_preinit_clone
+                PRIVATE PEAK_TEST_HAVE_FEXECVE=1)
+        endif()
     endif()
     if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
         target_compile_definitions(test_exec_chain PRIVATE PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK=1)
+    endif()
+    if(PEAK_TEST_HAVE_SYS_CLONE3)
+        target_compile_definitions(test_exec_chain
+            PRIVATE PEAK_TEST_HAVE_SYS_CLONE3=1)
+    endif()
+
+    set(_PEAK_EXEC_PREINIT_CASES
+        execve execv execl execle execvp execvp_eacces_eloop execlp
+        posix_spawn posix_spawnp)
+    if(PEAK_TEST_HAVE_EXECVPE)
+        list(APPEND _PEAK_EXEC_PREINIT_CASES execvpe)
+    endif()
+    if(PEAK_TEST_HAVE_FEXECVE)
+        list(APPEND _PEAK_EXEC_PREINIT_CASES fexecve)
+    endif()
+    if(PEAK_TEST_HAVE_EXECVEAT)
+        list(APPEND _PEAK_EXEC_PREINIT_CASES execveat)
+    endif()
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        list(APPEND _PEAK_EXEC_PREINIT_CASES raw_execve)
+        if(PEAK_TEST_HAVE_EXECVEAT)
+            list(APPEND _PEAK_EXEC_PREINIT_CASES raw_execveat)
+        endif()
+    endif()
+    string(REPLACE ";" "," _PEAK_EXEC_PREINIT_CASES_ARG
+        "${_PEAK_EXEC_PREINIT_CASES}")
+
+    set(_PEAK_EXEC_DEFAULT_BYPASS_CASES
+        execv execvpe execl execle fexecve posix_spawnp)
+    if(PEAK_TEST_HAVE_EXECVEAT)
+        list(APPEND _PEAK_EXEC_DEFAULT_BYPASS_CASES execveat)
+    endif()
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        list(APPEND _PEAK_EXEC_DEFAULT_BYPASS_CASES raw_execve)
+        if(PEAK_TEST_HAVE_EXECVEAT)
+            list(APPEND _PEAK_EXEC_DEFAULT_BYPASS_CASES raw_execveat)
+        endif()
+    endif()
+    string(REPLACE ";" "," _PEAK_EXEC_DEFAULT_BYPASS_CASES_ARG
+        "${_PEAK_EXEC_DEFAULT_BYPASS_CASES}")
+    add_test(NAME test_exec_preinit_contract
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_preinit_check.py
+                --exe $<TARGET_FILE:test_exec_preinit>
+                --libpeak $<TARGET_FILE:peak>
+                --expected-cases ${_PEAK_EXEC_PREINIT_CASES_ARG})
+    set_tests_properties(test_exec_preinit_contract
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "exec_preinit_contract_ok"
+            FAIL_REGULAR_EXPRESSION "Traceback|AssertionError"
+            TIMEOUT 20)
+    if(TARGET test_exec_preinit_clone)
+        add_test(NAME test_exec_preinit_clone_contract
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_preinit_check.py
+                    --exe $<TARGET_FILE:test_exec_preinit_clone>
+                    --libpeak $<TARGET_FILE:peak>
+                    --expected-cases ${_PEAK_EXEC_PREINIT_CASES_ARG})
+        set_tests_properties(test_exec_preinit_clone_contract
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "exec_preinit_contract_ok"
+                FAIL_REGULAR_EXPRESSION "Traceback|AssertionError"
+                TIMEOUT 20)
     endif()
 
     set(_PEAK_EXEC_CHAIN_TESTS
@@ -23,6 +162,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         exec_checkpoint_disabled
         exec_bad_stats_path_nonfatal
         execve_custom_env_injection
+        execve_call_env_optin_default_bypass
         raw_syscall_execve_custom_env_injection
         raw_syscall_execve_backend_disabled_injection
         raw_syscall_execve_failure_non_destructive
@@ -53,9 +193,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         fexecve_bad_argv_failure_non_destructive
         execl_success_checkpoint
         execlp_path_search
+        execlp_default_bypass_without_execvpe
         execle_custom_env_injection
         exec_failure_non_destructive
         execvp_path_search
+        execvp_default_bypass_without_execvpe
         execvp_empty_path_component
         helper_named_exec_still_checkpointed
         execvpe_caller_path_child_env_ignored
@@ -70,6 +212,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         fork_child_exec_parent_exec
         vfork_child_exec_parent_exec
         vfork_child_failed_exec_parent_exec
+        clone_private_vm_exec
+        clone_vm_exec
+        clone_vfork_exec
         vfork_execl_parent_exec
         vfork_execlp_parent_exec
         vfork_execle_parent_exec
@@ -87,6 +232,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         vfork_custom_env_chain_disabled
         vfork_custom_env_execvpe_chain
         vfork_custom_env_execvp_chain
+        vfork_execvp_native_fallback
         vfork_custom_env_execlp_chain
         vfork_custom_env_fexecve_chain
         fork_bad_env_vector_efault
@@ -100,6 +246,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         no_duplicate_ld_preload_whitespace
         no_duplicate_ld_preload_env_entries
         posix_spawn_custom_env_injection
+        posix_spawn_call_env_optin_default_bypass
         posix_spawn_env_build_failure_passthrough
         posix_spawn_null_env_injection
         posix_spawn_bad_env_failure_non_destructive
@@ -128,6 +275,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         exec_checkpoint_concurrent_fini_callbacks
         exec_checkpoint_snapshot_lock_contention
         exec_checkpoint_fork_child_fini
+        signal_handler_execve_default_bypass
+        default_disabled_family_bypass
         text_output_not_corrupted)
 
     if(PEAK_TEST_HAVE_EXECVEAT)
@@ -142,6 +291,21 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             vfork_raw_syscall_execveat_chain)
     endif()
 
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED AND PEAK_TEST_HAVE_SYS_CLONE)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS
+            raw_clone_libc_exec
+            raw_clone_raw_exec)
+    endif()
+
+    if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS
+            raw_syscall_execve_observer_bypass)
+    endif()
+
+    if(PEAK_TEST_HAVE_SYS_CLONE3)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS clone3_exec)
+    endif()
+
     if(NOT MPI_FOUND)
         list(APPEND _PEAK_EXEC_CHAIN_TESTS
             execve_loader_path_empty
@@ -153,6 +317,22 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
         list(APPEND _PEAK_EXEC_CHAIN_TESTS posix_spawn_usevfork_custom_env)
     endif()
+
+    set(_PEAK_EXEC_DEDICATED_DEFAULT_BYPASS_TESTS
+        execve_call_env_optin_default_bypass
+        execvp_default_bypass_without_execvpe
+        execlp_default_bypass_without_execvpe
+        posix_spawn_call_env_optin_default_bypass)
+    foreach(_peak_exec_dedicated_test
+            IN LISTS _PEAK_EXEC_DEDICATED_DEFAULT_BYPASS_TESTS)
+        list(FIND _PEAK_EXEC_CHAIN_TESTS
+            "${_peak_exec_dedicated_test}" _peak_exec_test_index)
+        if(_peak_exec_test_index EQUAL -1)
+            message(FATAL_ERROR
+                "missing dedicated default-bypass test: "
+                "${_peak_exec_dedicated_test}")
+        endif()
+    endforeach()
 
     add_test(NAME test_exec_chain_check_contracts
         COMMAND ${Python3_EXECUTABLE}
@@ -171,13 +351,25 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             PASS_REGULAR_EXPRESSION "exec_chain_checkpoint_contract_ok"
             TIMEOUT 10)
 
+    add_test(NAME test_exec_chain_timeout_contract
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_chain_check.py
+                --self-test-timeout-contract)
+    set_tests_properties(test_exec_chain_timeout_contract
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "exec_chain_timeout_contract_ok"
+            TIMEOUT 10)
+
     foreach(_peak_exec_test IN LISTS _PEAK_EXEC_CHAIN_TESTS)
         add_test(NAME test_${_peak_exec_test}
             COMMAND ${Python3_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_chain_check.py
                     --mode ${_peak_exec_test}
                     --exe $<TARGET_FILE:test_exec_chain>
-                    --libpeak $<TARGET_FILE:peak>)
+                    --libpeak $<TARGET_FILE:peak>
+                    --execve-observer $<TARGET_FILE:test_execve_observer>
+                    --expected-default-bypass-cases
+                        ${_PEAK_EXEC_DEFAULT_BYPASS_CASES_ARG})
         set_tests_properties(test_${_peak_exec_test}
             PROPERTIES
                 PASS_REGULAR_EXPRESSION "exec_chain_check_ok mode=${_peak_exec_test}"

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -103,7 +103,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawn_child_peak_env_only_injection
         posix_spawn_chain_disabled
         posix_spawn_failure_non_destructive
+        posix_spawn_resolver_null_preserves_errno
         posix_spawnp_path_search
+        posix_spawnp_env_build_failure_passthrough
+        posix_spawnp_resolver_null_preserves_errno
         posix_spawnp_empty_path_component
         posix_spawnp_child_env_path_ignored
         posix_spawnp_preflight_unavailable_delegates

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -30,6 +30,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         execve_preflight_unavailable_injection
         execve_child_peak_env_only_injection
         execve_null_env_injection
+        execve_loader_path_missing
+        execve_loader_path_explicit
+        execve_loader_path_chain_disabled
+        execve_loader_path_secure_skip
         execve_large_env_injection
         execve_env_build_failure_passthrough
         execve_bad_env_failure_non_destructive
@@ -71,6 +75,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         vfork_execle_parent_exec
         fork_custom_env_execve_chain
         vfork_custom_env_execve_chain
+        fork_loader_path
+        vfork_loader_path
+        fork_loader_path_secure_skip
+        vfork_loader_path_secure_skip
+        fork_parent_env_exhaustion
         vfork_custom_env_execle_chain
         fork_raw_syscall_custom_env_chain
         fork_raw_syscall_chain_disabled
@@ -86,6 +95,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         vfork_bad_env_string_efault
         vfork_env_slots_fallback
         vfork_long_preload_fallback
+        vfork_preload_entries_fallback
         no_duplicate_ld_preload
         no_duplicate_ld_preload_whitespace
         no_duplicate_ld_preload_env_entries
@@ -129,6 +139,14 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         list(APPEND _PEAK_EXEC_CHAIN_TESTS
             vfork_custom_env_execveat_chain
             vfork_raw_syscall_execveat_chain)
+    endif()
+
+    if(NOT MPI_FOUND)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS
+            execve_loader_path_empty
+            execve_loader_path_duplicate
+            execve_loader_path_preload_present
+            vfork_loader_path_preload_present)
     endif()
 
     if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -160,6 +160,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         exec_checkpoint_write_target_no_reentry
         execv_zero_call_checkpoint
         exec_checkpoint_disabled
+        exec_checkpoint_direct_disabled
         exec_bad_stats_path_nonfatal
         execve_custom_env_injection
         execve_call_env_optin_default_bypass
@@ -274,6 +275,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawn_explicit_peak_env_preserved
         exec_checkpoint_concurrent_fini_callbacks
         exec_checkpoint_snapshot_lock_contention
+        exec_checkpoint_statistics_snapshot_contention
+        exec_checkpoint_statistics_shadow_invalidation
         exec_checkpoint_fork_child_fini
         signal_handler_execve_default_bypass
         default_disabled_family_bypass

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -126,6 +126,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawnp_bad_argv_failure_non_destructive
         posix_spawn_explicit_peak_env_preserved
         exec_checkpoint_concurrent_fini_callbacks
+        exec_checkpoint_snapshot_lock_contention
         exec_checkpoint_fork_child_fini
         text_output_not_corrupted)
 
@@ -159,6 +160,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     set_tests_properties(test_exec_chain_check_contracts
         PROPERTIES
             PASS_REGULAR_EXPRESSION "OK"
+            TIMEOUT 10)
+
+    add_test(NAME test_exec_chain_checkpoint_contract
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_chain_check.py
+                --self-test-checkpoint-contract)
+    set_tests_properties(test_exec_chain_checkpoint_contract
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "exec_chain_checkpoint_contract_ok"
             TIMEOUT 10)
 
     foreach(_peak_exec_test IN LISTS _PEAK_EXEC_CHAIN_TESTS)

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -1,0 +1,147 @@
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_executable(test_exec_chain test_exec_chain.c)
+    target_link_options(test_exec_chain PRIVATE -Wl,--export-dynamic)
+    target_link_libraries(test_exec_chain PRIVATE pthread ${CMAKE_DL_LIBS})
+
+    include(CheckSymbolExists)
+    set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    check_symbol_exists(execveat "unistd.h" PEAK_TEST_HAVE_EXECVEAT)
+    check_symbol_exists(POSIX_SPAWN_USEVFORK "spawn.h" PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
+    unset(CMAKE_REQUIRED_DEFINITIONS)
+
+    if(PEAK_TEST_HAVE_EXECVEAT)
+        target_compile_definitions(test_exec_chain PRIVATE PEAK_TEST_HAVE_EXECVEAT=1)
+    endif()
+    if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
+        target_compile_definitions(test_exec_chain PRIVATE PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK=1)
+    endif()
+
+    set(_PEAK_EXEC_CHAIN_TESTS
+        execv_success_checkpoint
+        exec_checkpoint_write_target_no_reentry
+        execv_zero_call_checkpoint
+        exec_checkpoint_disabled
+        exec_bad_stats_path_nonfatal
+        execve_custom_env_injection
+        raw_syscall_execve_custom_env_injection
+        raw_syscall_execve_backend_disabled_injection
+        raw_syscall_execve_failure_non_destructive
+        raw_syscall_nonexec_passthrough
+        execve_preflight_unavailable_injection
+        execve_child_peak_env_only_injection
+        execve_null_env_injection
+        execve_large_env_injection
+        execve_env_build_failure_passthrough
+        execve_bad_env_failure_non_destructive
+        execve_bad_env_preflight_unknown_non_destructive
+        execve_bad_argv_failure_non_destructive
+        execve_explicit_peak_env_preserved
+        execve_child_chain_disabled
+        execve_child_checkpoint_disabled
+        execve_child_propagate_disabled
+        execve_propagate_disabled
+        execve_chain_disabled
+        execve_secure_skip
+        fexecve_custom_env_injection
+        fexecve_preflight_unavailable_injection
+        fexecve_bad_env_failure_non_destructive
+        fexecve_bad_env_preflight_unknown_non_destructive
+        fexecve_bad_argv_failure_non_destructive
+        execl_success_checkpoint
+        execlp_path_search
+        execle_custom_env_injection
+        exec_failure_non_destructive
+        execvp_path_search
+        execvp_empty_path_component
+        helper_named_exec_still_checkpointed
+        execvpe_caller_path_child_env_ignored
+        no_duplicate_ld_preload_execvpe_path_fallback
+        execvp_enoent_failure
+        execvp_enotdir_enoent_failure
+        execvp_enotdir_enoent_fallback
+        execvp_eacces_failure
+        execvp_eacces_fallback
+        execvp_enoent_fallback
+        execvp_enoexec_fallback
+        fork_child_exec_parent_exec
+        vfork_child_exec_parent_exec
+        vfork_child_failed_exec_parent_exec
+        vfork_execl_parent_exec
+        vfork_execlp_parent_exec
+        vfork_execle_parent_exec
+        fork_custom_env_execve_chain
+        vfork_custom_env_execve_chain
+        vfork_custom_env_execle_chain
+        fork_raw_syscall_custom_env_chain
+        fork_raw_syscall_chain_disabled
+        fork_custom_env_chain_disabled
+        vfork_custom_env_chain_disabled
+        vfork_custom_env_execvpe_chain
+        vfork_custom_env_execvp_chain
+        vfork_custom_env_execlp_chain
+        vfork_custom_env_fexecve_chain
+        fork_bad_env_vector_efault
+        vfork_bad_env_vector_efault
+        fork_bad_env_string_efault
+        vfork_bad_env_string_efault
+        vfork_env_slots_fallback
+        vfork_long_preload_fallback
+        no_duplicate_ld_preload
+        no_duplicate_ld_preload_whitespace
+        no_duplicate_ld_preload_env_entries
+        posix_spawn_custom_env_injection
+        posix_spawn_env_build_failure_passthrough
+        posix_spawn_null_env_injection
+        posix_spawn_bad_env_failure_non_destructive
+        posix_spawn_bad_env_preflight_unknown_non_destructive
+        posix_spawn_bad_argv_failure_non_destructive
+        posix_spawn_preflight_unavailable_injection
+        posix_spawn_preflight_unavailable_bad_env_delegates
+        posix_spawn_duplicate_ld_preload
+        posix_spawn_actions_attrs_injection
+        posix_spawn_actions_close_stderr
+        posix_spawn_child_peak_env_only_injection
+        posix_spawn_chain_disabled
+        posix_spawn_failure_non_destructive
+        posix_spawnp_path_search
+        posix_spawnp_empty_path_component
+        posix_spawnp_child_env_path_ignored
+        posix_spawnp_preflight_unavailable_delegates
+        posix_spawnp_preflight_unavailable_bad_env_delegates
+        posix_spawnp_bad_env_failure_non_destructive
+        posix_spawnp_bad_env_preflight_unknown_non_destructive
+        posix_spawnp_bad_argv_failure_non_destructive
+        posix_spawn_explicit_peak_env_preserved
+        exec_checkpoint_concurrent_fini_callbacks
+        text_output_not_corrupted)
+
+    if(PEAK_TEST_HAVE_EXECVEAT)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS
+            execveat_custom_env_injection
+            raw_syscall_execveat_custom_env_injection
+            execveat_bad_env_failure_non_destructive
+            execveat_bad_env_preflight_unknown_non_destructive
+            execveat_bad_argv_failure_non_destructive)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS
+            vfork_custom_env_execveat_chain
+            vfork_raw_syscall_execveat_chain)
+    endif()
+
+    if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
+        list(APPEND _PEAK_EXEC_CHAIN_TESTS posix_spawn_usevfork_custom_env)
+    endif()
+
+    foreach(_peak_exec_test IN LISTS _PEAK_EXEC_CHAIN_TESTS)
+        add_test(NAME test_${_peak_exec_test}
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_chain_check.py
+                    --mode ${_peak_exec_test}
+                    --exe $<TARGET_FILE:test_exec_chain>
+                    --libpeak $<TARGET_FILE:peak>)
+        set_tests_properties(test_${_peak_exec_test}
+            PROPERTIES
+                PASS_REGULAR_EXPRESSION "exec_chain_check_ok mode=${_peak_exec_test}"
+                FAIL_REGULAR_EXPRESSION "Traceback|AssertionError|exec_chain_check_failed"
+                TIMEOUT 30)
+    endforeach()
+endif()

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -116,6 +116,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawnp_bad_argv_failure_non_destructive
         posix_spawn_explicit_peak_env_preserved
         exec_checkpoint_concurrent_fini_callbacks
+        exec_checkpoint_fork_child_fini
         text_output_not_corrupted)
 
     if(PEAK_TEST_HAVE_EXECVEAT)
@@ -133,6 +134,14 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     if(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
         list(APPEND _PEAK_EXEC_CHAIN_TESTS posix_spawn_usevfork_custom_env)
     endif()
+
+    add_test(NAME test_exec_chain_check_contracts
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_exec_chain_check_contracts.py)
+    set_tests_properties(test_exec_chain_check_contracts
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "OK"
+            TIMEOUT 10)
 
     foreach(_peak_exec_test IN LISTS _PEAK_EXEC_CHAIN_TESTS)
         add_test(NAME test_${_peak_exec_test}

--- a/test/exec_chain/platform_probe/CMakeLists.txt
+++ b/test/exec_chain/platform_probe/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.9)
+project(peak_exec_platform_selection_probe LANGUAGES NONE)
+
+if(NOT DEFINED PEAK_SOURCE_ROOT)
+    message(FATAL_ERROR "PEAK_SOURCE_ROOT is required")
+endif()
+if(NOT DEFINED PEAK_HOST_C_COMPILER)
+    message(FATAL_ERROR "PEAK_HOST_C_COMPILER is required")
+endif()
+
+include("${PEAK_SOURCE_ROOT}/cmake/exec-platform.cmake")
+peak_exec_configure_platform_support()
+if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)
+    message(FATAL_ERROR "the platform selection probe enabled raw syscalls")
+endif()
+if(PEAK_DETACH_HELPER_SUPPORTED)
+    message(FATAL_ERROR "the platform selection probe enabled the detach helper")
+endif()
+
+# This selection probe verifies that unsupported platform metadata cannot
+# initialize either architecture-specific source path or helper construction.
+if(DEFINED CMAKE_ASM_COMPILER)
+    message(FATAL_ERROR "platform selection shape initialized an ASM compiler")
+endif()
+
+peak_exec_enable_raw_syscall_language()
+set(probe_sources portable_probe.c)
+set(trampoline_source
+    "${PEAK_SOURCE_ROOT}/src/exec_raw_syscall_trampoline.S")
+peak_exec_append_raw_syscall_trampoline(
+    probe_sources "${trampoline_source}")
+
+if(NOT "${probe_sources}" STREQUAL "portable_probe.c")
+    message(FATAL_ERROR
+        "platform selection shape selected unexpected production sources: "
+        "${probe_sources}")
+endif()
+
+get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+list(FIND enabled_languages "ASM" asm_language_index)
+if(NOT asm_language_index EQUAL -1)
+    message(FATAL_ERROR "platform selection shape enabled ASM: ${enabled_languages}")
+endif()
+list(FIND probe_sources "${trampoline_source}" trampoline_source_index)
+if(NOT trampoline_source_index EQUAL -1)
+    message(FATAL_ERROR
+        "platform selection shape selected the production syscall trampoline")
+endif()
+
+if(PEAK_DETACH_HELPER_SUPPORTED)
+    add_executable(peak_detach_helper_selection_probe portable_probe.c)
+endif()
+if(TARGET peak_detach_helper_selection_probe)
+    message(FATAL_ERROR "platform selection shape selected detach-helper construction")
+endif()
+
+set(probe_object "${CMAKE_CURRENT_BINARY_DIR}/portable_probe.o")
+add_custom_command(
+    OUTPUT "${probe_object}"
+    COMMAND "${PEAK_HOST_C_COMPILER}" -c
+            "${CMAKE_CURRENT_SOURCE_DIR}/portable_probe.c"
+            -o "${probe_object}"
+    DEPENDS ${probe_sources}
+    VERBATIM)
+add_custom_target(peak_exec_platform_selection_probe ALL DEPENDS "${probe_object}")
+message(STATUS
+    "peak_exec_platform_selection_configure_ok target=${CMAKE_SYSTEM_NAME}/"
+    "${CMAKE_SYSTEM_PROCESSOR} raw=${PEAK_EXEC_RAW_SYSCALL_SUPPORTED} "
+    "detach_helper=${PEAK_DETACH_HELPER_SUPPORTED}")

--- a/test/exec_chain/platform_probe/portable_probe.c
+++ b/test/exec_chain/platform_probe/portable_probe.c
@@ -1,0 +1,4 @@
+int peak_exec_platform_selection_ok(void)
+{
+    return 1;
+}

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -23,6 +23,7 @@ MODE_TO_APP_ARG = {
     "exec_checkpoint_write_target_no_reentry": "execv-write-target-success",
     "execv_zero_call_checkpoint": "execv-zero-call",
     "exec_checkpoint_disabled": "execv-success",
+    "exec_checkpoint_direct_disabled": "exec-checkpoint-direct-disabled",
     "exec_bad_stats_path_nonfatal": "execv-success",
     "execve_custom_env_injection": "execve-custom-env",
     "execve_call_env_optin_default_bypass": (
@@ -177,6 +178,12 @@ MODE_TO_APP_ARG = {
     "posix_spawn_explicit_peak_env_preserved": "posix-spawn-explicit-peak-env",
     "exec_checkpoint_concurrent_fini_callbacks": "exec-concurrent-fini-callbacks",
     "exec_checkpoint_snapshot_lock_contention": "exec-checkpoint-snapshot-lock-contention",
+    "exec_checkpoint_statistics_snapshot_contention": (
+        "exec-checkpoint-statistics-snapshot-contention"
+    ),
+    "exec_checkpoint_statistics_shadow_invalidation": (
+        "exec-checkpoint-statistics-shadow-invalidation"
+    ),
     "exec_checkpoint_fork_child_fini": "exec-checkpoint-fork-child-fini",
     "text_output_not_corrupted": "exec-failure",
 }
@@ -215,7 +222,9 @@ NO_EXEC_CHECKPOINT_MODES = {
     "raw_syscall_execve_backend_disabled_injection",
     "raw_syscall_execve_observer_bypass",
     "exec_checkpoint_disabled",
+    "exec_checkpoint_direct_disabled",
     "exec_checkpoint_concurrent_fini_callbacks",
+    "exec_checkpoint_statistics_shadow_invalidation",
     "execve_child_checkpoint_disabled",
     "exec_bad_stats_path_nonfatal",
     "raw_syscall_nonexec_passthrough",
@@ -288,6 +297,8 @@ CHECKPOINT_ONLY_MODES = CHECKPOINT_REQUIRED_MODES
 PARENT_CALL_COUNT_EXEMPT_MODES = frozenset({
     "execv_zero_call_checkpoint",
     "exec_checkpoint_write_target_no_reentry",
+    "exec_checkpoint_statistics_snapshot_contention",
+    "exec_checkpoint_statistics_shadow_invalidation",
 })
 
 POSTFORK_FALLBACK_OBSERVER_MODES = frozenset({
@@ -938,6 +949,8 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
         env["EXEC_CHAIN_CHILD_STATS_PREFIX"] = "peak_stats"
     if args.mode == "exec_checkpoint_disabled":
         env["PEAK_EXEC_CHECKPOINT"] = "0"
+    if args.mode == "exec_checkpoint_direct_disabled":
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
     if args.mode == "execve_propagate_disabled":
         env["PEAK_EXEC_PROPAGATE_PEAK_ENV"] = "0"
     if args.mode in {"execve_chain_disabled", "posix_spawn_chain_disabled"}:
@@ -1435,6 +1448,10 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(target_count(exec_files) == 0,
                 f"zero-call checkpoint recorded target calls: {exec_files}")
 
+    if args.mode == "exec_checkpoint_direct_disabled":
+        require("checkpoint_direct_disabled=1 errno_preserved=1 success=1" in output,
+                f"direct disabled checkpoint did not fail closed\n{output}")
+
     if args.mode == "exec_checkpoint_write_target_no_reentry":
         require("parent_write_before_exec" in output,
                 f"missing parent write marker\n{output}")
@@ -1780,6 +1797,31 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require("checkpoint_snapshot_lock_contention=1 errno_preserved=1 "
                 "missing_exec_enoent=1 cleanup=1 repeatable=1 success=1" in output,
                 f"checkpoint contention did not skip and clean up\n{output}")
+
+    if args.mode == "exec_checkpoint_statistics_snapshot_contention":
+        require("checkpoint_statistics_contention=1 busy_observed=1 "
+                "coherent_tuple=1 success=1" in output,
+                f"checkpoint statistics contention was not observed\n{output}")
+        rows = []
+        for path in exec_files:
+            rows.extend(csv.DictReader(path.open(encoding="utf-8")))
+        target_rows = [row for row in rows if row.get("function") == TARGET]
+        require(target_rows,
+                f"missing statistics contention checkpoint row: {exec_files}")
+        for row in target_rows:
+            require(int(row["count"]) == 1 and
+                    float(row["call_max_s"]) == 10.0 and
+                    float(row["call_min_s"]) == 10.0 and
+                    float(row["total_s"]) == 170.0 and
+                    float(row["exclusive_s"]) == 85.0,
+                    f"checkpoint accepted an incoherent statistics tuple: {row}")
+
+    if args.mode == "exec_checkpoint_statistics_shadow_invalidation":
+        require("checkpoint_shadow_invalidation=1 contender_returned=1 "
+                "errno_preserved=1 no_artifact=1 success=1" in output,
+                f"checkpoint shadow invalidation was not observed\n{output}")
+        require(not exec_files,
+                f"invalid shadow checkpoint left artifacts: {exec_files}")
 
     if args.mode == "exec_failure_non_destructive":
         require(f"exec_failure_errno={errno.ENOENT}" in output,

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -29,6 +29,13 @@ MODE_TO_APP_ARG = {
     "execve_preflight_unavailable_injection": "execve-custom-env",
     "execve_child_peak_env_only_injection": "execve-child-peak-env-only",
     "execve_null_env_injection": "execve-null-env",
+    "execve_loader_path_missing": "execve-loader-path-missing",
+    "execve_loader_path_explicit": "execve-loader-path-explicit",
+    "execve_loader_path_empty": "execve-loader-path-empty",
+    "execve_loader_path_duplicate": "execve-loader-path-duplicate",
+    "execve_loader_path_preload_present": "execve-loader-path-preload-present",
+    "execve_loader_path_chain_disabled": "execve-loader-path-chain-disabled",
+    "execve_loader_path_secure_skip": "execve-loader-path-secure",
     "execve_large_env_injection": "execve-large-env",
     "execve_env_build_failure_passthrough": "execve-custom-env",
     "execve_bad_env_failure_non_destructive": "execve-bad-env",
@@ -79,6 +86,12 @@ MODE_TO_APP_ARG = {
     "vfork_execle_parent_exec": "vfork-execle-parent-exec",
     "fork_custom_env_execve_chain": "fork-custom-env-execve",
     "vfork_custom_env_execve_chain": "vfork-custom-env-execve",
+    "fork_loader_path": "fork-loader-path",
+    "vfork_loader_path": "vfork-loader-path",
+    "fork_loader_path_secure_skip": "fork-loader-path-secure",
+    "vfork_loader_path_secure_skip": "vfork-loader-path-secure",
+    "vfork_loader_path_preload_present": "vfork-loader-path-preload-present",
+    "fork_parent_env_exhaustion": "fork-parent-env-exhaustion",
     "vfork_custom_env_execle_chain": "vfork-custom-env-execle",
     "fork_custom_env_chain_disabled": "fork-custom-env-disabled",
     "vfork_custom_env_chain_disabled": "vfork-custom-env-disabled",
@@ -98,6 +111,7 @@ MODE_TO_APP_ARG = {
     # buffer.  Inputs beyond either bound deliberately use libc's original envp.
     "vfork_env_slots_fallback": "vfork-env-slots-fallback",
     "vfork_long_preload_fallback": "vfork-long-preload-fallback",
+    "vfork_preload_entries_fallback": "vfork-preload-entries-fallback",
     "no_duplicate_ld_preload": "duplicate-preload",
     "no_duplicate_ld_preload_whitespace": "duplicate-preload-whitespace",
     "no_duplicate_ld_preload_env_entries": "duplicate-preload-entry",
@@ -200,6 +214,18 @@ CAPACITY_PASSTHROUGH_MODES = {
     "vfork_env_slots_fallback": ("env-slots", "large-env", 0),
     "vfork_long_preload_fallback": ("long-preload", "postfork-long-preload", 1),
 }
+
+LOADER_SENTINEL = "/tmp/peak-parent-loader-sentinel"
+
+
+def loader_test_value():
+    original = os.environ.get("LD_LIBRARY_PATH", "")
+    return f"{LOADER_SENTINEL}{os.pathsep}{original}" if original else LOADER_SENTINEL
+
+
+def child_loader_test_value():
+    original = os.environ.get("LD_LIBRARY_PATH", "")
+    return f"/tmp/child-loader{os.pathsep}{original}" if original else "/tmp/child-loader"
 
 NATIVE_REFERENCE_MODES = {
     "execve_bad_env_failure_non_destructive",
@@ -428,6 +454,47 @@ def install_path_fixture(tmpdir: Path, exe: Path):
     return bindir, blocked_dir
 
 
+def install_chain_disabled_observer(tmpdir: Path):
+    observer = tmpdir / "chain-disabled-observer.py"
+    observer.write_text(
+        """#!/usr/bin/env python3
+import os
+
+
+def value(name):
+    return os.environ.get(name, "<missing>")
+
+
+preload = os.environ.get("LD_PRELOAD", "")
+loader_path = os.environ.get("LD_LIBRARY_PATH")
+print(
+    "ld_preload_libpeak_count={} ld_preload_env_entries={} "
+    "ld_preload_extra_count=0 peak_target={} peak_statslog={} "
+    "marker={} peak_exec_chain={} peak_exec_checkpoint={} "
+    "peak_exec_propagate={} ld_library_path_env_entries={} "
+    "ld_library_path_0={} ld_library_path_1={} "
+    "chain_disabled_observer={}".format(
+        sum("libpeak" in entry for entry in preload.split()),
+        int(bool(preload)),
+        value("PEAK_TARGET"),
+        value("PEAK_STATSLOG_PATH"),
+        value("EXEC_CHAIN_TEST_MARKER"),
+        value("PEAK_EXEC_CHAIN"),
+        value("PEAK_EXEC_CHECKPOINT"),
+        value("PEAK_EXEC_PROPAGATE_PEAK_ENV"),
+        int(loader_path is not None),
+        loader_path if loader_path is not None else "<missing>",
+        "<missing>",
+        value("EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER"),
+    )
+)
+""",
+        encoding="utf-8",
+    )
+    observer.chmod(0o755)
+    return observer
+
+
 def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool):
     env = os.environ.copy()
     for name in list(env):
@@ -464,7 +531,12 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
         env["PEAK_EXEC_PROPAGATE_PEAK_ENV"] = "0"
     if args.mode in {"execve_chain_disabled", "posix_spawn_chain_disabled"}:
         env["PEAK_EXEC_CHAIN"] = "0"
-    if args.mode == "execve_secure_skip":
+    if args.mode in {
+        "execve_secure_skip",
+        "execve_loader_path_secure_skip",
+        "fork_loader_path_secure_skip",
+        "vfork_loader_path_secure_skip",
+    }:
         env["PEAK_TEST_EXEC_AT_SECURE"] = "1"
     if args.mode in {
         "execve_env_build_failure_passthrough",
@@ -472,6 +544,37 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
         "posix_spawnp_env_build_failure_passthrough",
     }:
         env["PEAK_TEST_EXEC_ENV_BUILD_FAIL"] = "1"
+    if args.mode in {
+        "execve_null_env_injection",
+        "execve_loader_path_missing",
+        "execve_loader_path_explicit",
+        "execve_loader_path_empty",
+        "execve_loader_path_duplicate",
+        "execve_loader_path_preload_present",
+        "execve_loader_path_chain_disabled",
+        "execve_loader_path_secure_skip",
+        "fork_loader_path",
+        "vfork_loader_path",
+        "fork_loader_path_secure_skip",
+        "vfork_loader_path_secure_skip",
+        "posix_spawn_null_env_injection",
+        "vfork_env_slots_fallback",
+        "vfork_long_preload_fallback",
+        "vfork_preload_entries_fallback",
+    }:
+        env["LD_LIBRARY_PATH"] = loader_test_value()
+    if args.mode == "execve_loader_path_explicit":
+        env["EXEC_CHAIN_TEST_CHILD_LOADER_PATH"] = child_loader_test_value()
+    if args.mode == "execve_loader_path_duplicate":
+        env["EXEC_CHAIN_TEST_CHILD_LOADER_PATH"] = child_loader_test_value()
+        env["EXEC_CHAIN_TEST_CHILD_LOADER_PATH_SECOND"] = (
+            f"/tmp/child-loader-second{os.pathsep}"
+            f"{os.environ.get('LD_LIBRARY_PATH', '')}"
+        )
+    if args.mode == "execve_loader_path_chain_disabled":
+        env["EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER"] = str(
+            install_chain_disabled_observer(tmpdir)
+        )
     if args.mode in {
         "posix_spawn_resolver_null_preserves_errno",
         "posix_spawnp_resolver_null_preserves_errno",
@@ -605,6 +708,21 @@ def require_single_ld_env(output):
             f"expected one LD_PRELOAD env entry\n{output}")
 
 
+def require_loader_paths(output, expected):
+    match = re.search(r"(?:^|\s)ld_library_path_env_entries=(\d+)(?:\s|$)",
+                      output)
+    require(match is not None, f"missing LD_LIBRARY_PATH count\n{output}")
+    require(int(match.group(1)) == len(expected),
+            f"unexpected LD_LIBRARY_PATH entries\n{output}")
+    actual = {}
+    for index, value in re.findall(
+            r"(?:^|\s)ld_library_path_(\d+)=(.*?)(?=\sld_library_path_\d+=|\n|$)",
+            output):
+        actual[int(index)] = value
+    require([actual.get(index) for index in range(len(expected))] == expected,
+            f"LD_LIBRARY_PATH entries were not preserved exactly: {actual}\n{output}")
+
+
 def check_common(args, proc, tmpdir: Path, native_observation=None):
     output = proc.stdout
     exec_files, final_files = csv_files(tmpdir)
@@ -660,6 +778,7 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(f"marker={marker}" in output,
                 f"capacity fallback did not preserve the native child marker\n{output}")
         require_ld_count(output, 0)
+        require_loader_paths(output, [])
         require(f"ld_preload_env_entries={ld_preload_env_entries}" in output,
                 f"capacity fallback changed the native LD_PRELOAD environment\n{output}")
         for name in (
@@ -697,6 +816,11 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         "raw_syscall_execve_custom_env_injection",
         "execve_preflight_unavailable_injection",
         "execve_null_env_injection",
+        "execve_loader_path_missing",
+        "execve_loader_path_explicit",
+        "execve_loader_path_empty",
+        "execve_loader_path_duplicate",
+        "execve_loader_path_preload_present",
         "execve_large_env_injection",
         "fexecve_custom_env_injection",
         "fexecve_preflight_unavailable_injection",
@@ -720,6 +844,10 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         "vfork_execle_parent_exec",
         "fork_custom_env_execve_chain",
         "vfork_custom_env_execve_chain",
+        "fork_loader_path",
+        "vfork_loader_path",
+        "fork_loader_path_secure_skip",
+        "vfork_loader_path_secure_skip",
         "vfork_custom_env_execle_chain",
         "fork_custom_env_chain_disabled",
         "vfork_custom_env_chain_disabled",
@@ -737,6 +865,7 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         "vfork_bad_env_string_efault",
         "vfork_env_slots_fallback",
         "vfork_long_preload_fallback",
+        "vfork_preload_entries_fallback",
         "no_duplicate_ld_preload",
         "no_duplicate_ld_preload_whitespace",
         "no_duplicate_ld_preload_env_entries",
@@ -813,14 +942,42 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require_ld_count(check_text, 1)
         require_single_ld_env(check_text)
 
+    expected_loader_paths = {
+        "execve_null_env_injection": [loader_test_value()],
+        "execve_loader_path_missing": [loader_test_value()],
+        "execve_loader_path_explicit": [child_loader_test_value()],
+        "execve_loader_path_empty": [""],
+        "execve_loader_path_duplicate": [
+            child_loader_test_value(),
+            f"/tmp/child-loader-second{os.pathsep}"
+            f"{os.environ.get('LD_LIBRARY_PATH', '')}",
+        ],
+        "execve_loader_path_preload_present": [],
+        "execve_loader_path_chain_disabled": [],
+        "execve_loader_path_secure_skip": [],
+        "fork_loader_path": [loader_test_value()],
+        "vfork_loader_path": [loader_test_value()],
+        "fork_loader_path_secure_skip": [],
+        "vfork_loader_path_secure_skip": [],
+        "vfork_loader_path_preload_present": [],
+        "fork_parent_env_exhaustion": [],
+        "posix_spawn_null_env_injection": [loader_test_value()],
+    }
+    if args.mode in expected_loader_paths:
+        require_loader_paths(output, expected_loader_paths[args.mode])
+
     if args.mode in {
         "fork_custom_env_chain_disabled",
         "vfork_custom_env_chain_disabled",
         "fork_raw_syscall_chain_disabled",
+        "execve_loader_path_chain_disabled",
     }:
         require_ld_count(output, 0)
         require("peak_exec_chain=0" in output,
                 f"child PEAK_EXEC_CHAIN=0 was not preserved\n{output}")
+        if args.mode == "execve_loader_path_chain_disabled":
+            require("chain_disabled_observer=<missing>" in output,
+                    f"child environment inherited harness-only observer path\n{output}")
 
     if args.mode in {
         "fork_custom_env_execve_chain",
@@ -830,6 +987,10 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         "vfork_custom_env_chain_disabled",
         "fork_raw_syscall_custom_env_chain",
         "fork_raw_syscall_chain_disabled",
+        "fork_loader_path",
+        "vfork_loader_path",
+        "fork_loader_path_secure_skip",
+        "vfork_loader_path_secure_skip",
     }:
         require("parent_env_unchanged=1" in output,
                 f"post-fork child changed parent environment\n{output}")
@@ -920,9 +1081,35 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
     if args.mode in {
         "execve_chain_disabled",
         "execve_secure_skip",
+        "execve_loader_path_secure_skip",
+        "fork_loader_path_secure_skip",
+        "vfork_loader_path_secure_skip",
         "posix_spawn_chain_disabled",
+        "fork_parent_env_exhaustion",
     }:
         require_ld_count(output, 0)
+
+    if args.mode in {
+        "execve_loader_path_preload_present",
+        "vfork_loader_path_preload_present",
+    }:
+        require_ld_count(output, 1)
+        require("marker=loader-path-preload-present" in output,
+                f"preexisting libpeak child environment was not preserved\n{output}")
+
+    if args.mode == "fork_parent_env_exhaustion":
+        require("parent_env_exhaustion_passthrough=1" in output,
+                f"unterminated parent environment was augmented\n{output}")
+        require("marker=parent-env-exhaustion" in output,
+                f"original child environment was not retained\n{output}")
+
+    if args.mode == "vfork_preload_entries_fallback":
+        require("postfork_preload_entries_passthrough=1" in output,
+                f"unterminated preload vector was augmented\n{output}")
+        require_ld_count(output, 0)
+        require("ld_preload_env_entries=256" in output,
+                f"unterminated preload vector was truncated\n{output}")
+        require_loader_paths(output, [])
 
     if args.mode == "exec_bad_stats_path_nonfatal":
         require("exec_child_ok" in output,

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -155,6 +155,7 @@ MODE_TO_APP_ARG = {
     "posix_spawnp_bad_argv_failure_non_destructive": "posix-spawnp-bad-argv",
     "posix_spawn_explicit_peak_env_preserved": "posix-spawn-explicit-peak-env",
     "exec_checkpoint_concurrent_fini_callbacks": "exec-concurrent-fini-callbacks",
+    "exec_checkpoint_snapshot_lock_contention": "exec-checkpoint-snapshot-lock-contention",
     "exec_checkpoint_fork_child_fini": "exec-checkpoint-fork-child-fini",
     "text_output_not_corrupted": "exec-failure",
 }
@@ -214,6 +215,43 @@ CAPACITY_PASSTHROUGH_MODES = {
     "vfork_env_slots_fallback": ("env-slots", "large-env", 0),
     "vfork_long_preload_fallback": ("long-preload", "postfork-long-preload", 1),
 }
+
+FAILURE_PATH_MODES = {
+    "raw_syscall_execve_failure_non_destructive",
+    "exec_failure_non_destructive",
+    "execvp_enoent_failure",
+    "execvp_enotdir_enoent_failure",
+    "execvp_enotdir_enoent_fallback",
+    "execvp_eacces_failure",
+    "execvp_eacces_fallback",
+    "execvp_enoent_fallback",
+    "text_output_not_corrupted",
+}
+
+CHECKPOINT_OPTIONAL_BASE_MODES = frozenset(
+    set(CAPACITY_PASSTHROUGH_MODES) |
+    FAILURE_PATH_MODES |
+    {"vfork_preload_entries_fallback"}
+)
+
+# Fork/vfork cases exercise the child lifecycle and parent state restoration
+# with the controller active.  The dedicated direct-exec cases below make the
+# best-effort checkpoint deterministic by quiescing before the exec boundary.
+ACTIVE_CONTROLLER_LIFECYCLE_MODES = frozenset(
+    mode for mode in MODE_TO_APP_ARG
+    if mode.startswith(("fork_", "vfork_"))
+)
+CHECKPOINT_OPTIONAL_MODES = frozenset(
+    set(CHECKPOINT_OPTIONAL_BASE_MODES) | ACTIVE_CONTROLLER_LIFECYCLE_MODES
+)
+CHECKPOINT_REQUIRED_MODES = frozenset(
+    set(MODE_TO_APP_ARG) - NO_EXEC_CHECKPOINT_MODES - CHECKPOINT_OPTIONAL_MODES
+)
+CHECKPOINT_ONLY_MODES = CHECKPOINT_REQUIRED_MODES
+PARENT_CALL_COUNT_EXEMPT_MODES = frozenset({
+    "execv_zero_call_checkpoint",
+    "exec_checkpoint_write_target_no_reentry",
+})
 
 POSTFORK_FALLBACK_OBSERVER_MODES = frozenset({
     "vfork_env_slots_fallback",
@@ -885,8 +923,11 @@ def run_fixture(args, tmpdir: Path, preload=True):
     bindir, blocked_dir = install_path_fixture(tmpdir, exe)
     env = base_env(args, tmpdir, bindir, blocked_dir, preload=preload)
     app_arg = MODE_TO_APP_ARG[args.mode]
+    command = [str(exe), app_arg]
+    if preload and args.mode in CHECKPOINT_ONLY_MODES:
+        command.append("--quiesce-controller")
     return subprocess.run(
-        [str(exe), app_arg],
+        command,
         cwd=tmpdir,
         env=env,
         text=True,
@@ -919,6 +960,43 @@ def target_count(paths, function=TARGET):
                 if row.get("function") == function:
                     total += int(row.get("count", "0"))
     return total
+
+
+def require_parent_checkpoint_calls(mode, exec_files):
+    if mode in PARENT_CALL_COUNT_EXEMPT_MODES:
+        return
+    if mode in ACTIVE_CONTROLLER_LIFECYCLE_MODES and not exec_files:
+        return
+    if mode not in CHECKPOINT_ONLY_MODES | ACTIVE_CONTROLLER_LIFECYCLE_MODES:
+        return
+    require(target_count(exec_files) >= 5,
+            f"checkpoint missed parent calls: {exec_files}")
+
+
+def run_checkpoint_contract_self_test():
+    with tempfile.TemporaryDirectory() as directory:
+        workdir = Path(directory)
+        valid = workdir / "peak_stats-p1-exec1.csv"
+        valid.write_text(
+            "function,count\npeak_exec_chain_hot_target,5\n",
+            encoding="utf-8",
+        )
+        require_parent_checkpoint_calls("fork_child_exec_parent_exec", [])
+        require_parent_checkpoint_calls("fork_child_exec_parent_exec", [valid])
+        try:
+            malformed = workdir / "peak_stats-p1-exec2.csv"
+            malformed.write_text(
+                "function,count\npeak_exec_chain_hot_target,4\n",
+                encoding="utf-8",
+            )
+            require_parent_checkpoint_calls(
+                "vfork_child_exec_parent_exec", [malformed])
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                "active-controller malformed checkpoint was accepted")
+    print("exec_chain_checkpoint_contract_ok")
 
 
 def require_bad_env_artifacts(mode, final_files, exec_files, operation):
@@ -1118,9 +1196,9 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
                 f"capacity fallback parent exec did not retain native success\n{output}")
         return
 
-    if args.mode not in NO_EXEC_CHECKPOINT_MODES:
+    if args.mode in CHECKPOINT_REQUIRED_MODES:
         require(exec_files, f"missing exec checkpoint for {args.mode}\n{output}")
-    else:
+    elif args.mode in NO_EXEC_CHECKPOINT_MODES:
         require(not exec_files,
                 f"unexpected exec checkpoint for {args.mode}: {exec_files}\n{output}")
 
@@ -1134,68 +1212,12 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(target_count(exec_files, "write") == 1,
                 "checkpoint I/O re-entered the profiled write target")
 
-    if args.mode in {
-        "execv_success_checkpoint",
-        "execve_custom_env_injection",
-        "raw_syscall_execve_custom_env_injection",
-        "execve_preflight_unavailable_injection",
-        "execve_null_env_injection",
-        "execve_loader_path_missing",
-        "execve_loader_path_explicit",
-        "execve_loader_path_empty",
-        "execve_loader_path_duplicate",
-        "execve_loader_path_preload_present",
-        "execve_large_env_injection",
-        "fexecve_custom_env_injection",
-        "fexecve_preflight_unavailable_injection",
-        "execveat_custom_env_injection",
-        "raw_syscall_execveat_custom_env_injection",
-        "execl_success_checkpoint",
-        "execlp_path_search",
-        "execle_custom_env_injection",
-        "execvp_path_search",
-        "execvp_empty_path_component",
-        "helper_named_exec_still_checkpointed",
-        "execvpe_caller_path_child_env_ignored",
-        "execve_child_peak_env_only_injection",
-        "execve_child_chain_disabled",
-        "execve_child_propagate_disabled",
-        "fork_child_exec_parent_exec",
-        "vfork_child_exec_parent_exec",
-        "vfork_child_failed_exec_parent_exec",
-        "vfork_execl_parent_exec",
-        "vfork_execlp_parent_exec",
-        "vfork_execle_parent_exec",
-        "fork_custom_env_execve_chain",
-        "vfork_custom_env_execve_chain",
-        "fork_loader_path",
-        "vfork_loader_path",
-        "fork_loader_path_secure_skip",
-        "vfork_loader_path_secure_skip",
-        "vfork_custom_env_execle_chain",
-        "fork_custom_env_chain_disabled",
-        "vfork_custom_env_chain_disabled",
-        "vfork_custom_env_execvpe_chain",
-        "vfork_custom_env_execvp_chain",
-        "vfork_custom_env_execlp_chain",
-        "vfork_custom_env_fexecve_chain",
-        "vfork_custom_env_execveat_chain",
-        "fork_raw_syscall_custom_env_chain",
-        "fork_raw_syscall_chain_disabled",
-        "vfork_raw_syscall_execveat_chain",
-        "fork_bad_env_vector_efault",
-        "vfork_bad_env_vector_efault",
-        "fork_bad_env_string_efault",
-        "vfork_bad_env_string_efault",
-        "vfork_env_slots_fallback",
-        "vfork_long_preload_fallback",
-        "vfork_preload_entries_fallback",
-        "no_duplicate_ld_preload",
-        "no_duplicate_ld_preload_whitespace",
-        "no_duplicate_ld_preload_env_entries",
-    }:
-        require(target_count(exec_files) >= 5,
-                f"checkpoint missed parent calls: {exec_files}")
+    require_parent_checkpoint_calls(args.mode, exec_files)
+
+    if args.mode == "fork_child_exec_parent_exec":
+        require(output.count("exec_child_ok") == 2,
+                "fork child exec and parent exec did not both complete\n"
+                f"{output}")
 
     if args.mode in {
         "execve_env_build_failure_passthrough",
@@ -1473,6 +1495,11 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require("exec_child_ok" in output,
                 f"bad checkpoint path made exec fail\n{output}")
 
+    if args.mode == "exec_checkpoint_snapshot_lock_contention":
+        require("checkpoint_snapshot_lock_contention=1 errno_preserved=1 "
+                "missing_exec_enoent=1 cleanup=1 repeatable=1 success=1" in output,
+                f"checkpoint contention did not skip and clean up\n{output}")
+
     if args.mode == "exec_failure_non_destructive":
         require(f"exec_failure_errno={errno.ENOENT}" in output,
                 f"missing exec failure marker\n{output}")
@@ -1617,6 +1644,8 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
 
 
 def main():
+    if sys.argv[1:] == ["--self-test-checkpoint-contract"]:
+        return run_checkpoint_contract_self_test()
     args = parse_args()
     with tempfile.TemporaryDirectory(
         prefix=f"peak-exec-chain-{args.mode}-",

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -215,7 +215,179 @@ CAPACITY_PASSTHROUGH_MODES = {
     "vfork_long_preload_fallback": ("long-preload", "postfork-long-preload", 1),
 }
 
+POSTFORK_FALLBACK_OBSERVER_MODES = frozenset({
+    "vfork_env_slots_fallback",
+    "vfork_long_preload_fallback",
+    "vfork_preload_entries_fallback",
+})
+
+POSTFORK_FALLBACK_EXPECTATIONS = {
+    "vfork_env_slots_fallback": {
+        "marker": "large-env",
+        "preload_entries": "0",
+        "preload_length": "0",
+        "preload_all_x": "1",
+        "pad_validated_count": "512",
+        "pad_mismatch_count": "0",
+        "path": "observer",
+        "observer_mode": "capacity-env-slots",
+        "parent_contract": (
+            "input_entries=514 input_pad_validated_count=512 "
+            "input_pad_mismatch_count=0 input_preload_entries=0 "
+            "input_preload_length=0 input_preload_all_x=1 "
+            "input_path_entries=1 input_loader_path_entries=0 "
+            "input_terminator_null=1"
+        ),
+    },
+    "vfork_long_preload_fallback": {
+        "marker": "postfork-long-preload",
+        "preload_entries": "1",
+        "preload_length": "8192",
+        "preload_all_x": "1",
+        "pad_validated_count": "0",
+        "pad_mismatch_count": "0",
+        "path": "observer",
+        "observer_mode": "capacity-long-preload",
+        "parent_contract": (
+            "input_entries=3 input_pad_validated_count=0 "
+            "input_pad_mismatch_count=0 input_preload_entries=1 "
+            "input_preload_length=8192 input_preload_all_x=1 "
+            "input_path_entries=1 input_loader_path_entries=0 "
+            "input_terminator_null=1"
+        ),
+    },
+    "vfork_preload_entries_fallback": {
+        "marker": "<missing>",
+        "preload_entries": "1",
+        "preload_length": "0",
+        "preload_all_x": "1",
+        "pad_validated_count": "0",
+        "pad_mismatch_count": "0",
+        "path": None,
+        "observer_mode": "capacity-preload-entries",
+        "parent_contract": (
+            "input_entries=256 input_preload_entries=256 "
+            "input_nonempty_preload_entries=0 "
+            "input_path_entries=0 input_loader_path_entries=0 "
+            "input_terminator_null=1"
+        ),
+    },
+}
+
 LOADER_SENTINEL = "/tmp/peak-parent-loader-sentinel"
+EXTRA_PRELOAD_TOKEN_A = "/tmp/peak_exec_chain_extra_preload_a.so"
+EXTRA_PRELOAD_TOKEN_B = "/tmp/peak_exec_chain_extra_preload_b.so"
+LOADER_OBSERVER_ENV = "EXEC_CHAIN_TEST_LOADER_OBSERVER"
+
+NO_LOADER_MODE_EXPECTATIONS = {
+    "execve_loader_path_chain_disabled": {
+        "marker": "loader-path-disabled",
+        "peak_exec_chain": "0",
+        "peak_target": "<missing>",
+        "peak_statslog": "<missing>",
+        "secure_test_hook": "<missing>",
+        "preload_count": "0",
+        "preload_entries": "0",
+        "extra_count": "0",
+        "use_observer": True,
+    },
+    "execve_loader_path_secure_skip": {
+        "marker": "loader-path-secure",
+        "peak_exec_chain": "<missing>",
+        "peak_target": TARGET,
+        "peak_statslog": "peak_stats",
+        "secure_test_hook": "1",
+        "preload_count": "0",
+        "preload_entries": "0",
+        "extra_count": "0",
+        "use_observer": True,
+    },
+    "execve_loader_path_preload_present": {
+        "marker": "loader-path-preload-present",
+        "peak_exec_chain": "<missing>",
+        "peak_target": TARGET,
+        "peak_statslog": "peak_stats",
+        "secure_test_hook": "<missing>",
+        "preload_count": "1",
+        "preload_entries": "1",
+        "extra_count": "1",
+        "use_observer": False,
+    },
+    "fork_loader_path_secure_skip": {
+        "marker": "postfork-loader-path",
+        "peak_exec_chain": "<missing>",
+        "peak_target": "<missing>",
+        "peak_statslog": "<missing>",
+        "secure_test_hook": "<missing>",
+        "preload_count": "0",
+        "preload_entries": "0",
+        "extra_count": "0",
+        "use_observer": True,
+    },
+    "vfork_loader_path_secure_skip": {
+        "marker": "postfork-loader-path",
+        "peak_exec_chain": "<missing>",
+        "peak_target": "<missing>",
+        "peak_statslog": "<missing>",
+        "secure_test_hook": "<missing>",
+        "preload_count": "0",
+        "preload_entries": "0",
+        "extra_count": "0",
+        "use_observer": True,
+    },
+    "vfork_loader_path_preload_present": {
+        "marker": "loader-path-preload-present",
+        "peak_exec_chain": "<missing>",
+        "peak_target": TARGET,
+        "peak_statslog": "peak_stats",
+        "secure_test_hook": "<missing>",
+        "preload_count": "1",
+        "preload_entries": "1",
+        "extra_count": "1",
+        "use_observer": False,
+    },
+    "fork_parent_env_exhaustion": {
+        "marker": "parent-env-exhaustion",
+        "peak_exec_chain": "1",
+        "peak_exec_propagate": "1",
+        "peak_target": "<missing>",
+        "peak_statslog": "<missing>",
+        "secure_test_hook": "<missing>",
+        "preload_count": "0",
+        "preload_entries": "0",
+        "extra_count": "0",
+        "use_observer": True,
+    },
+}
+
+LOADER_OBSERVER_MODES = frozenset(
+    mode
+    for mode, expected in NO_LOADER_MODE_EXPECTATIONS.items()
+    if expected["use_observer"]
+)
+
+OBSERVER_FIELD_NAMES = (
+    "ld_preload_libpeak_count",
+    "ld_preload_env_entries",
+    "ld_preload_extra_count",
+    "peak_target",
+    "peak_statslog",
+    "marker",
+    "peak_exec_chain",
+    "peak_exec_checkpoint",
+    "peak_exec_propagate",
+    "ld_library_path_env_entries",
+    "ld_library_path_0",
+    "ld_library_path_1",
+    "path",
+    "observer_mode",
+    "child_pad_validated_count",
+    "child_pad_mismatch_count",
+    "ld_preload_length",
+    "ld_preload_all_x",
+    "loader_observer",
+    "secure_test_hook",
+)
 
 
 def loader_test_value():
@@ -454,45 +626,139 @@ def install_path_fixture(tmpdir: Path, exe: Path):
     return bindir, blocked_dir
 
 
-def install_chain_disabled_observer(tmpdir: Path):
-    observer = tmpdir / "chain-disabled-observer.py"
-    observer.write_text(
-        """#!/usr/bin/env python3
-import os
+def install_loader_observer(tmpdir: Path):
+    observer = tmpdir / "loader-observer.sh"
+    script = (
+        """#!/bin/sh
+if [ "${LD_PRELOAD+x}" = x ]; then
+    ld_preload_env_entries=1
+    ld_preload_libpeak_count=0
+    ld_preload_extra_count=0
+    saved_ifs=$IFS
+    IFS=":$IFS"
+    set -f
+    for preload_entry in $LD_PRELOAD; do
+        case "$preload_entry" in
+            *libpeak*)
+                ld_preload_libpeak_count=$((ld_preload_libpeak_count + 1))
+                ;;
+        esac
+        case "$preload_entry" in
+            @EXTRA_PRELOAD_TOKEN_A@|@EXTRA_PRELOAD_TOKEN_B@)
+                ld_preload_extra_count=$((ld_preload_extra_count + 1))
+                ;;
+        esac
+    done
+    set +f
+    IFS=$saved_ifs
+else
+    ld_preload_env_entries=0
+    ld_preload_libpeak_count=0
+    ld_preload_extra_count=0
+fi
 
+if [ "${LD_LIBRARY_PATH+x}" = x ]; then
+    ld_library_path_env_entries=1
+    ld_library_path_0=$LD_LIBRARY_PATH
+else
+    ld_library_path_env_entries=0
+    ld_library_path_0='<missing>'
+fi
 
-def value(name):
-    return os.environ.get(name, "<missing>")
+preload_value=${LD_PRELOAD-}
+ld_preload_length=${#preload_value}
+case "$preload_value" in
+    *[!x]*) ld_preload_all_x=0 ;;
+    *) ld_preload_all_x=1 ;;
+esac
 
+child_pad_validated_count=0
+child_pad_mismatch_count=0
+case "${1-}" in
+    capacity-env-slots)
+        pad_index=0
+        while [ "$pad_index" -lt 512 ]; do
+            case "$pad_index" in
+                [0-9]) pad_name=CHILD_PAD_000$pad_index ;;
+                [0-9][0-9]) pad_name=CHILD_PAD_00$pad_index ;;
+                *) pad_name=CHILD_PAD_0$pad_index ;;
+            esac
+            eval "pad_value=\\${$pad_name-}"
+            if [ "$pad_value" = x ]; then
+                child_pad_validated_count=$((child_pad_validated_count + 1))
+            else
+                child_pad_mismatch_count=$((child_pad_mismatch_count + 1))
+            fi
+            pad_index=$((pad_index + 1))
+        done
+        ;;
+esac
 
-preload = os.environ.get("LD_PRELOAD", "")
-loader_path = os.environ.get("LD_LIBRARY_PATH")
-print(
-    "ld_preload_libpeak_count={} ld_preload_env_entries={} "
-    "ld_preload_extra_count=0 peak_target={} peak_statslog={} "
-    "marker={} peak_exec_chain={} peak_exec_checkpoint={} "
-    "peak_exec_propagate={} ld_library_path_env_entries={} "
-    "ld_library_path_0={} ld_library_path_1={} "
-    "chain_disabled_observer={}".format(
-        sum("libpeak" in entry for entry in preload.split()),
-        int(bool(preload)),
-        value("PEAK_TARGET"),
-        value("PEAK_STATSLOG_PATH"),
-        value("EXEC_CHAIN_TEST_MARKER"),
-        value("PEAK_EXEC_CHAIN"),
-        value("PEAK_EXEC_CHECKPOINT"),
-        value("PEAK_EXEC_PROPAGATE_PEAK_ENV"),
-        int(loader_path is not None),
-        loader_path if loader_path is not None else "<missing>",
-        "<missing>",
-        value("EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER"),
+output="ld_preload_libpeak_count=$ld_preload_libpeak_count "
+output="${output}ld_preload_env_entries=$ld_preload_env_entries "
+output="${output}ld_preload_extra_count=$ld_preload_extra_count "
+output="${output}peak_target=${PEAK_TARGET-<missing>} "
+output="${output}peak_statslog=${PEAK_STATSLOG_PATH-<missing>} "
+output="${output}marker=${EXEC_CHAIN_TEST_MARKER-<missing>} "
+output="${output}peak_exec_chain=${PEAK_EXEC_CHAIN-<missing>} "
+output="${output}peak_exec_checkpoint=${PEAK_EXEC_CHECKPOINT-<missing>} "
+output="${output}peak_exec_propagate=${PEAK_EXEC_PROPAGATE_PEAK_ENV-<missing>} "
+output="${output}ld_library_path_env_entries=$ld_library_path_env_entries "
+output="${output}ld_library_path_0=$ld_library_path_0 "
+output="${output}ld_library_path_1=<missing> "
+output="${output}path=${PATH-<missing>} "
+output="${output}observer_mode=${1-<missing>} "
+output="${output}child_pad_validated_count=$child_pad_validated_count "
+output="${output}child_pad_mismatch_count=$child_pad_mismatch_count "
+output="${output}ld_preload_length=$ld_preload_length "
+output="${output}ld_preload_all_x=$ld_preload_all_x "
+output="${output}loader_observer=${EXEC_CHAIN_TEST_LOADER_OBSERVER-<missing>} "
+output="${output}secure_test_hook=${PEAK_TEST_EXEC_AT_SECURE-<missing>}"
+printf '%s\n' "$output"
+"""
+        .replace("@EXTRA_PRELOAD_TOKEN_A@", EXTRA_PRELOAD_TOKEN_A)
+        .replace("@EXTRA_PRELOAD_TOKEN_B@", EXTRA_PRELOAD_TOKEN_B)
     )
-)
-""",
-        encoding="utf-8",
-    )
+    observer.write_text(script, encoding="utf-8")
     observer.chmod(0o755)
+    validate_loader_observer(observer)
     return observer
+
+
+def validate_loader_observer(observer: Path):
+    unavailable_path = observer.parent / "no-external-commands"
+    preload = (
+        f"{EXTRA_PRELOAD_TOKEN_A}:{EXTRA_PRELOAD_TOKEN_A} "
+        f"/tmp/libpeak-one.so\t/tmp/not-an-extra.so\n"
+        f"{EXTRA_PRELOAD_TOKEN_B}:/tmp/libpeak-two.so"
+    )
+    proc = subprocess.run(
+        [str(observer)],
+        env={
+            "PATH": str(unavailable_path),
+            "LD_PRELOAD": preload,
+            "EXEC_CHAIN_TEST_MARKER": "observer-contract",
+        },
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=5,
+    )
+    require(proc.returncode == 0,
+            f"chain-disabled observer contract failed\n{proc.stderr}")
+    require_observer_field(proc.stdout, "ld_preload_libpeak_count", "2")
+    require_observer_field(proc.stdout, "ld_preload_env_entries", "1")
+    require_observer_field(proc.stdout, "ld_preload_extra_count", "3")
+    require_observer_field(proc.stdout, "marker", "observer-contract")
+    require_observer_field(proc.stdout, "ld_library_path_env_entries", "0")
+    require_observer_field(proc.stdout, "path", str(unavailable_path))
+    require_observer_field(proc.stdout, "observer_mode", "<missing>")
+    require_observer_field(proc.stdout, "child_pad_validated_count", "0")
+    require_observer_field(proc.stdout, "child_pad_mismatch_count", "0")
+    require_observer_field(proc.stdout, "ld_preload_length", str(len(preload)))
+    require_observer_field(proc.stdout, "ld_preload_all_x", "0")
+    require_observer_field(proc.stdout, "loader_observer", "<missing>")
+    require_observer_field(proc.stdout, "secure_test_hook", "<missing>")
 
 
 def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool):
@@ -500,6 +766,7 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
     for name in list(env):
         if name.startswith("PEAK_"):
             env.pop(name, None)
+    env.pop(LOADER_OBSERVER_ENV, None)
     if preload:
         env["LD_PRELOAD"] = str(Path(args.libpeak).resolve())
         env["PEAK_TARGET"] = TARGET
@@ -571,10 +838,10 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
             f"/tmp/child-loader-second{os.pathsep}"
             f"{os.environ.get('LD_LIBRARY_PATH', '')}"
         )
-    if args.mode == "execve_loader_path_chain_disabled":
-        env["EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER"] = str(
-            install_chain_disabled_observer(tmpdir)
-        )
+    if args.mode in LOADER_OBSERVER_MODES | POSTFORK_FALLBACK_OBSERVER_MODES:
+        env[LOADER_OBSERVER_ENV] = str(install_loader_observer(tmpdir))
+        # The observer must remain usable without commands found through PATH.
+        env["PATH"] = str(tmpdir / "no-external-commands")
     if args.mode in {
         "posix_spawn_resolver_null_preserves_errno",
         "posix_spawnp_resolver_null_preserves_errno",
@@ -701,6 +968,17 @@ def require_ld_count(output, expected):
             f"expected {expected} libpeak LD_PRELOAD entries\n{output}")
 
 
+def require_observer_field(output, name, expected):
+    next_field = "|".join(re.escape(field) for field in OBSERVER_FIELD_NAMES)
+    match = re.search(
+        rf"(?:^|\s){re.escape(name)}=(.*?)(?=\s(?:{next_field})=|\n|$)",
+        output,
+    )
+    require(match is not None, f"missing observer field {name}\n{output}")
+    require(match.group(1) == expected,
+            f"expected {name}={expected}, got {match.group(1)}\n{output}")
+
+
 def require_single_ld_env(output):
     match = re.search(r"ld_preload_env_entries=(\d+)", output)
     require(match is not None, f"missing LD_PRELOAD env entry count\n{output}")
@@ -716,7 +994,9 @@ def require_loader_paths(output, expected):
             f"unexpected LD_LIBRARY_PATH entries\n{output}")
     actual = {}
     for index, value in re.findall(
-            r"(?:^|\s)ld_library_path_(\d+)=(.*?)(?=\sld_library_path_\d+=|\n|$)",
+            r"(?:^|\s)ld_library_path_(\d+)=(.*?)"
+            r"(?=\s(?:ld_library_path_\d+|path|loader_observer|"
+            r"secure_test_hook)=|\n|$)",
             output):
         actual[int(index)] = value
     require([actual.get(index) for index in range(len(expected))] == expected,
@@ -763,6 +1043,50 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
 
     require(proc.returncode == 0,
             f"fixture exited {proc.returncode}\n{output}")
+
+    expected_fallback_observer_modes = set(CAPACITY_PASSTHROUGH_MODES) | {
+        "vfork_preload_entries_fallback"
+    }
+    require(set(POSTFORK_FALLBACK_OBSERVER_MODES) ==
+            expected_fallback_observer_modes,
+            "post-fork fallback observer audit is incomplete: "
+            f"expected={sorted(expected_fallback_observer_modes)} "
+            f"observed={sorted(POSTFORK_FALLBACK_OBSERVER_MODES)}")
+    require(set(POSTFORK_FALLBACK_EXPECTATIONS) ==
+            expected_fallback_observer_modes,
+            "post-fork fallback assertions are incomplete")
+
+    if args.mode in POSTFORK_FALLBACK_OBSERVER_MODES:
+        expected = POSTFORK_FALLBACK_EXPECTATIONS[args.mode]
+        expected_fields = {
+            "ld_preload_libpeak_count": "0",
+            "ld_preload_env_entries": expected["preload_entries"],
+            "ld_preload_extra_count": "0",
+            "peak_target": "<missing>",
+            "peak_statslog": "<missing>",
+            "marker": expected["marker"],
+            "peak_exec_chain": "<missing>",
+            "peak_exec_checkpoint": "<missing>",
+            "peak_exec_propagate": "<missing>",
+            "ld_library_path_env_entries": "0",
+            "ld_library_path_0": "<missing>",
+            "ld_library_path_1": "<missing>",
+            "observer_mode": expected["observer_mode"],
+            "child_pad_validated_count": expected["pad_validated_count"],
+            "child_pad_mismatch_count": expected["pad_mismatch_count"],
+            "ld_preload_length": expected["preload_length"],
+            "ld_preload_all_x": expected["preload_all_x"],
+            "loader_observer": "<missing>",
+            "secure_test_hook": "<missing>",
+        }
+        if expected["path"] is not None:
+            expected_fields["path"] = (str(tmpdir / "no-external-commands")
+                                       if expected["path"] == "observer" else
+                                       expected["path"])
+        for name, value in expected_fields.items():
+            require_observer_field(output, name, value)
+        require(expected["parent_contract"] in output,
+                f"post-fork fallback input contract changed\n{output}")
 
     if args.mode in CAPACITY_PASSTHROUGH_MODES:
         kind, marker, ld_preload_env_entries = CAPACITY_PASSTHROUGH_MODES[args.mode]
@@ -963,8 +1287,46 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         "fork_parent_env_exhaustion": [],
         "posix_spawn_null_env_injection": [loader_test_value()],
     }
+    no_loader_modes = {
+        mode
+        for mode, expected in expected_loader_paths.items()
+        if expected == []
+    }
+    require(no_loader_modes == set(NO_LOADER_MODE_EXPECTATIONS),
+            "no-loader mode audit is incomplete: "
+            f"expected={sorted(no_loader_modes)} "
+            f"audited={sorted(NO_LOADER_MODE_EXPECTATIONS)}")
     if args.mode in expected_loader_paths:
         require_loader_paths(output, expected_loader_paths[args.mode])
+
+    if args.mode in NO_LOADER_MODE_EXPECTATIONS:
+        mode_expected = NO_LOADER_MODE_EXPECTATIONS[args.mode]
+        if mode_expected["use_observer"]:
+            expected_path = str(tmpdir / "no-external-commands")
+        else:
+            old_path = os.environ.get("PATH", "/bin:/usr/bin")
+            expected_path = f"{tmpdir / 'bin'}{os.pathsep}{old_path}"
+        expected_fields = {
+            "ld_preload_libpeak_count": mode_expected["preload_count"],
+            "ld_preload_env_entries": mode_expected["preload_entries"],
+            "ld_preload_extra_count": mode_expected["extra_count"],
+            "peak_target": mode_expected["peak_target"],
+            "peak_statslog": mode_expected["peak_statslog"],
+            "marker": mode_expected["marker"],
+            "peak_exec_chain": mode_expected["peak_exec_chain"],
+            "peak_exec_checkpoint": "<missing>",
+            "peak_exec_propagate": mode_expected.get(
+                "peak_exec_propagate", "<missing>"
+            ),
+            "ld_library_path_env_entries": "0",
+            "ld_library_path_0": "<missing>",
+            "ld_library_path_1": "<missing>",
+            "path": expected_path,
+            "loader_observer": "<missing>",
+            "secure_test_hook": mode_expected["secure_test_hook"],
+        }
+        for name, expected in expected_fields.items():
+            require_observer_field(output, name, expected)
 
     if args.mode in {
         "fork_custom_env_chain_disabled",
@@ -975,9 +1337,6 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require_ld_count(output, 0)
         require("peak_exec_chain=0" in output,
                 f"child PEAK_EXEC_CHAIN=0 was not preserved\n{output}")
-        if args.mode == "execve_loader_path_chain_disabled":
-            require("chain_disabled_observer=<missing>" in output,
-                    f"child environment inherited harness-only observer path\n{output}")
 
     if args.mode in {
         "fork_custom_env_execve_chain",
@@ -1107,8 +1466,7 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require("postfork_preload_entries_passthrough=1" in output,
                 f"unterminated preload vector was augmented\n{output}")
         require_ld_count(output, 0)
-        require("ld_preload_env_entries=256" in output,
-                f"unterminated preload vector was truncated\n{output}")
+        require_observer_field(output, "ld_preload_env_entries", "1")
         require_loader_paths(output, [])
 
     if args.mode == "exec_bad_stats_path_nonfatal":

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -141,6 +141,7 @@ MODE_TO_APP_ARG = {
     "posix_spawnp_bad_argv_failure_non_destructive": "posix-spawnp-bad-argv",
     "posix_spawn_explicit_peak_env_preserved": "posix-spawn-explicit-peak-env",
     "exec_checkpoint_concurrent_fini_callbacks": "exec-concurrent-fini-callbacks",
+    "exec_checkpoint_fork_child_fini": "exec-checkpoint-fork-child-fini",
     "text_output_not_corrupted": "exec-failure",
 }
 
@@ -193,6 +194,11 @@ NO_EXEC_CHECKPOINT_MODES = {
     "posix_spawnp_preflight_unavailable_bad_env_delegates",
     "posix_spawnp_bad_argv_failure_non_destructive",
     *SPAWN_MODES,
+}
+
+CAPACITY_PASSTHROUGH_MODES = {
+    "vfork_env_slots_fallback": ("env-slots", "large-env", 0),
+    "vfork_long_preload_fallback": ("long-preload", "postfork-long-preload", 1),
 }
 
 NATIVE_REFERENCE_MODES = {
@@ -609,6 +615,24 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(final_files,
                 f"fini did not complete after releasing checkpoint reader\n{output}")
 
+    if args.mode == "exec_checkpoint_fork_child_fini":
+        match = re.search(
+            r"fork_child_checkpoint_skipped=1 failed_exec_exit=1 "
+            r"normal_return_exit=1 parent_pid=(\d+)",
+            output,
+        )
+        require(match is not None,
+                f"fork-child lifecycle invariants were not proven\n{output}")
+        parent_pid = match.group(1)
+        require(len(exec_files) == 1,
+                f"expected one parent checkpoint, found {exec_files}\n{output}")
+        require(len(final_files) == 1,
+                f"expected one parent final CSV, found {final_files}\n{output}")
+        require(all(f"-p{parent_pid}" in path.name
+                    for path in exec_files + final_files),
+                f"fork child emitted PEAK artifacts: "
+                f"{exec_files + final_files}\n{output}")
+
     if args.mode == "execvp_enoexec_fallback":
         require(proc.returncode == 37,
                 f"ENOEXEC fallback returned {proc.returncode}\n{output}")
@@ -621,6 +645,35 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
 
     require(proc.returncode == 0,
             f"fixture exited {proc.returncode}\n{output}")
+
+    if args.mode in CAPACITY_PASSTHROUGH_MODES:
+        kind, marker, ld_preload_env_entries = CAPACITY_PASSTHROUGH_MODES[args.mode]
+        require(len(exec_files) <= 1,
+                f"capacity passthrough fabricated child/extra checkpoints: "
+                f"{exec_files}\n{output}")
+        if exec_files:
+            require(target_count(exec_files) == 5,
+                    "capacity passthrough checkpoint includes child calls or "
+                    f"misses the parent exec boundary: {exec_files}")
+        require(f"postfork_capacity_passthrough=1 kind={kind}" in output,
+                f"capacity fallback was not proven\n{output}")
+        require(f"marker={marker}" in output,
+                f"capacity fallback did not preserve the native child marker\n{output}")
+        require_ld_count(output, 0)
+        require(f"ld_preload_env_entries={ld_preload_env_entries}" in output,
+                f"capacity fallback changed the native LD_PRELOAD environment\n{output}")
+        for name in (
+            "peak_target",
+            "peak_statslog",
+            "peak_exec_chain",
+            "peak_exec_checkpoint",
+            "peak_exec_propagate",
+        ):
+            require(f"{name}=<missing>" in output,
+                    f"capacity fallback injected {name}\n{output}")
+        require("exec_child_ok" in output,
+                f"capacity fallback parent exec did not retain native success\n{output}")
+        return
 
     if args.mode not in NO_EXEC_CHECKPOINT_MODES:
         require(exec_files, f"missing exec checkpoint for {args.mode}\n{output}")
@@ -806,11 +859,6 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
     }:
         require("postfork_bad_env_efault=1" in output,
                 f"post-fork bad env did not preserve EFAULT\n{output}")
-
-    if args.mode in {"vfork_env_slots_fallback", "vfork_long_preload_fallback"}:
-        require_ld_count(output, 0)
-        require("postfork_capacity_passthrough=1" in output,
-                f"bounded child env did not pass through original envp\n{output}")
 
     if args.mode in {
         "no_duplicate_ld_preload",

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -1,0 +1,994 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import errno
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+TARGET = "peak_exec_chain_hot_target"
+
+MODE_TO_APP_ARG = {
+    "execv_success_checkpoint": "execv-success",
+    "exec_checkpoint_write_target_no_reentry": "execv-write-target-success",
+    "execv_zero_call_checkpoint": "execv-zero-call",
+    "exec_checkpoint_disabled": "execv-success",
+    "exec_bad_stats_path_nonfatal": "execv-success",
+    "execve_custom_env_injection": "execve-custom-env",
+    "raw_syscall_execve_custom_env_injection": "raw-syscall-execve-custom-env",
+    "raw_syscall_execve_backend_disabled_injection": "raw-syscall-execve-custom-env",
+    "raw_syscall_execve_failure_non_destructive": "raw-syscall-execve-failure",
+    "raw_syscall_nonexec_passthrough": "raw-syscall-nonexec",
+    "execve_preflight_unavailable_injection": "execve-custom-env",
+    "execve_child_peak_env_only_injection": "execve-child-peak-env-only",
+    "execve_null_env_injection": "execve-null-env",
+    "execve_large_env_injection": "execve-large-env",
+    "execve_env_build_failure_passthrough": "execve-custom-env",
+    "execve_bad_env_failure_non_destructive": "execve-bad-env",
+    "execve_bad_env_preflight_unknown_non_destructive": "execve-bad-env",
+    "execve_bad_argv_failure_non_destructive": "execve-bad-argv",
+    "execve_explicit_peak_env_preserved": "execve-explicit-peak-env",
+    "execve_child_chain_disabled": "execve-child-chain-disabled",
+    "execve_child_checkpoint_disabled": "execve-child-checkpoint-disabled",
+    "execve_child_propagate_disabled": "execve-child-propagate-disabled",
+    "execve_propagate_disabled": "execve-custom-env",
+    "execve_chain_disabled": "execve-custom-env",
+    "execve_secure_skip": "execve-custom-env",
+    "fexecve_custom_env_injection": "fexecve-custom-env",
+    "fexecve_preflight_unavailable_injection": "fexecve-custom-env",
+    "fexecve_bad_env_failure_non_destructive": "fexecve-bad-env",
+    "fexecve_bad_env_preflight_unknown_non_destructive": "fexecve-bad-env",
+    "fexecve_bad_argv_failure_non_destructive": "fexecve-bad-argv",
+    "execveat_custom_env_injection": "execveat-custom-env",
+    "raw_syscall_execveat_custom_env_injection": "raw-syscall-execveat-custom-env",
+    "execveat_bad_env_failure_non_destructive": "execveat-bad-env",
+    "execveat_bad_env_preflight_unknown_non_destructive": "execveat-bad-env",
+    "execveat_bad_argv_failure_non_destructive": "execveat-bad-argv",
+    "execl_success_checkpoint": "execl-success",
+    "execlp_path_search": "execlp-path-search",
+    "execle_custom_env_injection": "execle-custom-env",
+    "exec_failure_non_destructive": "exec-failure",
+    "execvp_path_search": "execvp-path-search",
+    "execvp_empty_path_component": "execvp-path-search",
+    "helper_named_exec_still_checkpointed": "helper-named-exec",
+    "execvpe_caller_path_child_env_ignored": "execvpe-child-env-path-ignored",
+    "no_duplicate_ld_preload_execvpe_path_fallback": (
+        "execvpe-child-path-duplicate-preload"
+    ),
+    "execvp_enoent_failure": "execvp-enoent",
+    "execvp_enotdir_enoent_failure": "execvp-enoent",
+    "execvp_enotdir_enoent_fallback": "execvp-enoent",
+    "execvp_eacces_failure": "execvp-eacces",
+    "execvp_eacces_fallback": "execvp-eacces",
+    "execvp_enoent_fallback": "execvp-enoent",
+    "execvp_enoexec_fallback": "execvp-enoexec",
+    "fork_child_exec_parent_exec": "fork-child-exec-parent-exec",
+    "vfork_child_exec_parent_exec": "vfork-child-exec-parent-exec",
+    "vfork_child_failed_exec_parent_exec": (
+        "vfork-child-failed-exec-parent-exec"
+    ),
+    "vfork_execl_parent_exec": "vfork-execl-parent-exec",
+    "vfork_execlp_parent_exec": "vfork-execlp-parent-exec",
+    "vfork_execle_parent_exec": "vfork-execle-parent-exec",
+    "fork_custom_env_execve_chain": "fork-custom-env-execve",
+    "vfork_custom_env_execve_chain": "vfork-custom-env-execve",
+    "vfork_custom_env_execle_chain": "vfork-custom-env-execle",
+    "fork_custom_env_chain_disabled": "fork-custom-env-disabled",
+    "vfork_custom_env_chain_disabled": "vfork-custom-env-disabled",
+    "vfork_custom_env_execvpe_chain": "vfork-custom-env-execvpe",
+    "vfork_custom_env_execvp_chain": "vfork-custom-env-execvp",
+    "vfork_custom_env_execlp_chain": "vfork-custom-env-execlp",
+    "vfork_custom_env_fexecve_chain": "vfork-custom-env-fexecve",
+    "vfork_custom_env_execveat_chain": "vfork-custom-env-execveat",
+    "fork_raw_syscall_custom_env_chain": "fork-raw-syscall-custom-env",
+    "fork_raw_syscall_chain_disabled": "fork-raw-syscall-chain-disabled",
+    "vfork_raw_syscall_execveat_chain": "vfork-raw-syscall-execveat",
+    "fork_bad_env_vector_efault": "fork-bad-env-vector",
+    "vfork_bad_env_vector_efault": "vfork-bad-env-vector",
+    "fork_bad_env_string_efault": "fork-bad-env-string",
+    "vfork_bad_env_string_efault": "vfork-bad-env-string",
+    # The child fast path has 255 usable stack env slots and an 8 KiB preload
+    # buffer.  Inputs beyond either bound deliberately use libc's original envp.
+    "vfork_env_slots_fallback": "vfork-env-slots-fallback",
+    "vfork_long_preload_fallback": "vfork-long-preload-fallback",
+    "no_duplicate_ld_preload": "duplicate-preload",
+    "no_duplicate_ld_preload_whitespace": "duplicate-preload-whitespace",
+    "no_duplicate_ld_preload_env_entries": "duplicate-preload-entry",
+    "posix_spawn_custom_env_injection": "posix-spawn-custom-env",
+    "posix_spawn_env_build_failure_passthrough": "posix-spawn-custom-env",
+    "posix_spawn_null_env_injection": "posix-spawn-null-env",
+    "posix_spawn_bad_env_failure_non_destructive": "posix-spawn-bad-env",
+    "posix_spawn_bad_env_preflight_unknown_non_destructive": (
+        "posix-spawn-bad-env"
+    ),
+    "posix_spawn_bad_argv_failure_non_destructive": "posix-spawn-bad-argv",
+    "posix_spawn_preflight_unavailable_injection": (
+        "posix-spawn-preflight-unavailable"
+    ),
+    "posix_spawn_preflight_unavailable_bad_env_delegates": (
+        "posix-spawn-bad-env"
+    ),
+    "posix_spawn_duplicate_ld_preload": "posix-spawn-duplicate-preload",
+    "posix_spawn_actions_attrs_injection": "posix-spawn-actions-attrs",
+    "posix_spawn_actions_close_stderr": "posix-spawn-actions-close-stderr",
+    "posix_spawn_usevfork_custom_env": "posix-spawn-usevfork-custom-env",
+    "posix_spawn_child_peak_env_only_injection": (
+        "posix-spawn-child-peak-env-only"
+    ),
+    "posix_spawn_chain_disabled": "posix-spawn-custom-env",
+    "posix_spawn_failure_non_destructive": "posix-spawn-failure",
+    "posix_spawnp_path_search": "posix-spawnp-path-search",
+    "posix_spawnp_empty_path_component": "posix-spawnp-path-search",
+    "posix_spawnp_child_env_path_ignored": "posix-spawnp-child-env-path-ignored",
+    "posix_spawnp_preflight_unavailable_delegates": "posix-spawnp-path-search",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates": (
+        "posix-spawnp-bad-env"
+    ),
+    "posix_spawnp_bad_env_failure_non_destructive": "posix-spawnp-bad-env",
+    "posix_spawnp_bad_env_preflight_unknown_non_destructive": (
+        "posix-spawnp-bad-env"
+    ),
+    "posix_spawnp_bad_argv_failure_non_destructive": "posix-spawnp-bad-argv",
+    "posix_spawn_explicit_peak_env_preserved": "posix-spawn-explicit-peak-env",
+    "exec_checkpoint_concurrent_fini_callbacks": "exec-concurrent-fini-callbacks",
+    "text_output_not_corrupted": "exec-failure",
+}
+
+SPAWN_MODES = {
+    "posix_spawn_custom_env_injection",
+    "posix_spawn_env_build_failure_passthrough",
+    "posix_spawn_null_env_injection",
+    "posix_spawn_duplicate_ld_preload",
+    "posix_spawn_actions_attrs_injection",
+    "posix_spawn_actions_close_stderr",
+    "posix_spawn_usevfork_custom_env",
+    "posix_spawn_child_peak_env_only_injection",
+    "posix_spawn_preflight_unavailable_injection",
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawn_chain_disabled",
+    "posix_spawn_failure_non_destructive",
+    "posix_spawnp_path_search",
+    "posix_spawnp_empty_path_component",
+    "posix_spawnp_child_env_path_ignored",
+    "posix_spawnp_preflight_unavailable_delegates",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    "posix_spawn_explicit_peak_env_preserved",
+}
+
+NO_EXEC_CHECKPOINT_MODES = {
+    "raw_syscall_execve_backend_disabled_injection",
+    "exec_checkpoint_disabled",
+    "exec_checkpoint_concurrent_fini_callbacks",
+    "execve_child_checkpoint_disabled",
+    "exec_bad_stats_path_nonfatal",
+    "execve_child_peak_env_only_injection",
+    "raw_syscall_nonexec_passthrough",
+    "execve_bad_env_failure_non_destructive",
+    "execve_bad_env_preflight_unknown_non_destructive",
+    "execve_bad_argv_failure_non_destructive",
+    "fexecve_bad_env_failure_non_destructive",
+    "fexecve_bad_env_preflight_unknown_non_destructive",
+    "fexecve_bad_argv_failure_non_destructive",
+    "execveat_bad_env_failure_non_destructive",
+    "execveat_bad_env_preflight_unknown_non_destructive",
+    "execveat_bad_argv_failure_non_destructive",
+    "posix_spawn_bad_env_failure_non_destructive",
+    "posix_spawn_bad_env_preflight_unknown_non_destructive",
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawn_bad_argv_failure_non_destructive",
+    "posix_spawnp_bad_env_failure_non_destructive",
+    "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    "posix_spawnp_bad_argv_failure_non_destructive",
+    *SPAWN_MODES,
+}
+
+NATIVE_REFERENCE_MODES = {
+    "execve_bad_env_failure_non_destructive",
+    "execve_bad_env_preflight_unknown_non_destructive",
+    "execve_bad_argv_failure_non_destructive",
+    "fexecve_bad_env_failure_non_destructive",
+    "fexecve_bad_env_preflight_unknown_non_destructive",
+    "fexecve_bad_argv_failure_non_destructive",
+    "execveat_bad_env_failure_non_destructive",
+    "execveat_bad_env_preflight_unknown_non_destructive",
+    "execveat_bad_argv_failure_non_destructive",
+    "execvpe_caller_path_child_env_ignored",
+    "execvp_empty_path_component",
+    "execvp_enotdir_enoent_failure",
+    "execvp_eacces_fallback",
+    "posix_spawnp_child_env_path_ignored",
+    "posix_spawnp_empty_path_component",
+    "posix_spawn_bad_env_failure_non_destructive",
+    "posix_spawn_bad_env_preflight_unknown_non_destructive",
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawnp_bad_env_failure_non_destructive",
+    "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+}
+
+PREFLIGHT_UNAVAILABLE_MODES = {
+    "execve_preflight_unavailable_injection",
+    "fexecve_preflight_unavailable_injection",
+    "posix_spawn_preflight_unavailable_injection",
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawnp_preflight_unavailable_delegates",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+}
+
+PREFLIGHT_UNKNOWN_BAD_ENV_MODES = {
+    "execve_bad_env_preflight_unknown_non_destructive",
+    "fexecve_bad_env_preflight_unknown_non_destructive",
+    "execveat_bad_env_preflight_unknown_non_destructive",
+    "posix_spawn_bad_env_preflight_unknown_non_destructive",
+    "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+}
+
+PREFLIGHT_ALL_UNAVAILABLE_MODES = {
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawnp_preflight_unavailable_delegates",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    *PREFLIGHT_UNKNOWN_BAD_ENV_MODES,
+}
+
+FALLBACK_EXECVP_MODES = {
+    "no_duplicate_ld_preload_execvpe_path_fallback",
+    "execvp_enotdir_enoent_fallback",
+    "execvp_eacces_fallback",
+    "execvp_enoent_fallback",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, choices=sorted(MODE_TO_APP_ARG))
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--libpeak", required=True)
+    return parser.parse_args()
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_native_reference(args, proc):
+    require(proc.returncode == 0,
+            f"native reference failed with {proc.returncode}\n{proc.stdout}")
+    mode = args.mode
+    output = proc.stdout
+    if mode in {
+        "execve_bad_env_failure_non_destructive",
+        "execve_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"execve_bad_env_errno={errno.EFAULT}" in output,
+                f"native execve bad-env missed EFAULT\n{output}")
+        return
+    if mode == "execve_bad_argv_failure_non_destructive":
+        require(f"execve_bad_argv_errno={errno.EFAULT}" in output,
+                f"native execve bad-argv missed EFAULT\n{output}")
+        return
+    if mode in {
+        "fexecve_bad_env_failure_non_destructive",
+        "fexecve_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"fexecve_bad_env_errno={errno.EFAULT}" in output,
+                f"native fexecve bad-env missed EFAULT\n{output}")
+        return
+    if mode == "fexecve_bad_argv_failure_non_destructive":
+        require(f"fexecve_bad_argv_errno={errno.EFAULT}" in output,
+                f"native fexecve bad-argv missed EFAULT\n{output}")
+        return
+    if mode in {
+        "execveat_bad_env_failure_non_destructive",
+        "execveat_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"execveat_bad_env_errno={errno.EFAULT}" in output,
+                f"native execveat bad-env missed EFAULT\n{output}")
+        return
+    if mode == "execveat_bad_argv_failure_non_destructive":
+        require(f"execveat_bad_argv_errno={errno.EFAULT}" in output,
+                f"native execveat bad-argv missed EFAULT\n{output}")
+        return
+    if mode in {
+        "posix_spawn_bad_env_failure_non_destructive",
+        "posix_spawn_bad_env_preflight_unknown_non_destructive",
+        "posix_spawn_preflight_unavailable_bad_env_delegates",
+    }:
+        require(f"posix_spawn_bad_env_result={errno.EFAULT}" in output,
+                f"native posix_spawn bad-env missed EFAULT\n{output}")
+        return
+    if mode == "posix_spawn_bad_argv_failure_non_destructive":
+        require(f"posix_spawn_bad_argv_result={errno.EFAULT}" in output,
+                f"native posix_spawn bad-argv missed EFAULT\n{output}")
+        return
+    if mode in {
+        "posix_spawnp_bad_env_failure_non_destructive",
+        "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+        "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    }:
+        require(f"posix_spawnp_bad_env_result={errno.EFAULT}" in output,
+                f"native posix_spawnp bad-env missed EFAULT\n{output}")
+        return
+    if mode == "posix_spawnp_bad_argv_failure_non_destructive":
+        require(f"posix_spawnp_bad_argv_result={errno.EFAULT}" in output,
+                f"native posix_spawnp bad-argv missed EFAULT\n{output}")
+        return
+    if mode in {
+        "execvp_enotdir_enoent_failure",
+    }:
+        require(f"execvp_enoent_errno={errno.ENOENT}" in output,
+                f"native execvp ENOTDIR/ENOENT missed ENOENT\n{output}")
+        return
+    if mode == "execvp_eacces_fallback":
+        require(f"execvp_eacces_errno={errno.EACCES}" in output,
+                f"native execvp EACCES missed EACCES\n{output}")
+        return
+    require("exec_child_ok" in output,
+            f"native PATH reference missed child\n{output}")
+
+
+def install_path_fixture(tmpdir: Path, exe: Path):
+    bindir = tmpdir / "bin"
+    bindir.mkdir()
+    target = bindir / "test_exec_chain"
+    try:
+        target.symlink_to(exe)
+    except OSError:
+        shutil.copy2(exe, target)
+        target.chmod(target.stat().st_mode | stat.S_IXUSR)
+
+    helper_named = bindir / "peak_detach_helper"
+    try:
+        helper_named.symlink_to(exe)
+    except OSError:
+        shutil.copy2(exe, helper_named)
+        helper_named.chmod(helper_named.stat().st_mode | stat.S_IXUSR)
+
+    enoexec = bindir / "enoexec-script"
+    enoexec.write_text("echo enoexec_script_ran\nexit 37\n", encoding="utf-8")
+    enoexec.chmod(0o755)
+
+    cwd_target = tmpdir / "test_exec_chain"
+    try:
+        cwd_target.symlink_to(exe)
+    except OSError:
+        shutil.copy2(exe, cwd_target)
+        cwd_target.chmod(cwd_target.stat().st_mode | stat.S_IXUSR)
+
+    blocked_dir = tmpdir / "blocked"
+    blocked_dir.mkdir()
+    blocked = blocked_dir / "blocked-exec"
+    blocked.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    blocked.chmod(0o644)
+    return bindir, blocked_dir
+
+
+def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool):
+    env = os.environ.copy()
+    for name in list(env):
+        if name.startswith("PEAK_"):
+            env.pop(name, None)
+    if preload:
+        env["LD_PRELOAD"] = str(Path(args.libpeak).resolve())
+        env["PEAK_TARGET"] = TARGET
+        env["PEAK_STATSLOG_PATH"] = str(tmpdir / "peak_stats")
+        env["PEAK_HEARTBEAT_INTERVAL"] = "0"
+        env["PEAK_TEXT_OUTPUT"] = "0"
+    else:
+        env.pop("LD_PRELOAD", None)
+    if args.mode == "raw_syscall_execve_backend_disabled_injection":
+        env.pop("PEAK_TARGET", None)
+
+    old_path = env.get("PATH", "/bin:/usr/bin")
+    env["PATH"] = f"{bindir}{os.pathsep}{old_path}"
+    if args.mode == "execvp_eacces_failure":
+        env["PATH"] = str(blocked_dir)
+    if args.mode in {
+        "posix_spawn_actions_attrs_injection",
+        "posix_spawn_actions_close_stderr",
+    }:
+        env["EXEC_CHAIN_SPAWN_ACTIONS_OUT"] = str(tmpdir / "spawn-actions.out")
+    if args.mode in {
+        "execve_child_peak_env_only_injection",
+        "posix_spawn_child_peak_env_only_injection",
+    }:
+        env["EXEC_CHAIN_CHILD_STATS_PREFIX"] = str(tmpdir / "peak_stats")
+    if args.mode == "exec_checkpoint_disabled":
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
+    if args.mode == "execve_propagate_disabled":
+        env["PEAK_EXEC_PROPAGATE_PEAK_ENV"] = "0"
+    if args.mode in {"execve_chain_disabled", "posix_spawn_chain_disabled"}:
+        env["PEAK_EXEC_CHAIN"] = "0"
+    if args.mode == "execve_secure_skip":
+        env["PEAK_TEST_EXEC_AT_SECURE"] = "1"
+    if args.mode in {
+        "execve_env_build_failure_passthrough",
+        "posix_spawn_env_build_failure_passthrough",
+    }:
+        env["PEAK_TEST_EXEC_ENV_BUILD_FAIL"] = "1"
+    if args.mode in PREFLIGHT_UNAVAILABLE_MODES | PREFLIGHT_UNKNOWN_BAD_ENV_MODES:
+        env["PEAK_TEST_EXEC_PREFLIGHT_UNAVAILABLE"] = "1"
+    if args.mode in PREFLIGHT_ALL_UNAVAILABLE_MODES:
+        env["PEAK_TEST_EXEC_PREFLIGHT_NO_PROC_MEM"] = "1"
+        env["PEAK_TEST_EXEC_PREFLIGHT_MAPS_UNAVAILABLE"] = "1"
+    if args.mode in FALLBACK_EXECVP_MODES:
+        env["PEAK_TEST_EXECVPE_FALLBACK"] = "1"
+    if args.mode == "exec_checkpoint_write_target_no_reentry":
+        env["PEAK_TARGET"] = "write"
+    if args.mode == "exec_bad_stats_path_nonfatal":
+        env["PEAK_STATSLOG_PATH"] = str(tmpdir / "missing-dir" / "peak_stats")
+    if args.mode == "text_output_not_corrupted":
+        env["PEAK_TEXT_OUTPUT"] = "1"
+    if args.mode in {"execvp_empty_path_component", "posix_spawnp_empty_path_component"}:
+        env["PATH"] = f"{os.pathsep}{tmpdir / 'missing-after-empty'}"
+    if args.mode == "no_duplicate_ld_preload_execvpe_path_fallback":
+        env["PATH"] = str(bindir)
+        env["EXEC_CHAIN_TEST_CHILD_PATH"] = str(bindir)
+        env["PEAK_EXEC_PROPAGATE_PEAK_ENV"] = "0"
+    if args.mode in {
+        "execvp_enotdir_enoent_failure",
+        "execvp_enotdir_enoent_fallback",
+    }:
+        not_dir = tmpdir / "not-a-dir"
+        not_dir.write_text("not a directory\n", encoding="utf-8")
+        env["PATH"] = f"{not_dir}{os.pathsep}{tmpdir / 'missing-dir'}"
+    if args.mode in {"execvp_eacces_fallback", "execvp_enoent_fallback"}:
+        env["PATH"] = str(blocked_dir if args.mode == "execvp_eacces_fallback"
+                          else tmpdir / "missing-dir")
+    return env
+
+
+def run_fixture(args, tmpdir: Path, preload=True):
+    exe = Path(args.exe).resolve()
+    tmpdir.mkdir(parents=True, exist_ok=True)
+    bindir, blocked_dir = install_path_fixture(tmpdir, exe)
+    env = base_env(args, tmpdir, bindir, blocked_dir, preload=preload)
+    app_arg = MODE_TO_APP_ARG[args.mode]
+    return subprocess.run(
+        [str(exe), app_arg],
+        cwd=tmpdir,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=20,
+    )
+
+
+def csv_files(tmpdir: Path):
+    all_csv = sorted(tmpdir.glob("peak_stats-p*.csv"))
+    exec_files = [path for path in all_csv if "-exec" in path.name]
+    final_files = [path for path in all_csv if "-exec" not in path.name]
+    return exec_files, final_files
+
+
+def target_count(paths, function=TARGET):
+    total = 0
+    for path in paths:
+        with path.open(newline="", encoding="utf-8", errors="replace") as fp:
+            reader = csv.DictReader(fp)
+            for row in reader:
+                if row.get("function") == function:
+                    total += int(row.get("count", "0"))
+    return total
+
+
+def require_ld_count(output, expected):
+    match = re.search(r"ld_preload_libpeak_count=(\d+)", output)
+    require(match is not None, f"missing LD_PRELOAD count\n{output}")
+    require(int(match.group(1)) == expected,
+            f"expected {expected} libpeak LD_PRELOAD entries\n{output}")
+
+
+def require_single_ld_env(output):
+    match = re.search(r"ld_preload_env_entries=(\d+)", output)
+    require(match is not None, f"missing LD_PRELOAD env entry count\n{output}")
+    require(int(match.group(1)) == 1,
+            f"expected one LD_PRELOAD env entry\n{output}")
+
+
+def check_common(args, proc, tmpdir: Path):
+    output = proc.stdout
+    exec_files, final_files = csv_files(tmpdir)
+
+    if args.mode == "exec_checkpoint_concurrent_fini_callbacks":
+        require("checkpoint_reader_gate_held=1 fini_waiting=1" in output,
+                f"checkpoint/fini lifetime-gate ordering was not proven\n{output}")
+        require(final_files,
+                f"fini did not complete after releasing checkpoint reader\n{output}")
+
+    if args.mode == "execvp_enoexec_fallback":
+        require(proc.returncode == 37,
+                f"ENOEXEC fallback returned {proc.returncode}\n{output}")
+        require("enoexec_script_ran" in output,
+                f"missing shell fallback output\n{output}")
+        require(exec_files, "missing checkpoint before ENOEXEC shell handoff")
+        require(target_count(exec_files) >= 5,
+                f"ENOEXEC checkpoint missed parent calls: {exec_files}")
+        return
+
+    require(proc.returncode == 0,
+            f"fixture exited {proc.returncode}\n{output}")
+
+    if args.mode not in NO_EXEC_CHECKPOINT_MODES:
+        require(exec_files, f"missing exec checkpoint for {args.mode}\n{output}")
+    else:
+        require(not exec_files,
+                f"unexpected exec checkpoint for {args.mode}: {exec_files}\n{output}")
+
+    if args.mode == "execv_zero_call_checkpoint":
+        require(target_count(exec_files) == 0,
+                f"zero-call checkpoint recorded target calls: {exec_files}")
+
+    if args.mode == "exec_checkpoint_write_target_no_reentry":
+        require("parent_write_before_exec" in output,
+                f"missing parent write marker\n{output}")
+        require(target_count(exec_files, "write") == 1,
+                "checkpoint I/O re-entered the profiled write target")
+
+    if args.mode in {
+        "execv_success_checkpoint",
+        "execve_custom_env_injection",
+        "raw_syscall_execve_custom_env_injection",
+        "execve_preflight_unavailable_injection",
+        "execve_null_env_injection",
+        "execve_large_env_injection",
+        "fexecve_custom_env_injection",
+        "fexecve_preflight_unavailable_injection",
+        "execveat_custom_env_injection",
+        "raw_syscall_execveat_custom_env_injection",
+        "execl_success_checkpoint",
+        "execlp_path_search",
+        "execle_custom_env_injection",
+        "execvp_path_search",
+        "execvp_empty_path_component",
+        "helper_named_exec_still_checkpointed",
+        "execvpe_caller_path_child_env_ignored",
+        "execve_child_chain_disabled",
+        "execve_child_propagate_disabled",
+        "fork_child_exec_parent_exec",
+        "vfork_child_exec_parent_exec",
+        "vfork_child_failed_exec_parent_exec",
+        "vfork_execl_parent_exec",
+        "vfork_execlp_parent_exec",
+        "vfork_execle_parent_exec",
+        "fork_custom_env_execve_chain",
+        "vfork_custom_env_execve_chain",
+        "vfork_custom_env_execle_chain",
+        "fork_custom_env_chain_disabled",
+        "vfork_custom_env_chain_disabled",
+        "vfork_custom_env_execvpe_chain",
+        "vfork_custom_env_execvp_chain",
+        "vfork_custom_env_execlp_chain",
+        "vfork_custom_env_fexecve_chain",
+        "vfork_custom_env_execveat_chain",
+        "fork_raw_syscall_custom_env_chain",
+        "fork_raw_syscall_chain_disabled",
+        "vfork_raw_syscall_execveat_chain",
+        "fork_bad_env_vector_efault",
+        "vfork_bad_env_vector_efault",
+        "fork_bad_env_string_efault",
+        "vfork_bad_env_string_efault",
+        "vfork_env_slots_fallback",
+        "vfork_long_preload_fallback",
+        "no_duplicate_ld_preload",
+        "no_duplicate_ld_preload_whitespace",
+        "no_duplicate_ld_preload_env_entries",
+    }:
+        require(target_count(exec_files) >= 5,
+                f"checkpoint missed parent calls: {exec_files}")
+
+    if args.mode in {
+        "execve_env_build_failure_passthrough",
+        "posix_spawn_env_build_failure_passthrough",
+    }:
+        require_ld_count(output, 0)
+        expected_marker = (
+            "custom-env"
+            if args.mode == "execve_env_build_failure_passthrough"
+            else "posix-spawn-env"
+        )
+        require(f"marker={expected_marker}" in output,
+                f"original envp was not passed through\n{output}")
+
+    if args.mode in {
+        "execve_custom_env_injection",
+        "raw_syscall_execve_custom_env_injection",
+        "raw_syscall_execve_backend_disabled_injection",
+        "execve_preflight_unavailable_injection",
+        "execve_null_env_injection",
+        "execve_large_env_injection",
+        "fexecve_custom_env_injection",
+        "fexecve_preflight_unavailable_injection",
+        "execveat_custom_env_injection",
+        "raw_syscall_execveat_custom_env_injection",
+        "execle_custom_env_injection",
+        "execve_child_checkpoint_disabled",
+        "execve_child_propagate_disabled",
+        "no_duplicate_ld_preload",
+        "no_duplicate_ld_preload_whitespace",
+        "no_duplicate_ld_preload_env_entries",
+        "no_duplicate_ld_preload_execvpe_path_fallback",
+        "posix_spawn_custom_env_injection",
+        "posix_spawn_null_env_injection",
+        "posix_spawn_duplicate_ld_preload",
+        "posix_spawn_actions_attrs_injection",
+        "posix_spawn_child_peak_env_only_injection",
+        "fork_custom_env_execve_chain",
+        "vfork_custom_env_execve_chain",
+        "vfork_custom_env_execle_chain",
+        "fork_raw_syscall_custom_env_chain",
+    }:
+        check_text = output
+        if args.mode in {
+            "posix_spawn_actions_attrs_injection",
+            "posix_spawn_actions_close_stderr",
+        }:
+            redirected = tmpdir / "spawn-actions.out"
+            require(redirected.exists(), "spawn action did not create output")
+            check_text = redirected.read_text(encoding="utf-8", errors="replace")
+            if args.mode == "posix_spawn_actions_attrs_injection":
+                require("posix_spawn_actions_attrs_ok" in output,
+                        f"missing spawn action parent marker\n{output}")
+            else:
+                require("posix_spawn_actions_close_stderr_ok" in output,
+                        f"missing close-stderr parent marker\n{output}")
+        require_ld_count(check_text, 1)
+        require_single_ld_env(check_text)
+
+    if args.mode in {
+        "fork_custom_env_chain_disabled",
+        "vfork_custom_env_chain_disabled",
+        "fork_raw_syscall_chain_disabled",
+    }:
+        require_ld_count(output, 0)
+        require("peak_exec_chain=0" in output,
+                f"child PEAK_EXEC_CHAIN=0 was not preserved\n{output}")
+
+    if args.mode in {
+        "fork_custom_env_execve_chain",
+        "vfork_custom_env_execve_chain",
+        "vfork_custom_env_execle_chain",
+        "fork_custom_env_chain_disabled",
+        "vfork_custom_env_chain_disabled",
+        "fork_raw_syscall_custom_env_chain",
+        "fork_raw_syscall_chain_disabled",
+    }:
+        require("parent_env_unchanged=1" in output,
+                f"post-fork child changed parent environment\n{output}")
+
+    if args.mode in {
+        "vfork_custom_env_execvpe_chain",
+        "vfork_custom_env_execvp_chain",
+        "vfork_custom_env_execlp_chain",
+        "vfork_custom_env_fexecve_chain",
+        "vfork_custom_env_execveat_chain",
+        "vfork_raw_syscall_execveat_chain",
+    }:
+        require_ld_count(output, 1)
+        require_single_ld_env(output)
+        require("marker=postfork-api-custom" in output,
+                f"post-fork custom env was not preserved\n{output}")
+        require("peak_target=explicit_child_target" in output,
+                f"post-fork explicit PEAK_TARGET was overwritten\n{output}")
+        require("postfork_api_parent_env_unchanged=1" in output,
+                f"post-fork wrapper changed parent environ\n{output}")
+
+    if args.mode in {
+        "fork_bad_env_vector_efault",
+        "vfork_bad_env_vector_efault",
+        "fork_bad_env_string_efault",
+        "vfork_bad_env_string_efault",
+    }:
+        require("postfork_bad_env_efault=1" in output,
+                f"post-fork bad env did not preserve EFAULT\n{output}")
+
+    if args.mode in {"vfork_env_slots_fallback", "vfork_long_preload_fallback"}:
+        require_ld_count(output, 0)
+        require("postfork_capacity_passthrough=1" in output,
+                f"bounded child env did not pass through original envp\n{output}")
+
+    if args.mode in {
+        "no_duplicate_ld_preload",
+        "no_duplicate_ld_preload_whitespace",
+        "no_duplicate_ld_preload_env_entries",
+        "no_duplicate_ld_preload_execvpe_path_fallback",
+        "posix_spawn_duplicate_ld_preload",
+    }:
+        match = re.search(r"ld_preload_extra_count=(\d+)", output)
+        require(match is not None, f"missing extra preload count\n{output}")
+        require(int(match.group(1)) == 2,
+                f"extra LD_PRELOAD entries were not preserved\n{output}")
+
+    if args.mode == "posix_spawn_actions_attrs_injection":
+        text = (tmpdir / "spawn-actions.out").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        match = re.search(r"ld_preload_extra_count=(\d+)", text)
+        require(match is not None, f"missing redirected preload count\n{text}")
+
+    if args.mode in {
+        "execve_explicit_peak_env_preserved",
+        "posix_spawn_explicit_peak_env_preserved",
+    }:
+        require("child_env_PEAK_TARGET=explicit_child_target" in output,
+                f"explicit child PEAK_TARGET was not preserved\n{output}")
+
+    if args.mode in {
+        "execve_child_peak_env_only_injection",
+        "posix_spawn_child_peak_env_only_injection",
+    }:
+        require("marker=child-peak-env" in output,
+                f"child-only PEAK env marker missing\n{output}")
+        require_ld_count(output, 1)
+
+    if args.mode == "execve_propagate_disabled":
+        require_ld_count(output, 1)
+        require("peak_target=<missing>" in output,
+                f"disabled propagation leaked PEAK_TARGET\n{output}")
+
+    if args.mode == "execve_child_checkpoint_disabled":
+        require_ld_count(output, 1)
+        require("peak_exec_checkpoint=0" in output,
+                f"child PEAK_EXEC_CHECKPOINT=0 was not preserved\n{output}")
+
+    if args.mode == "execve_child_propagate_disabled":
+        require_ld_count(output, 1)
+        require("peak_target=<missing>" in output,
+                f"child PEAK_EXEC_PROPAGATE_PEAK_ENV=0 leaked target\n{output}")
+        require("peak_exec_propagate=0" in output,
+                f"child PEAK_EXEC_PROPAGATE_PEAK_ENV=0 was not preserved\n{output}")
+
+    if args.mode == "execve_child_chain_disabled":
+        require_ld_count(output, 0)
+        require("peak_exec_chain=0" in output,
+                f"child PEAK_EXEC_CHAIN=0 was not preserved\n{output}")
+
+    if args.mode in {
+        "execve_chain_disabled",
+        "execve_secure_skip",
+        "posix_spawn_chain_disabled",
+    }:
+        require_ld_count(output, 0)
+
+    if args.mode == "exec_bad_stats_path_nonfatal":
+        require("exec_child_ok" in output,
+                f"bad checkpoint path made exec fail\n{output}")
+
+    if args.mode == "exec_failure_non_destructive":
+        require(f"exec_failure_errno={errno.ENOENT}" in output,
+                f"missing exec failure marker\n{output}")
+        require(final_files, "missing final CSV after failed exec")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after failed exec")
+
+    if args.mode == "raw_syscall_execve_failure_non_destructive":
+        require(f"raw_syscall_execve_errno={errno.ENOENT}" in output,
+                f"missing raw syscall exec failure marker\n{output}")
+        require(final_files, "missing final CSV after failed raw syscall exec")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after raw syscall exec failure")
+
+    if args.mode == "raw_syscall_nonexec_passthrough":
+        match = re.search(r"raw_syscall_getpid=(\d+) expected=(\d+) errno=(\d+)",
+                          output)
+        require(match is not None and match.group(1) == match.group(2) and
+                int(match.group(3)) == errno.EALREADY,
+                f"non-exec syscall was not transparently forwarded\n{output}")
+        require("raw_syscall_write=ok" in output,
+                f"multi-argument syscall was not transparently forwarded\n{output}")
+
+    if args.mode in {
+        "execvp_enoent_failure",
+        "execvp_enotdir_enoent_failure",
+        "execvp_enotdir_enoent_fallback",
+        "execvp_enoent_fallback",
+    }:
+        require(f"execvp_enoent_errno={errno.ENOENT}" in output,
+                f"missing execvp ENOENT marker\n{output}")
+        require(final_files, "missing final CSV after execvp ENOENT")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after execvp ENOENT")
+
+    if args.mode in {"execvp_eacces_failure", "execvp_eacces_fallback"}:
+        require(f"execvp_eacces_errno={errno.EACCES}" in output,
+                f"missing execvp EACCES marker\n{output}")
+        require(final_files, "missing final CSV after execvp EACCES")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after execvp EACCES")
+
+    if args.mode in {
+        "execve_bad_env_failure_non_destructive",
+        "execve_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"execve_bad_env_errno={errno.EFAULT}" in output,
+                f"missing execve bad-env marker\n{output}")
+        require(final_files, "missing final CSV after bad-env execve")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-env execve")
+        require(not exec_files,
+                f"bad-env execve should not write exec checkpoints: {exec_files}")
+
+    if args.mode == "execve_bad_argv_failure_non_destructive":
+        require(f"execve_bad_argv_errno={errno.EFAULT}" in output,
+                f"missing execve bad-argv marker\n{output}")
+        require(final_files, "missing final CSV after bad-argv execve")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-argv execve")
+        require(not exec_files,
+                f"bad-argv execve should not write exec checkpoints: {exec_files}")
+
+    if args.mode in {
+        "fexecve_bad_env_failure_non_destructive",
+        "fexecve_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"fexecve_bad_env_errno={errno.EFAULT}" in output,
+                f"missing fexecve bad-env marker\n{output}")
+        require(final_files, "missing final CSV after bad-env fexecve")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-env fexecve")
+        require(not exec_files,
+                f"bad-env fexecve should not write exec checkpoints: {exec_files}")
+
+    if args.mode == "fexecve_bad_argv_failure_non_destructive":
+        require(f"fexecve_bad_argv_errno={errno.EFAULT}" in output,
+                f"missing fexecve bad-argv marker\n{output}")
+        require(final_files, "missing final CSV after bad-argv fexecve")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-argv fexecve")
+        require(not exec_files,
+                f"bad-argv fexecve should not write exec checkpoints: {exec_files}")
+
+    if args.mode in {
+        "execveat_bad_env_failure_non_destructive",
+        "execveat_bad_env_preflight_unknown_non_destructive",
+    }:
+        require(f"execveat_bad_env_errno={errno.EFAULT}" in output,
+                f"missing execveat bad-env marker\n{output}")
+        require(final_files, "missing final CSV after bad-env execveat")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-env execveat")
+        require(not exec_files,
+                f"bad-env execveat should not write exec checkpoints: {exec_files}")
+
+    if args.mode == "execveat_bad_argv_failure_non_destructive":
+        require(f"execveat_bad_argv_errno={errno.EFAULT}" in output,
+                f"missing execveat bad-argv marker\n{output}")
+        require(final_files, "missing final CSV after bad-argv execveat")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after bad-argv execveat")
+        require(not exec_files,
+                f"bad-argv execveat should not write exec checkpoints: {exec_files}")
+
+    if args.mode == "posix_spawn_failure_non_destructive":
+        require(f"posix_spawn_failure_result={errno.ENOENT}" in output,
+                f"missing posix_spawn failure marker\n{output}")
+        require(final_files, "missing final CSV after failed posix_spawn")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after failed posix_spawn")
+
+    if args.mode in {
+        "posix_spawn_bad_env_failure_non_destructive",
+        "posix_spawn_bad_env_preflight_unknown_non_destructive",
+        "posix_spawn_preflight_unavailable_bad_env_delegates",
+        "posix_spawnp_bad_env_failure_non_destructive",
+        "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+        "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    }:
+        marker = (
+            f"posix_spawnp_bad_env_result={errno.EFAULT}"
+            if args.mode.startswith("posix_spawnp_")
+            else f"posix_spawn_bad_env_result={errno.EFAULT}"
+        )
+        require(marker in output,
+                f"missing spawn bad-env marker\n{output}")
+        require(final_files, "missing final CSV after spawn bad-env")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after spawn bad-env")
+        require(not exec_files,
+                f"spawn bad-env should not write exec checkpoints: {exec_files}")
+
+    if args.mode in {
+        "posix_spawn_bad_argv_failure_non_destructive",
+        "posix_spawnp_bad_argv_failure_non_destructive",
+    }:
+        marker = (
+            f"posix_spawnp_bad_argv_result={errno.EFAULT}"
+            if args.mode.startswith("posix_spawnp_")
+            else f"posix_spawn_bad_argv_result={errno.EFAULT}"
+        )
+        require(marker in output,
+                f"missing spawn bad-argv marker\n{output}")
+        require(final_files, "missing final CSV after spawn bad-argv")
+        require(target_count(final_files) >= 6,
+                "normal final CSV missed calls after spawn bad-argv")
+        require(not exec_files,
+                f"spawn bad-argv should not write exec checkpoints: {exec_files}")
+
+    if args.mode in {
+        "posix_spawnp_path_search",
+        "posix_spawnp_preflight_unavailable_delegates",
+        "posix_spawnp_child_env_path_ignored",
+        "posix_spawnp_empty_path_component",
+    }:
+        require("exec_child_ok" in output,
+                f"spawnp child did not run\n{output}")
+
+    if args.mode in {
+        "execvpe_caller_path_child_env_ignored",
+        "posix_spawnp_child_env_path_ignored",
+        "execvp_empty_path_component",
+        "posix_spawnp_empty_path_component",
+    }:
+        require("exec_child_ok" in output,
+                f"caller PATH search did not find fixture\n{output}")
+
+    if args.mode == "posix_spawn_actions_close_stderr":
+        text = (tmpdir / "spawn-actions.out").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        require("child_stdout_after_stderr_close" in text,
+                f"close-stderr child stdout marker missing\n{text}")
+        require("child_stderr_sentinel_after_spawn_close" not in output,
+                f"closed stderr sentinel leaked to parent output\n{output}")
+        require("child_stderr_sentinel_after_spawn_close" not in text,
+                f"closed stderr sentinel leaked to redirected stdout\n{text}")
+
+    if args.mode == "posix_spawn_usevfork_custom_env":
+        require("posix_spawn_usevfork_ok" in output,
+                f"missing usevfork marker\n{output}")
+
+    if args.mode == "text_output_not_corrupted":
+        require("exec_failure_errno=2" in output,
+                f"missing failed exec marker\n{output}")
+        require("PEAK Library" in output,
+                f"text PEAK output missing\n{output}")
+        require(TARGET in output,
+                f"text PEAK output lost target name\n{output}")
+
+
+def main():
+    args = parse_args()
+    with tempfile.TemporaryDirectory(
+        prefix=f"peak-exec-chain-{args.mode}-",
+        dir=os.getcwd(),
+    ) as tmp:
+        tmpdir = Path(tmp)
+        if args.mode in NATIVE_REFERENCE_MODES:
+            native_proc = run_fixture(args, tmpdir / "native", preload=False)
+            require_native_reference(args, native_proc)
+        peak_tmp = tmpdir / "peak"
+        peak_tmp.mkdir()
+        proc = run_fixture(args, peak_tmp, preload=True)
+        try:
+            check_common(args, proc, peak_tmp)
+        except Exception:
+            sys.stdout.write(proc.stdout)
+            for path in sorted(peak_tmp.glob("*")):
+                if path.is_file():
+                    print(f"artifact {path.name}:")
+                    try:
+                        data = path.read_bytes()
+                        if b"\0" in data[:4096] or len(data) > 32768:
+                            print(f"<skipped binary/large artifact size={len(data)}>")
+                            continue
+                        print(data.decode("utf-8", errors="replace"))
+                    except Exception as exc:
+                        print(f"<unreadable: {exc}>")
+            raise
+    print(f"exec_chain_check_ok mode={args.mode}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -124,7 +124,10 @@ MODE_TO_APP_ARG = {
     ),
     "posix_spawn_chain_disabled": "posix-spawn-custom-env",
     "posix_spawn_failure_non_destructive": "posix-spawn-failure",
+    "posix_spawn_resolver_null_preserves_errno": "posix-spawn-resolver-null",
     "posix_spawnp_path_search": "posix-spawnp-path-search",
+    "posix_spawnp_env_build_failure_passthrough": "posix-spawnp-custom-env",
+    "posix_spawnp_resolver_null_preserves_errno": "posix-spawnp-resolver-null",
     "posix_spawnp_empty_path_component": "posix-spawnp-path-search",
     "posix_spawnp_child_env_path_ignored": "posix-spawnp-child-env-path-ignored",
     "posix_spawnp_preflight_unavailable_delegates": "posix-spawnp-path-search",
@@ -154,7 +157,10 @@ SPAWN_MODES = {
     "posix_spawn_preflight_unavailable_bad_env_delegates",
     "posix_spawn_chain_disabled",
     "posix_spawn_failure_non_destructive",
+    "posix_spawn_resolver_null_preserves_errno",
     "posix_spawnp_path_search",
+    "posix_spawnp_env_build_failure_passthrough",
+    "posix_spawnp_resolver_null_preserves_errno",
     "posix_spawnp_empty_path_component",
     "posix_spawnp_child_env_path_ignored",
     "posix_spawnp_preflight_unavailable_delegates",
@@ -168,7 +174,6 @@ NO_EXEC_CHECKPOINT_MODES = {
     "exec_checkpoint_concurrent_fini_callbacks",
     "execve_child_checkpoint_disabled",
     "exec_bad_stats_path_nonfatal",
-    "execve_child_peak_env_only_injection",
     "raw_syscall_nonexec_passthrough",
     "execve_bad_env_failure_non_destructive",
     "execve_bad_env_preflight_unknown_non_destructive",
@@ -238,6 +243,18 @@ PREFLIGHT_ALL_UNAVAILABLE_MODES = {
     *PREFLIGHT_UNKNOWN_BAD_ENV_MODES,
 }
 
+SPAWN_OBSERVATION_MODES = {
+    "posix_spawn_bad_env_failure_non_destructive",
+    "posix_spawn_bad_env_preflight_unknown_non_destructive",
+    "posix_spawn_preflight_unavailable_bad_env_delegates",
+    "posix_spawn_bad_argv_failure_non_destructive",
+    "posix_spawn_failure_non_destructive",
+    "posix_spawnp_bad_env_failure_non_destructive",
+    "posix_spawnp_bad_env_preflight_unknown_non_destructive",
+    "posix_spawnp_preflight_unavailable_bad_env_delegates",
+    "posix_spawnp_bad_argv_failure_non_destructive",
+}
+
 FALLBACK_EXECVP_MODES = {
     "no_duplicate_ld_preload_execvpe_path_fallback",
     "execvp_enotdir_enoent_fallback",
@@ -264,6 +281,10 @@ def require_native_reference(args, proc):
             f"native reference failed with {proc.returncode}\n{proc.stdout}")
     mode = args.mode
     output = proc.stdout
+    if mode in SPAWN_OBSERVATION_MODES:
+        observation = parse_spawn_observation(output)
+        require_valid_spawn_observation(observation, "native")
+        return observation
     if mode in {
         "execve_bad_env_failure_non_destructive",
         "execve_bad_env_preflight_unknown_non_destructive",
@@ -335,6 +356,36 @@ def require_native_reference(args, proc):
             f"native PATH reference missed child\n{output}")
 
 
+def parse_spawn_observation(output):
+    match = re.search(
+        r"spawn_observation operation=(?P<operation>\S+) "
+        r"result=(?P<result>-?\d+) errno=(?P<errno>-?\d+) "
+        r"pid_created=(?P<pid_created>[01]) "
+        r"invalid_success=(?P<invalid_success>[01]) "
+        r"wait_status=(?P<wait_status>-?\d+) "
+        r"child_exit=(?P<child_exit>-?\d+) "
+        r"child_signal=(?P<child_signal>-?\d+) "
+        r"wait_errno=(?P<wait_errno>-?\d+) "
+        r"continued_sink=(?P<continued_sink>\d+)",
+        output,
+    )
+    require(match is not None, f"missing spawn observation\n{output}")
+    observation = match.groupdict()
+    for name in observation:
+        if name != "operation":
+            observation[name] = int(observation[name])
+    return observation
+
+
+def require_valid_spawn_observation(observation, label):
+    require(observation["pid_created"] == int(observation["result"] == 0),
+            f"{label} spawn child creation did not follow its return value\n"
+            f"{observation}")
+    require(not observation["invalid_success"],
+            f"{label} posix_spawn returned success without a usable child PID\n"
+            f"{observation}")
+
+
 def install_path_fixture(tmpdir: Path, exe: Path):
     bindir = tmpdir / "bin"
     bindir.mkdir()
@@ -379,7 +430,7 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
     if preload:
         env["LD_PRELOAD"] = str(Path(args.libpeak).resolve())
         env["PEAK_TARGET"] = TARGET
-        env["PEAK_STATSLOG_PATH"] = str(tmpdir / "peak_stats")
+        env["PEAK_STATSLOG_PATH"] = "peak_stats"
         env["PEAK_HEARTBEAT_INTERVAL"] = "0"
         env["PEAK_TEXT_OUTPUT"] = "0"
     else:
@@ -400,7 +451,7 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
         "execve_child_peak_env_only_injection",
         "posix_spawn_child_peak_env_only_injection",
     }:
-        env["EXEC_CHAIN_CHILD_STATS_PREFIX"] = str(tmpdir / "peak_stats")
+        env["EXEC_CHAIN_CHILD_STATS_PREFIX"] = "peak_stats"
     if args.mode == "exec_checkpoint_disabled":
         env["PEAK_EXEC_CHECKPOINT"] = "0"
     if args.mode == "execve_propagate_disabled":
@@ -412,8 +463,14 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
     if args.mode in {
         "execve_env_build_failure_passthrough",
         "posix_spawn_env_build_failure_passthrough",
+        "posix_spawnp_env_build_failure_passthrough",
     }:
         env["PEAK_TEST_EXEC_ENV_BUILD_FAIL"] = "1"
+    if args.mode in {
+        "posix_spawn_resolver_null_preserves_errno",
+        "posix_spawnp_resolver_null_preserves_errno",
+    }:
+        env["PEAK_TEST_EXEC_SPAWN_RESOLVER_NULL"] = "1"
     if args.mode in PREFLIGHT_UNAVAILABLE_MODES | PREFLIGHT_UNKNOWN_BAD_ENV_MODES:
         env["PEAK_TEST_EXEC_PREFLIGHT_UNAVAILABLE"] = "1"
     if args.mode in PREFLIGHT_ALL_UNAVAILABLE_MODES:
@@ -464,9 +521,16 @@ def run_fixture(args, tmpdir: Path, preload=True):
 
 
 def csv_files(tmpdir: Path):
-    all_csv = sorted(tmpdir.glob("peak_stats-p*.csv"))
-    exec_files = [path for path in all_csv if "-exec" in path.name]
-    final_files = [path for path in all_csv if "-exec" not in path.name]
+    stats_name = re.compile(
+        r"^(?:peak_stats|peak_statslog)-p\d+(?P<checkpoint>-exec\d+)?\.csv$"
+    )
+    all_csv = sorted(tmpdir.glob("*.csv"))
+    matched_csv = [(path, stats_name.fullmatch(path.name)) for path in all_csv]
+    unexpected_csv = [path for path, match in matched_csv if match is None]
+    require(not unexpected_csv,
+            f"unexpected CSV artifacts in {tmpdir}: {unexpected_csv}")
+    exec_files = [path for path, match in matched_csv if match["checkpoint"]]
+    final_files = [path for path, match in matched_csv if not match["checkpoint"]]
     return exec_files, final_files
 
 
@@ -479,6 +543,46 @@ def target_count(paths, function=TARGET):
                 if row.get("function") == function:
                     total += int(row.get("count", "0"))
     return total
+
+
+def require_bad_env_artifacts(mode, final_files, exec_files, operation):
+    require(final_files, f"missing final CSV after bad-env {operation}")
+    if mode in PREFLIGHT_UNKNOWN_BAD_ENV_MODES:
+        require(len(final_files) == 1,
+                f"expected one final CSV after preflight-unknown {operation}: "
+                f"{final_files}")
+    require(target_count(final_files) >= 6,
+            f"normal final CSV missed calls after bad-env {operation}")
+    require(not exec_files,
+            f"bad-env {operation} should not write exec checkpoints: {exec_files}")
+
+
+def require_spawn_observation(args, output, final_files, exec_files,
+                              native_observation):
+    observation = parse_spawn_observation(output)
+    require(native_observation is not None,
+            f"missing native spawn reference for {args.mode}")
+    require_valid_spawn_observation(native_observation, "native")
+    require_valid_spawn_observation(observation, "PEAK")
+    require(observation == native_observation,
+            "PEAK spawn behavior diverged from the same-host native reference\n"
+            f"native={native_observation}\npeak={observation}\n{output}")
+    require(observation["continued_sink"] >= 6,
+            f"parent did not continue profiling after spawn call\n{output}")
+    if observation["pid_created"]:
+        require(observation["wait_status"] >= 0,
+                f"created spawn child was not waited\n{output}")
+        require(observation["wait_errno"] == 0,
+                f"waiting for created spawn child failed\n{output}")
+    else:
+        require(observation["wait_status"] == -1,
+                f"spawn reported no child but recorded a wait status\n{output}")
+    require(len(final_files) == 1,
+            f"expected exactly one final CSV after spawn failure: {final_files}")
+    require(target_count(final_files) >= 6,
+            "normal final CSV missed calls after spawn failure")
+    require(not exec_files,
+            f"spawn failure should not write exec checkpoints: {exec_files}")
 
 
 def require_ld_count(output, expected):
@@ -495,7 +599,7 @@ def require_single_ld_env(output):
             f"expected one LD_PRELOAD env entry\n{output}")
 
 
-def check_common(args, proc, tmpdir: Path):
+def check_common(args, proc, tmpdir: Path, native_observation=None):
     output = proc.stdout
     exec_files, final_files = csv_files(tmpdir)
 
@@ -552,6 +656,7 @@ def check_common(args, proc, tmpdir: Path):
         "execvp_empty_path_component",
         "helper_named_exec_still_checkpointed",
         "execvpe_caller_path_child_env_ignored",
+        "execve_child_peak_env_only_injection",
         "execve_child_chain_disabled",
         "execve_child_propagate_disabled",
         "fork_child_exec_parent_exec",
@@ -589,15 +694,26 @@ def check_common(args, proc, tmpdir: Path):
     if args.mode in {
         "execve_env_build_failure_passthrough",
         "posix_spawn_env_build_failure_passthrough",
+        "posix_spawnp_env_build_failure_passthrough",
     }:
         require_ld_count(output, 0)
-        expected_marker = (
-            "custom-env"
-            if args.mode == "execve_env_build_failure_passthrough"
-            else "posix-spawn-env"
-        )
+        expected_marker = {
+            "execve_env_build_failure_passthrough": "custom-env",
+            "posix_spawn_env_build_failure_passthrough": "posix-spawn-env",
+            "posix_spawnp_env_build_failure_passthrough": "posix-spawnp-env",
+        }[args.mode]
         require(f"marker={expected_marker}" in output,
                 f"original envp was not passed through\n{output}")
+
+    if args.mode in {
+        "posix_spawn_resolver_null_preserves_errno",
+        "posix_spawnp_resolver_null_preserves_errno",
+    }:
+        expected_path_search = "1" if args.mode.startswith("posix_spawnp_") else "0"
+        require(
+            f"posix_spawn_resolver_null_ok path_search={expected_path_search}" in output,
+            f"spawn resolver-null fallback did not preserve errno\n{output}",
+        )
 
     if args.mode in {
         "execve_custom_env_injection",
@@ -812,11 +928,7 @@ def check_common(args, proc, tmpdir: Path):
     }:
         require(f"execve_bad_env_errno={errno.EFAULT}" in output,
                 f"missing execve bad-env marker\n{output}")
-        require(final_files, "missing final CSV after bad-env execve")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after bad-env execve")
-        require(not exec_files,
-                f"bad-env execve should not write exec checkpoints: {exec_files}")
+        require_bad_env_artifacts(args.mode, final_files, exec_files, "execve")
 
     if args.mode == "execve_bad_argv_failure_non_destructive":
         require(f"execve_bad_argv_errno={errno.EFAULT}" in output,
@@ -833,11 +945,7 @@ def check_common(args, proc, tmpdir: Path):
     }:
         require(f"fexecve_bad_env_errno={errno.EFAULT}" in output,
                 f"missing fexecve bad-env marker\n{output}")
-        require(final_files, "missing final CSV after bad-env fexecve")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after bad-env fexecve")
-        require(not exec_files,
-                f"bad-env fexecve should not write exec checkpoints: {exec_files}")
+        require_bad_env_artifacts(args.mode, final_files, exec_files, "fexecve")
 
     if args.mode == "fexecve_bad_argv_failure_non_destructive":
         require(f"fexecve_bad_argv_errno={errno.EFAULT}" in output,
@@ -854,11 +962,7 @@ def check_common(args, proc, tmpdir: Path):
     }:
         require(f"execveat_bad_env_errno={errno.EFAULT}" in output,
                 f"missing execveat bad-env marker\n{output}")
-        require(final_files, "missing final CSV after bad-env execveat")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after bad-env execveat")
-        require(not exec_files,
-                f"bad-env execveat should not write exec checkpoints: {exec_files}")
+        require_bad_env_artifacts(args.mode, final_files, exec_files, "execveat")
 
     if args.mode == "execveat_bad_argv_failure_non_destructive":
         require(f"execveat_bad_argv_errno={errno.EFAULT}" in output,
@@ -869,50 +973,12 @@ def check_common(args, proc, tmpdir: Path):
         require(not exec_files,
                 f"bad-argv execveat should not write exec checkpoints: {exec_files}")
 
-    if args.mode == "posix_spawn_failure_non_destructive":
-        require(f"posix_spawn_failure_result={errno.ENOENT}" in output,
-                f"missing posix_spawn failure marker\n{output}")
-        require(final_files, "missing final CSV after failed posix_spawn")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after failed posix_spawn")
-
-    if args.mode in {
-        "posix_spawn_bad_env_failure_non_destructive",
-        "posix_spawn_bad_env_preflight_unknown_non_destructive",
-        "posix_spawn_preflight_unavailable_bad_env_delegates",
-        "posix_spawnp_bad_env_failure_non_destructive",
-        "posix_spawnp_bad_env_preflight_unknown_non_destructive",
-        "posix_spawnp_preflight_unavailable_bad_env_delegates",
-    }:
-        marker = (
-            f"posix_spawnp_bad_env_result={errno.EFAULT}"
-            if args.mode.startswith("posix_spawnp_")
-            else f"posix_spawn_bad_env_result={errno.EFAULT}"
-        )
-        require(marker in output,
-                f"missing spawn bad-env marker\n{output}")
-        require(final_files, "missing final CSV after spawn bad-env")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after spawn bad-env")
-        require(not exec_files,
-                f"spawn bad-env should not write exec checkpoints: {exec_files}")
-
-    if args.mode in {
-        "posix_spawn_bad_argv_failure_non_destructive",
-        "posix_spawnp_bad_argv_failure_non_destructive",
-    }:
-        marker = (
-            f"posix_spawnp_bad_argv_result={errno.EFAULT}"
-            if args.mode.startswith("posix_spawnp_")
-            else f"posix_spawn_bad_argv_result={errno.EFAULT}"
-        )
-        require(marker in output,
-                f"missing spawn bad-argv marker\n{output}")
-        require(final_files, "missing final CSV after spawn bad-argv")
-        require(target_count(final_files) >= 6,
-                "normal final CSV missed calls after spawn bad-argv")
-        require(not exec_files,
-                f"spawn bad-argv should not write exec checkpoints: {exec_files}")
+    if args.mode in SPAWN_OBSERVATION_MODES:
+        require_spawn_observation(args,
+                                  output,
+                                  final_files,
+                                  exec_files,
+                                  native_observation)
 
     if args.mode in {
         "posix_spawnp_path_search",
@@ -964,14 +1030,15 @@ def main():
         dir=os.getcwd(),
     ) as tmp:
         tmpdir = Path(tmp)
-        if args.mode in NATIVE_REFERENCE_MODES:
+        native_observation = None
+        if args.mode in NATIVE_REFERENCE_MODES | SPAWN_OBSERVATION_MODES:
             native_proc = run_fixture(args, tmpdir / "native", preload=False)
-            require_native_reference(args, native_proc)
+            native_observation = require_native_reference(args, native_proc)
         peak_tmp = tmpdir / "peak"
         peak_tmp.mkdir()
         proc = run_fixture(args, peak_tmp, preload=True)
         try:
-            check_common(args, proc, peak_tmp)
+            check_common(args, proc, peak_tmp, native_observation)
         except Exception:
             sys.stdout.write(proc.stdout)
             for path in sorted(peak_tmp.glob("*")):

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -6,6 +6,7 @@ import errno
 import os
 import re
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -16,15 +17,23 @@ from pathlib import Path
 TARGET = "peak_exec_chain_hot_target"
 
 MODE_TO_APP_ARG = {
+    "signal_handler_execve_default_bypass": "signal-handler-execve",
+    "default_disabled_family_bypass": "default-disabled-family-bypass",
     "execv_success_checkpoint": "execv-success",
     "exec_checkpoint_write_target_no_reentry": "execv-write-target-success",
     "execv_zero_call_checkpoint": "execv-zero-call",
     "exec_checkpoint_disabled": "execv-success",
     "exec_bad_stats_path_nonfatal": "execv-success",
     "execve_custom_env_injection": "execve-custom-env",
+    "execve_call_env_optin_default_bypass": (
+        "execve-call-env-optin-default-bypass"
+    ),
     "raw_syscall_execve_custom_env_injection": "raw-syscall-execve-custom-env",
     "raw_syscall_execve_backend_disabled_injection": "raw-syscall-execve-custom-env",
     "raw_syscall_execve_failure_non_destructive": "raw-syscall-execve-failure",
+    "raw_syscall_execve_observer_bypass": (
+        "raw-syscall-execve-observer-bypass"
+    ),
     "raw_syscall_nonexec_passthrough": "raw-syscall-nonexec",
     "execve_preflight_unavailable_injection": "execve-custom-env",
     "execve_child_peak_env_only_injection": "execve-child-peak-env-only",
@@ -60,9 +69,11 @@ MODE_TO_APP_ARG = {
     "execveat_bad_argv_failure_non_destructive": "execveat-bad-argv",
     "execl_success_checkpoint": "execl-success",
     "execlp_path_search": "execlp-path-search",
+    "execlp_default_bypass_without_execvpe": "execlp-path-search",
     "execle_custom_env_injection": "execle-custom-env",
     "exec_failure_non_destructive": "exec-failure",
     "execvp_path_search": "execvp-path-search",
+    "execvp_default_bypass_without_execvpe": "execvp-path-search",
     "execvp_empty_path_component": "execvp-path-search",
     "helper_named_exec_still_checkpointed": "helper-named-exec",
     "execvpe_caller_path_child_env_ignored": "execvpe-child-env-path-ignored",
@@ -81,6 +92,12 @@ MODE_TO_APP_ARG = {
     "vfork_child_failed_exec_parent_exec": (
         "vfork-child-failed-exec-parent-exec"
     ),
+    "clone_private_vm_exec": "clone-private-vm-exec",
+    "clone_vm_exec": "clone-vm-exec",
+    "clone_vfork_exec": "clone-vfork-exec",
+    "clone3_exec": "clone3-exec",
+    "raw_clone_libc_exec": "raw-clone-libc-exec",
+    "raw_clone_raw_exec": "raw-clone-raw-exec",
     "vfork_execl_parent_exec": "vfork-execl-parent-exec",
     "vfork_execlp_parent_exec": "vfork-execlp-parent-exec",
     "vfork_execle_parent_exec": "vfork-execle-parent-exec",
@@ -97,6 +114,7 @@ MODE_TO_APP_ARG = {
     "vfork_custom_env_chain_disabled": "vfork-custom-env-disabled",
     "vfork_custom_env_execvpe_chain": "vfork-custom-env-execvpe",
     "vfork_custom_env_execvp_chain": "vfork-custom-env-execvp",
+    "vfork_execvp_native_fallback": "vfork-execvp-native-fallback",
     "vfork_custom_env_execlp_chain": "vfork-custom-env-execlp",
     "vfork_custom_env_fexecve_chain": "vfork-custom-env-fexecve",
     "vfork_custom_env_execveat_chain": "vfork-custom-env-execveat",
@@ -116,6 +134,9 @@ MODE_TO_APP_ARG = {
     "no_duplicate_ld_preload_whitespace": "duplicate-preload-whitespace",
     "no_duplicate_ld_preload_env_entries": "duplicate-preload-entry",
     "posix_spawn_custom_env_injection": "posix-spawn-custom-env",
+    "posix_spawn_call_env_optin_default_bypass": (
+        "posix-spawn-call-env-optin-default-bypass"
+    ),
     "posix_spawn_env_build_failure_passthrough": "posix-spawn-custom-env",
     "posix_spawn_null_env_injection": "posix-spawn-null-env",
     "posix_spawn_bad_env_failure_non_destructive": "posix-spawn-bad-env",
@@ -185,7 +206,14 @@ SPAWN_MODES = {
 }
 
 NO_EXEC_CHECKPOINT_MODES = {
+    "signal_handler_execve_default_bypass",
+    "default_disabled_family_bypass",
+    "execlp_default_bypass_without_execvpe",
+    "execvp_default_bypass_without_execvpe",
+    "execve_call_env_optin_default_bypass",
+    "posix_spawn_call_env_optin_default_bypass",
     "raw_syscall_execve_backend_disabled_injection",
+    "raw_syscall_execve_observer_bypass",
     "exec_checkpoint_disabled",
     "exec_checkpoint_concurrent_fini_callbacks",
     "execve_child_checkpoint_disabled",
@@ -227,6 +255,15 @@ FAILURE_PATH_MODES = {
     "execvp_enoent_fallback",
     "text_output_not_corrupted",
 }
+
+CLONE_MODES = frozenset({
+    "clone_private_vm_exec",
+    "clone_vm_exec",
+    "clone_vfork_exec",
+    "clone3_exec",
+    "raw_clone_libc_exec",
+    "raw_clone_raw_exec",
+})
 
 CHECKPOINT_OPTIONAL_BASE_MODES = frozenset(
     set(CAPACITY_PASSTHROUGH_MODES) |
@@ -331,7 +368,8 @@ NO_LOADER_MODE_EXPECTATIONS = {
     },
     "execve_loader_path_secure_skip": {
         "marker": "loader-path-secure",
-        "peak_exec_chain": "<missing>",
+        "peak_exec_chain": "1",
+        "peak_exec_checkpoint": "1",
         "peak_target": TARGET,
         "peak_statslog": "peak_stats",
         "secure_test_hook": "1",
@@ -342,7 +380,8 @@ NO_LOADER_MODE_EXPECTATIONS = {
     },
     "execve_loader_path_preload_present": {
         "marker": "loader-path-preload-present",
-        "peak_exec_chain": "<missing>",
+        "peak_exec_chain": "1",
+        "peak_exec_checkpoint": "1",
         "peak_target": TARGET,
         "peak_statslog": "peak_stats",
         "secure_test_hook": "<missing>",
@@ -375,7 +414,8 @@ NO_LOADER_MODE_EXPECTATIONS = {
     },
     "vfork_loader_path_preload_present": {
         "marker": "loader-path-preload-present",
-        "peak_exec_chain": "<missing>",
+        "peak_exec_chain": "1",
+        "peak_exec_checkpoint": "1",
         "peak_target": TARGET,
         "peak_statslog": "peak_stats",
         "secure_test_hook": "<missing>",
@@ -438,6 +478,7 @@ def child_loader_test_value():
     return f"/tmp/child-loader{os.pathsep}{original}" if original else "/tmp/child-loader"
 
 NATIVE_REFERENCE_MODES = {
+    "default_disabled_family_bypass",
     "execve_bad_env_failure_non_destructive",
     "execve_bad_env_preflight_unknown_non_destructive",
     "execve_bad_argv_failure_non_destructive",
@@ -502,6 +543,19 @@ FALLBACK_EXECVP_MODES = {
     "execvp_enotdir_enoent_fallback",
     "execvp_eacces_fallback",
     "execvp_enoent_fallback",
+    "execlp_default_bypass_without_execvpe",
+    "execvp_default_bypass_without_execvpe",
+    "vfork_execvp_native_fallback",
+}
+
+CALL_ENV_DEFAULT_BYPASS_MODES = {
+    "execve_call_env_optin_default_bypass",
+    "posix_spawn_call_env_optin_default_bypass",
+}
+
+EXECVP_DEFAULT_BYPASS_MODES = {
+    "execlp_default_bypass_without_execvpe",
+    "execvp_default_bypass_without_execvpe",
 }
 
 
@@ -510,6 +564,8 @@ def parse_args():
     parser.add_argument("--mode", required=True, choices=sorted(MODE_TO_APP_ARG))
     parser.add_argument("--exe", required=True)
     parser.add_argument("--libpeak", required=True)
+    parser.add_argument("--execve-observer")
+    parser.add_argument("--expected-default-bypass-cases", required=True)
     return parser.parse_args()
 
 
@@ -518,11 +574,28 @@ def require(condition, message):
         raise AssertionError(message)
 
 
+def parse_default_bypass_cases(output):
+    matches = re.findall(
+        r"^default_bypass_case=(\w+) result=(-?\d+) errno=(\d+)$",
+        output,
+        re.MULTILINE,
+    )
+    results = {}
+    for name, result, error_number in matches:
+        require(name not in results,
+                f"duplicate default-bypass case {name}\n{output}")
+        results[name] = (int(result), int(error_number))
+    require(results, f"missing default-bypass cases\n{output}")
+    return results
+
+
 def require_native_reference(args, proc):
     require(proc.returncode == 0,
             f"native reference failed with {proc.returncode}\n{proc.stdout}")
     mode = args.mode
     output = proc.stdout
+    if mode == "default_disabled_family_bypass":
+        return parse_default_bypass_cases(output)
     if mode in SPAWN_OBSERVATION_MODES:
         observation = parse_spawn_observation(output)
         require_valid_spawn_observation(observation, "native")
@@ -811,10 +884,43 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
         env["PEAK_STATSLOG_PATH"] = "peak_stats"
         env["PEAK_HEARTBEAT_INTERVAL"] = "0"
         env["PEAK_TEXT_OUTPUT"] = "0"
+        env["PEAK_EXEC_CHAIN"] = "1"
+        env["PEAK_EXEC_CHECKPOINT"] = "1"
     else:
         env.pop("LD_PRELOAD", None)
     if args.mode == "raw_syscall_execve_backend_disabled_injection":
         env.pop("PEAK_TARGET", None)
+    if args.mode == "raw_syscall_execve_observer_bypass":
+        require(args.execve_observer is not None,
+                "raw execve observer test requires --execve-observer")
+        env["LD_PRELOAD"] = os.pathsep.join(
+            (str(Path(args.libpeak).resolve()),
+             str(Path(args.execve_observer).resolve()))
+        )
+        env["PEAK_EXEC_CHAIN"] = "0"
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
+        env["PEAK_EXEC_TRACE_PATH"] = str(tmpdir / "unexpected-exec-trace")
+        env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
+    if args.mode == "signal_handler_execve_default_bypass":
+        env.pop("PEAK_EXEC_CHAIN", None)
+        env.pop("PEAK_EXEC_CHECKPOINT", None)
+        env["PEAK_EXEC_TRACE_PATH"] = str(tmpdir / "unexpected-exec-trace")
+        env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
+    if args.mode == "default_disabled_family_bypass":
+        env["PEAK_EXEC_CHAIN"] = "0"
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
+        env["PEAK_EXEC_TRACE_PATH"] = str(tmpdir / "unexpected-exec-trace")
+        env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
+    if args.mode in CALL_ENV_DEFAULT_BYPASS_MODES:
+        env["PEAK_EXEC_CHAIN"] = "0"
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
+        env["PEAK_EXEC_TRACE_PATH"] = str(tmpdir / "unexpected-exec-trace")
+        env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
+    if args.mode in EXECVP_DEFAULT_BYPASS_MODES:
+        env["PEAK_EXEC_CHAIN"] = "0"
+        env["PEAK_EXEC_CHECKPOINT"] = "0"
+        env["PEAK_EXEC_TRACE_PATH"] = str(tmpdir / "unexpected-exec-trace")
+        env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
 
     old_path = env.get("PATH", "/bin:/usr/bin")
     env["PATH"] = f"{bindir}{os.pathsep}{old_path}"
@@ -917,6 +1023,37 @@ def base_env(args, tmpdir: Path, bindir: Path, blocked_dir: Path, preload: bool)
     return env
 
 
+def run_process_group(command, cwd, env, timeout):
+    proc = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        output, _ = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as timeout_error:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            output, _ = proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired as cleanup_error:
+            raise RuntimeError(
+                f"fixture process group did not terminate: {command}"
+            ) from cleanup_error
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout,
+            output=output,
+        ) from timeout_error
+    return subprocess.CompletedProcess(command, proc.returncode, output)
+
+
 def run_fixture(args, tmpdir: Path, preload=True):
     exe = Path(args.exe).resolve()
     tmpdir.mkdir(parents=True, exist_ok=True)
@@ -926,15 +1063,7 @@ def run_fixture(args, tmpdir: Path, preload=True):
     command = [str(exe), app_arg]
     if preload and args.mode in CHECKPOINT_ONLY_MODES:
         command.append("--quiesce-controller")
-    return subprocess.run(
-        command,
-        cwd=tmpdir,
-        env=env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        timeout=20,
-    )
+    return run_process_group(command, tmpdir, env, timeout=20)
 
 
 def csv_files(tmpdir: Path):
@@ -984,6 +1113,13 @@ def run_checkpoint_contract_self_test():
         require_parent_checkpoint_calls("fork_child_exec_parent_exec", [])
         require_parent_checkpoint_calls("fork_child_exec_parent_exec", [valid])
         try:
+            require_parent_checkpoint_calls("clone_vm_exec", [])
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("clone mode accepted a missing checkpoint")
+        require_parent_checkpoint_calls("clone_vm_exec", [valid])
+        try:
             malformed = workdir / "peak_stats-p1-exec2.csv"
             malformed.write_text(
                 "function,count\npeak_exec_chain_hot_target,4\n",
@@ -997,6 +1133,29 @@ def run_checkpoint_contract_self_test():
             raise AssertionError(
                 "active-controller malformed checkpoint was accepted")
     print("exec_chain_checkpoint_contract_ok")
+
+
+def run_timeout_contract_self_test():
+    child_script = (
+        "import os, time; "
+        "os.fork(); "
+        "print('timeout_process_ready', flush=True); "
+        "time.sleep(60)"
+    )
+    try:
+        run_process_group(
+            [sys.executable, "-c", child_script],
+            os.getcwd(),
+            os.environ.copy(),
+            timeout=1,
+        )
+    except subprocess.TimeoutExpired as timeout_error:
+        output = timeout_error.output or ""
+        require(output.count("timeout_process_ready") == 2,
+                f"timeout contract did not start both processes\n{output}")
+    else:
+        raise AssertionError("timeout contract fixture unexpectedly completed")
+    print("exec_chain_timeout_contract_ok")
 
 
 def require_bad_env_artifacts(mode, final_files, exec_files, operation):
@@ -1196,11 +1355,81 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
                 f"capacity fallback parent exec did not retain native success\n{output}")
         return
 
+    if args.mode == "clone3_exec" and "clone3_skip_" in output:
+        skip_lines = [
+            line for line in output.splitlines()
+            if line.startswith("clone3_skip_")
+        ]
+        require(skip_lines == ["clone3_skip_enosys=1"],
+                f"invalid clone3 runtime skip marker\n{output}")
+        require(not exec_files,
+                f"clone3 ENOSYS skip wrote a checkpoint: {exec_files}")
+        return
+
     if args.mode in CHECKPOINT_REQUIRED_MODES:
         require(exec_files, f"missing exec checkpoint for {args.mode}\n{output}")
     elif args.mode in NO_EXEC_CHECKPOINT_MODES:
         require(not exec_files,
                 f"unexpected exec checkpoint for {args.mode}: {exec_files}\n{output}")
+
+    if args.mode == "signal_handler_execve_default_bypass":
+        require("signal_handler_execve_default_bypass=1" in output,
+                f"signal-handler execve did not preserve native ENOENT\n{output}")
+        require(not (tmpdir / "unexpected-exec-trace").exists(),
+                "default bypass entered exec trace handling")
+        require(not exec_files,
+                f"default bypass entered checkpoint handling: {exec_files}")
+
+    if args.mode == "default_disabled_family_bypass":
+        observation = parse_default_bypass_cases(output)
+        expected_cases = set(args.expected_default_bypass_cases.split(","))
+        dedicated_cases = {"execve", "execvp", "execlp", "posix_spawn"}
+        require(not (expected_cases & dedicated_cases),
+                "family bypass cases duplicate dedicated coverage: "
+                f"{sorted(expected_cases & dedicated_cases)}")
+        require(set(observation) == expected_cases,
+                "default-disabled family case set changed: "
+                f"expected={sorted(expected_cases)} "
+                f"actual={sorted(observation)}\n{output}")
+        require(observation == native_observation,
+                "default-disabled wrappers diverged from native behavior\n"
+                f"native={native_observation}\npeak={observation}\n{output}")
+        require("default_disabled_family_bypass=1" in output,
+                f"default-disabled family marker missing\n{output}")
+        require(not (tmpdir / "unexpected-exec-trace").exists(),
+                "default-disabled family entered trace handling")
+        require(not exec_files,
+                f"default-disabled family checkpointed: {exec_files}")
+
+    if args.mode in CALL_ENV_DEFAULT_BYPASS_MODES:
+        marker = {
+            "execve_call_env_optin_default_bypass": "call-env-optin-execve",
+            "posix_spawn_call_env_optin_default_bypass": "call-env-optin-spawn",
+        }[args.mode]
+        require_ld_count(output, 0)
+        require(f"marker={marker}" in output,
+                f"call-specific envp was not passed through unchanged\n{output}")
+        require("peak_exec_chain=1" in output,
+                f"call-specific chain option was not preserved\n{output}")
+        require("peak_exec_checkpoint=1" in output,
+                f"call-specific checkpoint option was not preserved\n{output}")
+        require("peak_target=<missing>" in output,
+                f"default bypass propagated the parent PEAK target\n{output}")
+        require(not (tmpdir / "unexpected-exec-trace").exists(),
+                "call-specific opt-in entered exec trace handling")
+        require(not exec_files,
+                f"call-specific opt-in entered checkpoint handling: {exec_files}")
+        if args.mode == "posix_spawn_call_env_optin_default_bypass":
+            require("posix_spawn_call_env_optin_default_bypass=1" in output,
+                    f"spawn bypass parent marker missing\n{output}")
+
+    if args.mode in EXECVP_DEFAULT_BYPASS_MODES:
+        require("exec_child_ok" in output,
+                f"native execvp path did not run the child\n{output}")
+        require(not (tmpdir / "unexpected-exec-trace").exists(),
+                "default execvp path entered exec trace handling")
+        require(not exec_files,
+                f"default execvp path checkpointed: {exec_files}")
 
     if args.mode == "execv_zero_call_checkpoint":
         require(target_count(exec_files) == 0,
@@ -1218,6 +1447,47 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(output.count("exec_child_ok") == 2,
                 "fork child exec and parent exec did not both complete\n"
                 f"{output}")
+
+    if args.mode in CLONE_MODES:
+        require(output.count("exec_child_ok") == 2,
+                "clone child exec and parent exec did not both complete\n"
+                f"{output}")
+        match = re.search(
+            r"clone_parent_environment_invariant=1 "
+            r"environ_pointer_unchanged=1 entries=(\d+) bytes=(\d+) "
+            r"fingerprint=([0-9a-f]{16}) mode=(\S+) parent_pid=(\d+)",
+            output,
+        )
+        require(match is not None,
+                f"clone parent environment invariant was not proven\n{output}")
+        parent_pid = match.group(5)
+        parent_exec_files = [
+            path for path in exec_files
+            if f"-p{parent_pid}-exec" in path.name
+        ]
+        parent_final_files = [
+            path for path in final_files
+            if f"-p{parent_pid}.csv" in path.name
+        ]
+        require(parent_exec_files,
+                f"clone parent wrote no exec checkpoint: {exec_files}")
+        require(target_count(parent_exec_files) >= 5,
+                "clone parent checkpoint missed post-child target calls")
+        require(parent_final_files,
+                f"clone parent wrote no continued final output: {final_files}")
+        require(target_count(parent_final_files) >= 7,
+                "clone parent PEAK output did not continue after child path")
+        if args.mode in {
+            "clone_private_vm_exec",
+            "clone3_exec",
+            "raw_clone_libc_exec",
+            "raw_clone_raw_exec",
+        }:
+            require(output.count("clone_private_failed_exec_enoent=1") == 1,
+                    f"private clone did not prove ENOENT before exec\n{output}")
+        else:
+            require("clone_private_failed_exec_enoent" not in output,
+                    f"shared-VM clone ran a failed-exec path\n{output}")
 
     if args.mode in {
         "execve_env_build_failure_passthrough",
@@ -1336,7 +1606,9 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
             "peak_statslog": mode_expected["peak_statslog"],
             "marker": mode_expected["marker"],
             "peak_exec_chain": mode_expected["peak_exec_chain"],
-            "peak_exec_checkpoint": "<missing>",
+            "peak_exec_checkpoint": mode_expected.get(
+                "peak_exec_checkpoint", "<missing>"
+            ),
             "peak_exec_propagate": mode_expected.get(
                 "peak_exec_propagate", "<missing>"
             ),
@@ -1392,6 +1664,15 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
                 f"post-fork explicit PEAK_TARGET was overwritten\n{output}")
         require("postfork_api_parent_env_unchanged=1" in output,
                 f"post-fork wrapper changed parent environ\n{output}")
+
+    if args.mode == "vfork_execvp_native_fallback":
+        require_ld_count(output, 0)
+        require("marker=postfork-api-custom" in output,
+                f"native execvp did not preserve the child environment\n{output}")
+        require("peak_target=explicit_child_target" in output,
+                f"native execvp changed the explicit child target\n{output}")
+        require("postfork_api_parent_env_unchanged=1" in output,
+                f"native execvp fallback changed parent environ\n{output}")
 
     if args.mode in {
         "fork_bad_env_vector_efault",
@@ -1513,6 +1794,13 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(final_files, "missing final CSV after failed raw syscall exec")
         require(target_count(final_files) >= 6,
                 "normal final CSV missed calls after raw syscall exec failure")
+
+    if args.mode == "raw_syscall_execve_observer_bypass":
+        require("raw_execve_observer_bypass=1 result=-1 "
+                f"errno={errno.ENOENT} observed_execve_calls=0" in output,
+                "raw SYS_execve reached another execve interposer\n" + output)
+        require(not (tmpdir / "unexpected-exec-trace").exists(),
+                "raw default bypass entered exec trace handling")
 
     if args.mode == "raw_syscall_nonexec_passthrough":
         match = re.search(r"raw_syscall_getpid=(\d+) expected=(\d+) errno=(\d+)",
@@ -1646,6 +1934,8 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
 def main():
     if sys.argv[1:] == ["--self-test-checkpoint-contract"]:
         return run_checkpoint_contract_self_test()
+    if sys.argv[1:] == ["--self-test-timeout-contract"]:
+        return run_timeout_contract_self_test()
     args = parse_args()
     with tempfile.TemporaryDirectory(
         prefix=f"peak-exec-chain-{args.mode}-",

--- a/test/exec_chain/run_exec_platform_selection_contract.py
+++ b/test/exec_chain/run_exec_platform_selection_contract.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(command, label):
+    proc = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"platform selection {label} failed with {proc.returncode}:\n"
+            f"{proc.stdout}"
+        )
+    return proc.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cmake", required=True)
+    parser.add_argument("--c-compiler", required=True)
+    parser.add_argument("--source-root", required=True)
+    parser.add_argument("--probe-source", required=True)
+    args = parser.parse_args()
+
+    # These synthetic system values exercise CMake platform selection only.
+    # The portable object is compiled by the configured host compiler.
+    platform_shapes = [("Darwin", "x86_64"), ("Linux", "ppc64le")]
+    with tempfile.TemporaryDirectory(prefix="peak-exec-platform-probe-") as tmp:
+        tmp_path = Path(tmp)
+        for system_name, system_processor in platform_shapes:
+            label = f"{system_name}/{system_processor}"
+            toolchain = tmp_path / f"{system_name}-{system_processor}.cmake"
+            build_dir = tmp_path / f"build-{system_name}-{system_processor}"
+            toolchain.write_text(
+                f'set(CMAKE_SYSTEM_NAME "{system_name}")\n'
+                f'set(CMAKE_SYSTEM_PROCESSOR "{system_processor}")\n',
+                encoding="utf-8",
+            )
+            configure_output = run(
+                [
+                    args.cmake,
+                    "-S",
+                    str(Path(args.probe_source).resolve()),
+                    "-B",
+                    str(build_dir),
+                    f"-DCMAKE_TOOLCHAIN_FILE={toolchain}",
+                    f"-DPEAK_HOST_C_COMPILER={args.c_compiler}",
+                    f"-DPEAK_SOURCE_ROOT={Path(args.source_root).resolve()}",
+                ],
+                f"configure {label}",
+            )
+            expected_marker = (
+                "peak_exec_platform_selection_configure_ok "
+                f"target={label} raw=OFF detach_helper=OFF"
+            )
+            if expected_marker not in configure_output:
+                raise AssertionError(
+                    f"platform selection configure marker missing for {label}:\n"
+                    + configure_output
+                )
+            run(
+                [
+                    args.cmake,
+                    "--build",
+                    str(build_dir),
+                    "--target",
+                    "peak_exec_platform_selection_probe",
+                ],
+                f"build {label}",
+            )
+            probe_object = build_dir / "portable_probe.o"
+            if not probe_object.is_file() or probe_object.stat().st_size == 0:
+                raise AssertionError(
+                    f"platform selection portable object was not built for {label}"
+                )
+
+    print("exec_chain_platform_selection_contract_ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/exec_chain/run_exec_preinit_check.py
+++ b/test/exec_chain/run_exec_preinit_check.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+import argparse
+import errno
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+RESULT_RE = re.compile(
+    r"^preinit_case=(\w+) result=(-?\d+) errno=(\d+)$",
+    re.MULTILINE,
+)
+REENTRY_RE = re.compile(
+    r"^resolver_reentry_case=(\w+) result=(-?\d+) errno=(\d+)$",
+    re.MULTILINE,
+)
+SPAWN_REENTRY_RE = re.compile(
+    r"^spawn_resolver_reentry_case=(\w+) result=(-?\d+) errno=(\d+)$",
+    re.MULTILINE,
+)
+SPAWN_PUBLICATION_REENTRY_RE = re.compile(
+    r"^spawn_publication_reentry_case=(\w+) result=(-?\d+) errno=(\d+)$",
+    re.MULTILINE,
+)
+SPAWN_PUBLICATION_WAITED_RE = re.compile(
+    r"^spawn_publication_waited_case=(\w+) ok=(\d+)$", re.MULTILINE
+)
+SPAWN_RAW_FORK_CHILD_RE = re.compile(
+    r"^spawn_raw_fork_child_case=(\w+) ok=(\d+)$", re.MULTILINE
+)
+FORK_CHILD_RE = re.compile(r"^resolver_raw_fork_child_ok=(\d+)$", re.MULTILINE)
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def parse_results(output):
+    results = {}
+    for name, result, error_number in RESULT_RE.findall(output):
+        require(name not in results, f"duplicate preinit case {name}\n{output}")
+        results[name] = (int(result), int(error_number))
+    return results
+
+
+def run_case(exe: Path, libpeak: Path, workdir: Path, preload: bool):
+    env = os.environ.copy()
+    for name in list(env):
+        if name.startswith("PEAK_"):
+            env.pop(name, None)
+    env.pop("LD_PRELOAD", None)
+    empty_path = workdir / "empty-path"
+    eacces_path = workdir / "eacces-path"
+    eloop_path = workdir / "eloop-path"
+    empty_path.mkdir(exist_ok=True)
+    eacces_path.mkdir(exist_ok=True)
+    eloop_path.mkdir(exist_ok=True)
+    blocked_command = eacces_path / "peak-preinit-eacces-eloop"
+    blocked_command.write_text("not executable\n", encoding="utf-8")
+    blocked_command.chmod(0o644)
+    loop_command = eloop_path / "peak-preinit-eacces-eloop"
+    if not loop_command.is_symlink():
+        loop_command.symlink_to(loop_command.name)
+    env["PATH"] = os.pathsep.join(
+        (str(eacces_path), str(eloop_path), str(empty_path))
+    )
+    env["PEAK_EXEC_CHAIN"] = "1"
+    env["PEAK_EXEC_CHECKPOINT"] = "1"
+    env["PEAK_EXEC_TRACE_PATH"] = str(workdir / "unexpected-exec-trace")
+    env["PEAK_TEST_EXEC_PREFLIGHT_TRAP"] = "1"
+    env["PEAK_HEARTBEAT_INTERVAL"] = "0"
+    env["PEAK_TEXT_OUTPUT"] = "0"
+    if preload:
+        env["LD_PRELOAD"] = str(libpeak)
+
+    proc = subprocess.run(
+        [str(exe)],
+        cwd=workdir,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=10,
+    )
+    label = "preloaded" if preload else "native"
+    require(proc.returncode == 0,
+            f"{label} preinit failed with {proc.returncode}:\n{proc.stdout}")
+    results = parse_results(proc.stdout)
+    require(results, f"missing preinit results in {label} output:\n{proc.stdout}")
+    reentry = REENTRY_RE.findall(proc.stdout)
+    spawn_reentry = SPAWN_REENTRY_RE.findall(proc.stdout)
+    spawn_publication_reentry = SPAWN_PUBLICATION_REENTRY_RE.findall(proc.stdout)
+    spawn_publication_waited = SPAWN_PUBLICATION_WAITED_RE.findall(proc.stdout)
+    spawn_raw_fork_child = SPAWN_RAW_FORK_CHILD_RE.findall(proc.stdout)
+    fork_child = FORK_CHILD_RE.findall(proc.stdout)
+    return (results, reentry, spawn_reentry, spawn_publication_reentry,
+            spawn_publication_waited,
+            spawn_raw_fork_child, fork_child, proc.stdout)
+
+
+def require_native_contract(results, output):
+    enoent_exec_cases = {
+        "execve",
+        "execv",
+        "execl",
+        "execle",
+        "execvp",
+        "execlp",
+        "execvpe",
+        "execveat",
+        "raw_execve",
+        "raw_execveat",
+    }
+    for name in enoent_exec_cases & results.keys():
+        require(results[name] == (-1, errno.ENOENT),
+                f"native {name} contract changed: {results[name]}\n{output}")
+    if "execvp_eacces_eloop" in results:
+        require(results["execvp_eacces_eloop"] == (-1, errno.ELOOP),
+                "native execvp masked terminal ELOOP: "
+                f"{results['execvp_eacces_eloop']}\n{output}")
+    if "fexecve" in results:
+        # Older glibc implements fexecve via /proc/self/fd/<fd>, so its
+        # invalid-fd fallback can report ENOENT instead of EBADF/EINVAL.
+        require(results["fexecve"][0] == -1 and
+                results["fexecve"][1] in {
+                    errno.EBADF, errno.EINVAL, errno.ENOENT},
+                f"native fexecve contract changed: {results['fexecve']}\n"
+                f"{output}")
+    for name in ("posix_spawn", "posix_spawnp"):
+        require(results[name][0] in {0, errno.ENOENT},
+                f"native {name} contract changed: {results[name]}\n{output}")
+
+
+def require_spawn_results(cases, expected_result, label, output):
+    require([(name, int(result)) for name, result, _ in cases] == [
+                ("posix_spawn", expected_result),
+                ("posix_spawnp", expected_result)],
+            f"{label} changed: {cases}\n{output}")
+
+
+def spawn_results_match_native(cases, native):
+    expected = []
+    for name in ("posix_spawn", "posix_spawnp"):
+        native_result = native.get(name)
+        if native_result is None:
+            return False
+        expected.append((name, native_result[0]))
+    return [(name, int(result)) for name, result, _ in cases] == expected
+
+
+def require_spawn_results_match_native(cases, native, label, output):
+    require(spawn_results_match_native(cases, native),
+            f"{label} differs from native spawn results: "
+            f"native={native} actual={cases}\n{output}")
+
+
+def check_spawn_publication_result_contract():
+    modern_native = {
+        "posix_spawn": (errno.ENOENT, errno.EALREADY),
+        "posix_spawnp": (errno.ENOENT, errno.EALREADY),
+    }
+    old_glibc_native = {
+        "posix_spawn": (0, errno.EALREADY),
+        "posix_spawnp": (0, errno.EALREADY),
+    }
+    modern_results = [
+        ("posix_spawn", str(errno.ENOENT), "0"),
+        ("posix_spawnp", str(errno.ENOENT), "0"),
+    ]
+    old_glibc_results = [
+        ("posix_spawn", "0", str(errno.ENOENT)),
+        ("posix_spawnp", "0", str(errno.ENOENT)),
+    ]
+    require(spawn_results_match_native(modern_results, modern_native),
+            "modern spawn publication result contract rejected ENOENT")
+    require(spawn_results_match_native(old_glibc_results, old_glibc_native),
+            "old-glibc spawn publication result contract rejected 0")
+    require(not spawn_results_match_native(old_glibc_results, modern_native),
+            "spawn publication result contract accepted a native mismatch")
+
+
+def require_preloaded_contract(native, preloaded, output):
+    require(set(preloaded) == set(native),
+            f"preloaded preinit cases differ: native={sorted(native)} "
+            f"preloaded={sorted(preloaded)}\n{output}")
+    for name, native_result in native.items():
+        if name in {"posix_spawn", "posix_spawnp"}:
+            require(preloaded[name][0] == native_result[0],
+                    f"preloaded {name} result differs: "
+                    f"native={native_result} preloaded={preloaded[name]}\n{output}")
+        else:
+            require(preloaded[name] == native_result,
+                    f"preloaded {name} differs: native={native_result} "
+                    f"preloaded={preloaded[name]}\n{output}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--libpeak", required=True)
+    parser.add_argument("--expected-cases", required=True)
+    args = parser.parse_args()
+    exe = Path(args.exe).resolve()
+    libpeak = Path(args.libpeak).resolve()
+    expected_cases = set(args.expected_cases.split(","))
+    check_spawn_publication_result_contract()
+
+    with tempfile.TemporaryDirectory(prefix="peak-exec-preinit-") as tmp:
+        workdir = Path(tmp)
+        (native, native_reentry, native_spawn_reentry,
+         native_spawn_publication_reentry, native_spawn_publication_waited,
+         native_spawn_raw_fork_child, native_fork_child, native_output) = run_case(
+            exe, libpeak, workdir, False)
+        (preloaded, preloaded_reentry, preloaded_spawn_reentry,
+         preloaded_spawn_publication_reentry, preloaded_spawn_publication_waited,
+         preloaded_spawn_raw_fork_child, preloaded_fork_child,
+         preloaded_output) = run_case(
+            exe, libpeak, workdir, True)
+        require(set(native) == expected_cases,
+                f"native preinit cases differ: expected={sorted(expected_cases)} "
+                f"actual={sorted(native)}\n{native_output}")
+        require_native_contract(native, native_output)
+        require_preloaded_contract(native, preloaded, preloaded_output)
+        require(native_reentry == [("execve", "0", "0")],
+                f"native unexpectedly ran resolver hook: {native_reentry}")
+        require(preloaded_reentry == [("execve", "-1", str(errno.ENOENT))],
+                "resolver-contention reentry did not take the native execve "
+                f"failure path: {preloaded_reentry}\n{preloaded_output}")
+        require_spawn_results(native_spawn_reentry, 0,
+                              "native spawn resolver hooks", native_output)
+        require_spawn_results(preloaded_spawn_reentry, errno.ENOSYS,
+                              "spawn resolver nonblocking fallback",
+                              preloaded_output)
+        require_spawn_results(native_spawn_publication_reentry, 0,
+                              "native spawn publication hooks", native_output)
+        require_spawn_results_match_native(
+            preloaded_spawn_publication_reentry, native,
+            "concurrent resolver native spawn behavior", preloaded_output)
+        require(native_spawn_publication_waited == [
+                    ("posix_spawn", "0"), ("posix_spawnp", "0")],
+                "native unexpectedly ran spawn publication wait hooks: "
+                f"{native_spawn_publication_waited}")
+        require(preloaded_spawn_publication_waited == [
+                    ("posix_spawn", "1"), ("posix_spawnp", "1")],
+                "concurrent resolver caller completed before READY publication: "
+                f"{preloaded_spawn_publication_waited}\n{preloaded_output}")
+        require(native_spawn_raw_fork_child == [("posix_spawn", "0"),
+                                                 ("posix_spawnp", "0")],
+                "native unexpectedly ran spawn raw-fork hooks: "
+                f"{native_spawn_raw_fork_child}")
+        require(preloaded_spawn_raw_fork_child == [("posix_spawn", "1"),
+                                                    ("posix_spawnp", "1")],
+                "raw-fork child did not fail closed from an in-progress resolver: "
+                f"{preloaded_spawn_raw_fork_child}\n{preloaded_output}")
+        require(native_fork_child == ["0"],
+                "native unexpectedly ran resolver fork hook: "
+                f"{native_fork_child}\n{native_output}")
+        require(preloaded_fork_child == ["1"],
+                "raw-fork child inherited a blocking resolver state: "
+                f"{preloaded_fork_child}\n{preloaded_output}")
+        require(not (workdir / "unexpected-exec-trace").exists(),
+                "pre-constructor exec entered trace handling")
+        require(not list(workdir.glob("*-exec*.csv")),
+                "pre-constructor exec created a checkpoint")
+
+    print("exec_preinit_contract_ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -3145,6 +3145,7 @@ fini_thread_main(void* data)
 typedef struct {
     const char* self;
     PeakCheckpointFn checkpoint;
+    int result;
 } CheckpointThreadArgs;
 
 static void*
@@ -3153,7 +3154,21 @@ checkpoint_thread_main(void* data)
     CheckpointThreadArgs* args = data;
     char* const argv[] = {(char*)args->self, (char*)"child-basic", NULL};
 
-    (void)args->checkpoint(args->self, argv);
+    args->result = args->checkpoint(args->self, argv);
+    return NULL;
+}
+
+typedef struct {
+    PeakTestReadyFn function;
+    int result;
+} TestHookThreadArgs;
+
+static void*
+test_hook_thread_main(void* data)
+{
+    TestHookThreadArgs* args = data;
+
+    args->result = args->function();
     return NULL;
 }
 
@@ -3376,6 +3391,149 @@ release_holder:
     execv(self, child_argv);
     perror("exec-checkpoint-snapshot-lock-contention");
     return 196;
+}
+
+static int
+run_exec_checkpoint_statistics_snapshot_contention(const char* self)
+{
+    PeakTestReadyFn mutation_begin = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_mutation_begin");
+    PeakTestVoidFn mutation_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_mutation_release");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_busy_pause_enable");
+    PeakTestReadyFn busy_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_busy_is_held");
+    PeakTestVoidFn busy_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_busy_release");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    CheckpointThreadArgs args = {.self = self, .checkpoint = checkpoint, .result = -1};
+    pthread_t checkpoint_thread;
+
+    if (mutation_begin == NULL || mutation_release == NULL || pause_enable == NULL ||
+        busy_is_held == NULL || busy_release == NULL || checkpoint == NULL) {
+        fprintf(stderr, "checkpoint statistics test hooks unavailable\n");
+        return 197;
+    }
+    call_hot_target(1);
+    if (mutation_begin() != 0) {
+        fprintf(stderr, "checkpoint statistics mutation setup failed\n");
+        return 198;
+    }
+    pause_enable();
+    int rc = pthread_create(&checkpoint_thread, NULL, checkpoint_thread_main, &args);
+    if (rc != 0) {
+        mutation_release();
+        fprintf(stderr, "pthread_create statistics checkpoint failed: %s\n", strerror(rc));
+        return 199;
+    }
+    if (wait_for_test_hook(busy_is_held, "checkpoint statistics contention") != 0) {
+        mutation_release();
+        busy_release();
+        return join_test_thread(checkpoint_thread, "statistics checkpoint") == 0 ?
+                   200 : 201;
+    }
+    mutation_release();
+    busy_release();
+    if (join_test_thread(checkpoint_thread, "statistics checkpoint") != 0 ||
+        args.result != 0) {
+        fprintf(stderr, "checkpoint statistics snapshot did not retry successfully\n");
+        return 201;
+    }
+    printf("checkpoint_statistics_contention=1 busy_observed=1 "
+           "coherent_tuple=1 success=1\n");
+    fflush(stdout);
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    execv(self, argv);
+    perror("exec-checkpoint-statistics-snapshot-contention");
+    return 202;
+}
+
+static int
+run_exec_checkpoint_statistics_shadow_invalidation(const char* self)
+{
+    PeakTestReadyFn mutation_begin = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_mutation_begin");
+    PeakTestVoidFn mutation_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_mutation_release");
+    PeakTestReadyFn mutation_contend = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_general_listener_test_checkpoint_mutation_contend");
+    PeakTestReadyFn contender_invalidated = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT,
+        "peak_general_listener_test_checkpoint_mutation_contender_invalidated");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    TestHookThreadArgs contender_args = {.function = mutation_contend, .result = 0};
+    pthread_t contender_thread;
+
+    if (mutation_begin == NULL || mutation_release == NULL || mutation_contend == NULL ||
+        contender_invalidated == NULL || checkpoint == NULL) {
+        fprintf(stderr, "checkpoint shadow invalidation test hooks unavailable\n");
+        return 203;
+    }
+    call_hot_target(1);
+    if (mutation_begin() != 0) {
+        fprintf(stderr, "checkpoint shadow invalidation mutation setup failed\n");
+        return 204;
+    }
+    int rc = pthread_create(&contender_thread,
+                            NULL,
+                            test_hook_thread_main,
+                            &contender_args);
+    if (rc != 0) {
+        mutation_release();
+        fprintf(stderr, "pthread_create shadow contender failed: %s\n", strerror(rc));
+        return 205;
+    }
+    if (wait_for_test_hook(contender_invalidated, "checkpoint shadow invalidation") != 0) {
+        mutation_release();
+        return join_test_thread(contender_thread, "shadow contender") == 0 ? 206 : 207;
+    }
+    if (join_test_thread(contender_thread, "shadow contender") != 0 ||
+        contender_args.result != 0) {
+        mutation_release();
+        fprintf(stderr, "checkpoint shadow contender did not return promptly\n");
+        return 208;
+    }
+    errno = ERANGE;
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    if (checkpoint(self, argv) != -1 || errno != ERANGE) {
+        mutation_release();
+        fprintf(stderr, "checkpoint shadow invalidation did not fail closed errno=%d\n",
+                errno);
+        return 209;
+    }
+    mutation_release();
+    printf("checkpoint_shadow_invalidation=1 contender_returned=1 "
+           "errno_preserved=1 no_artifact=1 success=1\n");
+    fflush(stdout);
+    execv(self, argv);
+    perror("exec-checkpoint-statistics-shadow-invalidation");
+    return 210;
+}
+
+static int
+run_exec_checkpoint_direct_disabled(const char* self)
+{
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+
+    if (checkpoint == NULL) {
+        fprintf(stderr, "direct disabled checkpoint hook unavailable\n");
+        return 212;
+    }
+    errno = ERANGE;
+    if (checkpoint(self, argv) != -1 || errno != ERANGE) {
+        fprintf(stderr, "direct disabled checkpoint did not preserve errno=%d\n", errno);
+        return 213;
+    }
+    printf("checkpoint_direct_disabled=1 errno_preserved=1 success=1\n");
+    fflush(stdout);
+    execv(self, argv);
+    perror("exec-checkpoint-direct-disabled");
+    return 214;
 }
 
 static int
@@ -3884,6 +4042,15 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "exec-checkpoint-snapshot-lock-contention") == 0) {
         return run_exec_checkpoint_snapshot_lock_contention(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-statistics-snapshot-contention") == 0) {
+        return run_exec_checkpoint_statistics_snapshot_contention(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-statistics-shadow-invalidation") == 0) {
+        return run_exec_checkpoint_statistics_shadow_invalidation(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-direct-disabled") == 0) {
+        return run_exec_checkpoint_direct_disabled(argv[0]);
     }
     if (strcmp(argv[1], "exec-checkpoint-fork-child-fini") == 0) {
         return run_exec_checkpoint_fork_child_fini(argv[0]);

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -29,6 +29,7 @@ extern char** environ;
 #define EXTRA_PRELOAD_TOKEN_A "/tmp/peak_exec_chain_extra_preload_a.so"
 #define EXTRA_PRELOAD_TOKEN_B "/tmp/peak_exec_chain_extra_preload_b.so"
 #define LOADER_OBSERVER_ENV "EXEC_CHAIN_TEST_LOADER_OBSERVER"
+#define CONTROLLER_QUIESCE_ARG "--quiesce-controller"
 
 static volatile unsigned long peak_exec_chain_sink;
 
@@ -55,6 +56,20 @@ call_hot_target(int loops)
     for (int i = 0; i < loops; i++) {
         peak_exec_chain_hot_target(i);
     }
+}
+
+static void
+quiesce_controller_for_required_checkpoint(void)
+{
+    void (*controller_stop)(void);
+
+    controller_stop = (void (*)(void))dlsym(
+        RTLD_DEFAULT, "peak_general_listener_controller_stop");
+    if (controller_stop == NULL) {
+        fprintf(stderr, "general controller stop API unavailable\n");
+        exit(101);
+    }
+    controller_stop();
 }
 
 static const char*
@@ -1947,7 +1962,12 @@ run_fork_child_exec_parent_exec(const char* self)
             (char*)"child-basic",
             NULL
         };
-        call_hot_target(2);
+        /*
+         * The fork child inherits a multithreaded runtime with arbitrary
+         * library locks held.  Until exec, do not call instrumented ordinary
+         * functions: entering Gum may acquire an inherited allocator lock and
+         * deadlock permanently.
+         */
         execv(self, child_argv);
         _exit(175);
     }
@@ -2662,6 +2682,108 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
 }
 
 static int
+run_exec_checkpoint_snapshot_lock_contention(const char* self)
+{
+    PeakTestReadyFn hold = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT,
+        "peak_general_listener_test_checkpoint_snapshot_lock_hold");
+    PeakTestReadyFn release = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT,
+        "peak_general_listener_test_checkpoint_snapshot_lock_release");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    char* const missing_argv[] = {(char*)"missing-exec", NULL};
+    char* const child_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    int failure = 0;
+    int hold_rc;
+    int release_rc;
+
+    if (hold == NULL || release == NULL || checkpoint == NULL) {
+        fprintf(stderr, "checkpoint snapshot-lock test hooks unavailable\n");
+        return 187;
+    }
+
+    call_hot_target(5);
+    hold_rc = hold();
+    if (hold_rc != 0) {
+        fprintf(stderr,
+                "checkpoint snapshot-lock holder failed: %s\n",
+                strerror(hold_rc));
+        return 188;
+    }
+
+    errno = EALREADY;
+    if (checkpoint(self, child_argv) != -1 || errno != EALREADY) {
+        fprintf(stderr,
+                "checkpoint snapshot contention did not fail open: errno=%d\n",
+                errno);
+        failure = 189;
+        goto release_holder;
+    }
+
+    errno = EALREADY;
+    if (execv("/definitely/missing/peak-checkpoint-lock", missing_argv) != -1 ||
+        errno != ENOENT) {
+        fprintf(stderr,
+                "missing exec under checkpoint contention failed: errno=%d\n",
+                errno);
+        failure = 190;
+    }
+
+release_holder:
+    release_rc = release();
+    if (release_rc != 0) {
+        fprintf(stderr,
+                "checkpoint snapshot-lock release failed: %s\n",
+                strerror(release_rc));
+        return 191;
+    }
+    if (failure != 0) {
+        return failure;
+    }
+
+    errno = ERANGE;
+    if (checkpoint(self, child_argv) != 0 || errno != ERANGE) {
+        fprintf(stderr,
+                "checkpoint after snapshot-lock release failed: errno=%d\n",
+                errno);
+        return 192;
+    }
+
+    hold_rc = hold();
+    if (hold_rc != 0) {
+        fprintf(stderr,
+                "second checkpoint snapshot-lock hold failed: %s\n",
+                strerror(hold_rc));
+        return 193;
+    }
+    errno = EALREADY;
+    if (checkpoint(self, child_argv) != -1 || errno != EALREADY) {
+        fprintf(stderr,
+                "second checkpoint snapshot contention did not fail open: errno=%d\n",
+                errno);
+        failure = 194;
+    }
+    release_rc = release();
+    if (release_rc != 0) {
+        fprintf(stderr,
+                "second checkpoint snapshot-lock release failed: %s\n",
+                strerror(release_rc));
+        return 195;
+    }
+    if (failure != 0) {
+        return failure;
+    }
+
+    printf("checkpoint_snapshot_lock_contention=1 errno_preserved=1 "
+           "missing_exec_enoent=1 cleanup=1 repeatable=1 success=1\n");
+    fflush(stdout);
+    execv(self, child_argv);
+    perror("exec-checkpoint-snapshot-lock-contention");
+    return 196;
+}
+
+static int
 run_exec_checkpoint_fork_child_fini(const char* self)
 {
     pthread_t checkpoint_thread;
@@ -2792,6 +2914,9 @@ main(int argc, char** argv)
     if (argc < 2) {
         fprintf(stderr, "usage: %s <mode>\n", argv[0]);
         return 2;
+    }
+    if (argc >= 3 && strcmp(argv[argc - 1], CONTROLLER_QUIESCE_ARG) == 0) {
+        quiesce_controller_for_required_checkpoint();
     }
 
     if (strcmp(argv[1], "child-basic") == 0) {
@@ -3117,6 +3242,9 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "exec-concurrent-fini-callbacks") == 0) {
         return run_exec_checkpoint_concurrent_fini_callbacks(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-snapshot-lock-contention") == 0) {
+        return run_exec_checkpoint_snapshot_lock_contention(argv[0]);
     }
     if (strcmp(argv[1], "exec-checkpoint-fork-child-fini") == 0) {
         return run_exec_checkpoint_fork_child_fini(argv[0]);

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -2264,8 +2264,10 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
     printf("checkpoint_reader_gate_held=1 fini_waiting=1\n");
     fflush(stdout);
     reader_release();
-    if (join_test_thread(checkpoint_thread, "checkpoint reader") != 0 ||
-        join_test_thread(fini_thread, "fini") != 0) {
+    int checkpoint_join =
+        join_test_thread(checkpoint_thread, "checkpoint reader");
+    int fini_join = join_test_thread(fini_thread, "fini");
+    if (checkpoint_join != 0 || fini_join != 0) {
         return 185;
     }
 
@@ -2273,6 +2275,131 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
     execv(self, argv);
     perror("exec-concurrent-fini-callbacks");
     return 186;
+}
+
+static int
+run_exec_checkpoint_fork_child_fini(const char* self)
+{
+    pthread_t checkpoint_thread;
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    pid_t pid;
+    int child_status;
+    int checkpoint_child_ok = 0;
+    int failed_exec_child_ok = 0;
+    int normal_return_child_ok = 0;
+
+    if (checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL) {
+        fprintf(stderr, "checkpoint/fork test hooks unavailable\n");
+        return 195;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    int create_rc = pthread_create(&checkpoint_thread,
+                                   NULL,
+                                   checkpoint_thread_main,
+                                   &checkpoint_args);
+    if (create_rc != 0) {
+        fprintf(stderr,
+                "pthread_create fork checkpoint reader failed: %s\n",
+                strerror(create_rc));
+        return 196;
+    }
+    if (wait_for_test_hook(reader_is_held,
+                           "checkpoint reader before fork") != 0) {
+        reader_release();
+        int join_rc = join_test_thread(checkpoint_thread,
+                                       "fork checkpoint reader");
+        return join_rc == 0 ? 196 : 198;
+    }
+
+    pid = fork();
+    if (pid == 0) {
+        char* const child_argv[] = {(char*)self, (char*)"child-basic", NULL};
+
+        alarm(10);
+        errno = EAGAIN;
+        if (checkpoint(self, child_argv) != -1 || errno != EAGAIN) {
+            _exit(200);
+        }
+        exit(0);
+    }
+    if (pid < 0) {
+        int fork_errno = errno;
+
+        reader_release();
+        int join_rc = join_test_thread(checkpoint_thread,
+                                       "fork checkpoint reader");
+        fprintf(stderr,
+                "fork checkpoint child failed: %s\n",
+                strerror(fork_errno));
+        return join_rc == 0 ? 197 : 198;
+    }
+
+    child_status = wait_for_child(pid);
+    checkpoint_child_ok = child_status == 0;
+    if (!checkpoint_child_ok) {
+        fprintf(stderr, "checkpoint_fork_child_status=%d\n", child_status);
+    }
+
+    pid = fork();
+    if (pid == 0) {
+        char* const child_argv[] = {(char*)"missing-exec", NULL};
+
+        alarm(10);
+        errno = 0;
+        if (execv("/definitely/missing/peak-exec-child", child_argv) != -1 ||
+            errno != ENOENT) {
+            _exit(201);
+        }
+        exit(0);
+    }
+    if (pid < 0) {
+        perror("fork failed-exec child");
+    } else {
+        child_status = wait_for_child(pid);
+        failed_exec_child_ok = child_status == 0;
+        if (!failed_exec_child_ok) {
+            fprintf(stderr, "failed_exec_fork_child_status=%d\n", child_status);
+        }
+    }
+
+    pid = fork();
+    if (pid == 0) {
+        alarm(10);
+        return 0;
+    }
+    if (pid < 0) {
+        perror("fork normal-return child");
+    } else {
+        child_status = wait_for_child(pid);
+        normal_return_child_ok = child_status == 0;
+        if (!normal_return_child_ok) {
+            fprintf(stderr, "normal_return_fork_child_status=%d\n", child_status);
+        }
+    }
+
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "checkpoint reader") != 0) {
+        return 198;
+    }
+    if (!checkpoint_child_ok || !failed_exec_child_ok ||
+        !normal_return_child_ok) {
+        return 199;
+    }
+    printf("fork_child_checkpoint_skipped=1 failed_exec_exit=1 "
+           "normal_return_exit=1 parent_pid=%ld\n",
+           (long)getpid());
+    return 0;
 }
 
 int
@@ -2552,7 +2679,9 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "exec-concurrent-fini-callbacks") == 0) {
         return run_exec_checkpoint_concurrent_fini_callbacks(argv[0]);
     }
-
+    if (strcmp(argv[1], "exec-checkpoint-fork-child-fini") == 0) {
+        return run_exec_checkpoint_fork_child_fini(argv[0]);
+    }
     fprintf(stderr, "unknown mode: %s\n", argv[1]);
     return 2;
 }

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -28,6 +28,7 @@
 extern char** environ;
 #define EXTRA_PRELOAD_TOKEN_A "/tmp/peak_exec_chain_extra_preload_a.so"
 #define EXTRA_PRELOAD_TOKEN_B "/tmp/peak_exec_chain_extra_preload_b.so"
+#define LOADER_OBSERVER_ENV "EXEC_CHAIN_TEST_LOADER_OBSERVER"
 
 static volatile unsigned long peak_exec_chain_sink;
 
@@ -713,6 +714,9 @@ run_child_print_ld(void)
     const char* peak_exec_chain = getenv("PEAK_EXEC_CHAIN");
     const char* peak_exec_checkpoint = getenv("PEAK_EXEC_CHECKPOINT");
     const char* peak_exec_propagate = getenv("PEAK_EXEC_PROPAGATE_PEAK_ENV");
+    const char* path = getenv("PATH");
+    const char* loader_observer = getenv(LOADER_OBSERVER_ENV);
+    const char* secure_test_hook = getenv("PEAK_TEST_EXEC_AT_SECURE");
     const char* loader_path_0 = ld_library_path_env_value(0);
     const char* loader_path_1 = ld_library_path_env_value(1);
 
@@ -721,7 +725,8 @@ run_child_print_ld(void)
            "ld_preload_extra_count=%d peak_target=%s peak_statslog=%s "
            "marker=%s peak_exec_chain=%s peak_exec_checkpoint=%s "
            "peak_exec_propagate=%s ld_library_path_env_entries=%d "
-           "ld_library_path_0=%s ld_library_path_1=%s\n",
+           "ld_library_path_0=%s ld_library_path_1=%s path=%s "
+           "loader_observer=%s secure_test_hook=%s\n",
            count_libpeak_preload_entries(),
            count_ld_preload_env_entries(),
            count_extra_preload_entries(),
@@ -733,7 +738,10 @@ run_child_print_ld(void)
            peak_exec_propagate != NULL ? peak_exec_propagate : "<missing>",
            count_ld_library_path_env_entries(),
            loader_path_0 != NULL ? loader_path_0 : "<missing>",
-           loader_path_1 != NULL ? loader_path_1 : "<missing>");
+           loader_path_1 != NULL ? loader_path_1 : "<missing>",
+           path != NULL ? path : "<missing>",
+           loader_observer != NULL ? loader_observer : "<missing>",
+           secure_test_hook != NULL ? secure_test_hook : "<missing>");
     fflush(stdout);
     return 0;
 }
@@ -895,7 +903,8 @@ run_execve_loader_path_env(const char* self,
                            const char* second_value,
                            int disable_chain)
 {
-    const char* child = self;
+    const char* observer = getenv(LOADER_OBSERVER_ENV);
+    const char* child = observer != NULL && observer[0] != '\0' ? observer : self;
     char* argv[] = {(char*)self, (char*)"child-print-ld", NULL};
     char** envp = make_loader_path_child_env(marker, value, second_value);
     size_t index = 0;
@@ -903,13 +912,8 @@ run_execve_loader_path_env(const char* self,
     while (envp[index] != NULL) {
         index++;
     }
+    argv[0] = (char*)child;
     if (disable_chain) {
-        const char* observer = getenv("EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER");
-
-        if (observer != NULL && observer[0] != '\0') {
-            child = observer;
-            argv[0] = (char*)child;
-        }
         envp[index++] = make_env_entry("PEAK_EXEC_CHAIN", "0");
         envp[index] = NULL;
     }
@@ -2070,8 +2074,10 @@ run_postfork_custom_env(const char* self,
                         int use_raw_syscall,
                         int omit_loader_path)
 {
+    const char* observer = getenv(LOADER_OBSERVER_ENV);
+    const char* child = observer != NULL && observer[0] != '\0' ? observer : self;
     char* const child_argv[] = {
-        (char*)self,
+        (char*)child,
         (char*)"child-print-ld",
         NULL
     };
@@ -2106,15 +2112,15 @@ run_postfork_custom_env(const char* self,
     }
     if (pid == 0) {
         if (use_execle) {
-            execle(self,
-                   self,
+            execle(child,
+                   child,
                    "child-print-ld",
                    (char*)NULL,
                    child_env);
         } else if (use_raw_syscall) {
-            (void)syscall(SYS_execve, self, child_argv, child_env);
+            (void)syscall(SYS_execve, child, child_argv, child_env);
         } else {
-            execve(self, child_argv, child_env);
+            execve(child, child_argv, child_env);
         }
         _exit(193);
     }
@@ -2174,7 +2180,9 @@ run_vfork_preloaded_env(const char* self)
 static int
 run_fork_parent_env_exhaustion(const char* self)
 {
-    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    const char* observer = getenv(LOADER_OBSERVER_ENV);
+    const char* child = observer != NULL && observer[0] != '\0' ? observer : self;
+    char* const child_argv[] = {(char*)child, (char*)"child-print-ld", NULL};
     char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
     char** child_env = make_child_control_env("parent-env-exhaustion");
     pid_t pid = fork();
@@ -2186,7 +2194,7 @@ run_fork_parent_env_exhaustion(const char* self)
     }
     if (pid == 0) {
         environ = make_unterminated_nonpeak_env();
-        execve(self, child_argv, child_env);
+        execve(child, child_argv, child_env);
         _exit(232);
     }
     child_status = wait_for_child(pid);
@@ -2337,7 +2345,12 @@ run_postfork_bad_env(const char* self, int use_vfork, int bad_string)
 static int
 run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
 {
-    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    const char* observer = getenv(LOADER_OBSERVER_ENV);
+    const char* child = observer != NULL && observer[0] != '\0' ? observer : self;
+    const char* child_mode = child == self ?
+        "child-print-ld" :
+        (long_preload ? "capacity-long-preload" : "capacity-env-slots");
+    char* const child_argv[] = {(char*)child, (char*)child_mode, NULL};
     char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
     char** envp = long_preload ? make_long_preload_child_env() :
                                 make_large_child_env();
@@ -2349,7 +2362,7 @@ run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
         return 219;
     }
     if (pid == 0) {
-        execve(self, child_argv, envp);
+        execve(child, child_argv, envp);
         _exit(220);
     }
     child_status = wait_for_child(pid);
@@ -2357,8 +2370,72 @@ run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
         fprintf(stderr, "postfork_capacity_child_status=%d\n", child_status);
         return 221;
     }
-    printf("postfork_capacity_passthrough=1 kind=%s\n",
-           long_preload ? "long-preload" : "env-slots");
+    const size_t bounded_entries = long_preload ? 3 : 514;
+    size_t input_entries = 0;
+    size_t input_pad_validated_count = 0;
+    size_t input_pad_mismatch_count = 0;
+    size_t input_preload_entries = 0;
+    size_t input_preload_length = 0;
+    int input_preload_all_x = 1;
+    size_t input_path_entries = 0;
+    size_t input_loader_path_entries = 0;
+
+    for (size_t index = 0; index < bounded_entries; index++) {
+        const char* entry = envp[index];
+
+        if (entry == NULL) {
+            continue;
+        }
+        input_entries++;
+        if (strncmp(entry, "LD_PRELOAD=", strlen("LD_PRELOAD=")) == 0) {
+            const char* value = entry + strlen("LD_PRELOAD=");
+
+            input_preload_entries++;
+            input_preload_length += strlen(value);
+            for (const char* scan = value; *scan != '\0'; scan++) {
+                if (*scan != 'x') {
+                    input_preload_all_x = 0;
+                }
+            }
+        } else if (strncmp(entry, "PATH=", strlen("PATH=")) == 0) {
+            input_path_entries++;
+        } else if (strncmp(entry,
+                           "LD_LIBRARY_PATH=",
+                           strlen("LD_LIBRARY_PATH=")) == 0) {
+            input_loader_path_entries++;
+        }
+    }
+    if (!long_preload) {
+        char expected[64];
+
+        for (size_t index = 0; index < 512; index++) {
+            snprintf(expected,
+                     sizeof(expected),
+                     "CHILD_PAD_%04zu=x",
+                     index);
+            if (envp[index + 2] != NULL &&
+                strcmp(envp[index + 2], expected) == 0) {
+                input_pad_validated_count++;
+            } else {
+                input_pad_mismatch_count++;
+            }
+        }
+    }
+    printf("postfork_capacity_passthrough=1 kind=%s input_entries=%zu "
+           "input_pad_validated_count=%zu input_pad_mismatch_count=%zu "
+           "input_preload_entries=%zu input_preload_length=%zu "
+           "input_preload_all_x=%d input_path_entries=%zu "
+           "input_loader_path_entries=%zu input_terminator_null=%d\n",
+           long_preload ? "long-preload" : "env-slots",
+           input_entries,
+           input_pad_validated_count,
+           input_pad_mismatch_count,
+           input_preload_entries,
+           input_preload_length,
+           input_preload_all_x,
+           input_path_entries,
+           input_loader_path_entries,
+           envp[bounded_entries] == NULL ? 1 : 0);
     fflush(stdout);
     call_hot_target(5);
     execv(self, parent_argv);
@@ -2369,7 +2446,11 @@ run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
 static int
 run_vfork_preload_entries_fallback(const char* self)
 {
-    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    const char* observer = getenv(LOADER_OBSERVER_ENV);
+    const char* child = observer != NULL && observer[0] != '\0' ? observer : self;
+    const char* child_mode = child == self ?
+        "child-print-ld" : "capacity-preload-entries";
+    char* const child_argv[] = {(char*)child, (char*)child_mode, NULL};
     char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
     char** envp = make_preload_entries_without_terminator();
     pid_t pid = vfork();
@@ -2380,7 +2461,7 @@ run_vfork_preload_entries_fallback(const char* self)
         return 223;
     }
     if (pid == 0) {
-        execve(self, child_argv, envp);
+        execve(child, child_argv, envp);
         _exit(224);
     }
     child_status = wait_for_child(pid);
@@ -2388,7 +2469,43 @@ run_vfork_preload_entries_fallback(const char* self)
         fprintf(stderr, "postfork_preload_entries_child_status=%d\n", child_status);
         return 225;
     }
-    printf("postfork_preload_entries_passthrough=1\n");
+    const size_t bounded_entries = 256;
+    size_t input_entries = 0;
+    size_t input_preload_entries = 0;
+    size_t input_nonempty_preload_entries = 0;
+    size_t input_path_entries = 0;
+    size_t input_loader_path_entries = 0;
+
+    for (size_t index = 0; index < bounded_entries; index++) {
+        const char* entry = envp[index];
+
+        if (entry == NULL) {
+            continue;
+        }
+        input_entries++;
+        if (strncmp(entry, "LD_PRELOAD=", strlen("LD_PRELOAD=")) == 0) {
+            input_preload_entries++;
+            if (entry[strlen("LD_PRELOAD=")] != '\0') {
+                input_nonempty_preload_entries++;
+            }
+        } else if (strncmp(entry, "PATH=", strlen("PATH=")) == 0) {
+            input_path_entries++;
+        } else if (strncmp(entry,
+                           "LD_LIBRARY_PATH=",
+                           strlen("LD_LIBRARY_PATH=")) == 0) {
+            input_loader_path_entries++;
+        }
+    }
+    printf("postfork_preload_entries_passthrough=1 input_entries=%zu "
+           "input_preload_entries=%zu input_nonempty_preload_entries=%zu "
+           "input_path_entries=%zu "
+           "input_loader_path_entries=%zu input_terminator_null=%d\n",
+           input_entries,
+           input_preload_entries,
+           input_nonempty_preload_entries,
+           input_path_entries,
+           input_loader_path_entries,
+           envp[bounded_entries] == NULL ? 1 : 0);
     fflush(stdout);
     call_hot_target(5);
     execv(self, parent_argv);

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -1,0 +1,2489 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#if defined(__GNUC__)
+#define PEAK_NOINLINE __attribute__((noinline, noclone))
+#define PEAK_EXPORT __attribute__((visibility("default"), used, externally_visible))
+#else
+#define PEAK_NOINLINE
+#define PEAK_EXPORT
+#endif
+
+extern char** environ;
+#define EXTRA_PRELOAD_TOKEN_A "/tmp/peak_exec_chain_extra_preload_a.so"
+#define EXTRA_PRELOAD_TOKEN_B "/tmp/peak_exec_chain_extra_preload_b.so"
+
+static volatile unsigned long peak_exec_chain_sink;
+
+typedef struct {
+    char* name;
+    char* value;
+} EnvSnapshotEntry;
+
+typedef struct {
+    EnvSnapshotEntry entries[128];
+    size_t count;
+} EnvSnapshot;
+
+void PEAK_EXPORT PEAK_NOINLINE
+peak_exec_chain_hot_target(int value)
+{
+    peak_exec_chain_sink += (unsigned long)value + 1UL;
+    asm volatile("" ::: "memory");
+}
+
+static void
+call_hot_target(int loops)
+{
+    for (int i = 0; i < loops; i++) {
+        peak_exec_chain_hot_target(i);
+    }
+}
+
+static const char*
+env_or_default(const char* name, const char* fallback)
+{
+    const char* value = getenv(name);
+    return value != NULL && value[0] != '\0' ? value : fallback;
+}
+
+static char*
+make_env_entry(const char* name, const char* value)
+{
+    size_t name_len = strlen(name);
+    size_t value_len = strlen(value);
+    char* entry = malloc(name_len + 1 + value_len + 1);
+
+    if (entry == NULL) {
+        perror("malloc");
+        exit(100);
+    }
+    memcpy(entry, name, name_len);
+    entry[name_len] = '=';
+    memcpy(entry + name_len + 1, value, value_len + 1);
+    return entry;
+}
+
+static void
+append_current_env_entry_if_present(char** envp, size_t* index, const char* name)
+{
+    const char* value = getenv(name);
+
+    if (value != NULL && value[0] != '\0') {
+        envp[(*index)++] = make_env_entry(name, value);
+    }
+}
+
+static char**
+make_minimal_child_env(const char* marker)
+{
+    char** envp = calloc(6, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", marker);
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_bad_path_child_env(void)
+{
+    char** envp = calloc(5, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH", "/definitely/not/a/peak/path");
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", "bad-path-env");
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_large_child_env(void)
+{
+    const size_t pad_count = 512;
+    char** envp = calloc(pad_count + 5, sizeof(char*));
+    char name[64];
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", "large-env");
+    for (size_t i = 0; i < pad_count; i++) {
+        snprintf(name, sizeof(name), "CHILD_PAD_%04zu", i);
+        envp[index++] = make_env_entry(name, "x");
+    }
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_long_preload_child_env(void)
+{
+    const size_t value_len = PATH_MAX * 2U;
+    char* value = malloc(value_len + 1);
+    char** envp = calloc(5, sizeof(char*));
+
+    if (value == NULL || envp == NULL) {
+        perror("malloc");
+        exit(100);
+    }
+    memset(value, 'x', value_len);
+    value[value_len] = '\0';
+    envp[0] = make_env_entry("PATH", env_or_default("PATH", "/bin:/usr/bin"));
+    envp[1] = make_env_entry("EXEC_CHAIN_TEST_MARKER", "postfork-long-preload");
+    envp[2] = make_env_entry("LD_PRELOAD", value);
+    free(value);
+    return envp;
+}
+
+static char*
+make_duplicate_preload_value(void)
+{
+    const char* preload = env_or_default("LD_PRELOAD", "");
+    size_t preload_len = strlen(preload);
+    size_t extra_a_len = strlen(EXTRA_PRELOAD_TOKEN_A);
+    size_t extra_b_len = strlen(EXTRA_PRELOAD_TOKEN_B);
+    char* value = malloc(preload_len * 2 + extra_a_len + extra_b_len + 4);
+
+    if (value == NULL) {
+        perror("malloc");
+        exit(100);
+    }
+    sprintf(value,
+            "%s:%s:%s:%s",
+            EXTRA_PRELOAD_TOKEN_A,
+            preload,
+            EXTRA_PRELOAD_TOKEN_B,
+            preload);
+    return value;
+}
+
+static char*
+make_whitespace_duplicate_preload_value(void)
+{
+    const char* preload = env_or_default("LD_PRELOAD", "");
+    size_t preload_len = strlen(preload);
+    size_t extra_a_len = strlen(EXTRA_PRELOAD_TOKEN_A);
+    size_t extra_b_len = strlen(EXTRA_PRELOAD_TOKEN_B);
+    char* value = malloc(preload_len * 2 + extra_a_len + extra_b_len + 5);
+
+    if (value == NULL) {
+        perror("malloc");
+        exit(100);
+    }
+    sprintf(value,
+            "%s %s\t%s\n%s",
+            EXTRA_PRELOAD_TOKEN_A,
+            preload,
+            EXTRA_PRELOAD_TOKEN_B,
+            preload);
+    return value;
+}
+
+static char**
+make_duplicate_preload_env_with(char* duplicate_preload,
+                                const char* marker)
+{
+    char** envp = calloc(9, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("LD_PRELOAD", duplicate_preload);
+    envp[index++] = make_env_entry("PEAK_TARGET",
+                                   env_or_default("PEAK_TARGET",
+                                                  "peak_exec_chain_hot_target"));
+    envp[index++] = make_env_entry("PEAK_STATSLOG_PATH",
+                                   env_or_default("PEAK_STATSLOG_PATH",
+                                                  "./peak_statslog"));
+    envp[index++] = make_env_entry("PEAK_HEARTBEAT_INTERVAL", "0");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", marker);
+    envp[index] = NULL;
+    free(duplicate_preload);
+    return envp;
+}
+
+static char**
+make_duplicate_preload_env(void)
+{
+    return make_duplicate_preload_env_with(make_duplicate_preload_value(),
+                                           "duplicate-preload");
+}
+
+static char**
+make_whitespace_duplicate_preload_env(void)
+{
+    return make_duplicate_preload_env_with(
+        make_whitespace_duplicate_preload_value(),
+        "duplicate-preload-whitespace");
+}
+
+static char**
+make_duplicate_preload_entry_env(void)
+{
+    const char* preload = env_or_default("LD_PRELOAD", "");
+    char** envp = calloc(11, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("LD_PRELOAD", EXTRA_PRELOAD_TOKEN_A);
+    envp[index++] = make_env_entry("LD_PRELOAD", preload);
+    envp[index++] = make_env_entry("LD_PRELOAD", EXTRA_PRELOAD_TOKEN_B);
+    envp[index++] = make_env_entry("PEAK_TARGET",
+                                   env_or_default("PEAK_TARGET",
+                                                  "peak_exec_chain_hot_target"));
+    envp[index++] = make_env_entry("PEAK_STATSLOG_PATH",
+                                   env_or_default("PEAK_STATSLOG_PATH",
+                                                  "./peak_statslog"));
+    envp[index++] = make_env_entry("PEAK_HEARTBEAT_INTERVAL", "0");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER",
+                                   "duplicate-preload-entry");
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_child_path_env(void)
+{
+    char** envp = calloc(5, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry(
+        "PATH",
+        env_or_default("EXEC_CHAIN_TEST_CHILD_PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER",
+                                   "child-path-env");
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_child_path_duplicate_preload_env(void)
+{
+    char* duplicate_preload = make_duplicate_preload_value();
+    char** envp = calloc(6, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry(
+        "PATH",
+        env_or_default("EXEC_CHAIN_TEST_CHILD_PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("LD_PRELOAD", duplicate_preload);
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER",
+                                   "child-path-duplicate-preload-env");
+    envp[index] = NULL;
+    free(duplicate_preload);
+    return envp;
+}
+
+static char**
+make_child_peak_only_env(void)
+{
+    char** envp = calloc(7, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER",
+                                   "child-peak-env");
+    envp[index++] = make_env_entry("PEAK_TARGET",
+                                   "peak_exec_chain_hot_target");
+    envp[index++] = make_env_entry(
+        "PEAK_STATSLOG_PATH",
+        env_or_default("EXEC_CHAIN_CHILD_STATS_PREFIX", "./peak_statslog"));
+    envp[index++] = make_env_entry("PEAK_HEARTBEAT_INTERVAL", "0");
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_explicit_peak_env(void)
+{
+    char** envp = calloc(8, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("PEAK_TARGET", "explicit_child_target");
+    envp[index++] = make_env_entry("PEAK_STATSLOG_PATH",
+                                   env_or_default("PEAK_STATSLOG_PATH",
+                                                  "./peak_statslog"));
+    envp[index++] = make_env_entry("PEAK_HEARTBEAT_INTERVAL", "0");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER",
+                                   "explicit-peak-env");
+    envp[index] = NULL;
+    return envp;
+}
+
+static char**
+make_child_peak_control_env(const char* name, const char* value)
+{
+    char** envp = calloc(10, sizeof(char*));
+    size_t index = 0;
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[index++] = make_env_entry("PATH",
+                                   env_or_default("PATH", "/bin:/usr/bin"));
+    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
+    envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", name);
+    envp[index++] = make_env_entry(name, value);
+    envp[index] = NULL;
+    return envp;
+}
+
+static char* const*
+invalid_envp_for_test(void)
+{
+    return (char* const*)(uintptr_t)1;
+}
+
+static char* const*
+invalid_argv_for_test(void)
+{
+    return (char* const*)(uintptr_t)1;
+}
+
+static void
+snapshot_and_unset_peak_env(EnvSnapshot* snapshot)
+{
+    if (snapshot == NULL) {
+        return;
+    }
+    memset(snapshot, 0, sizeof(*snapshot));
+    if (environ != NULL) {
+        for (char** scan = environ;
+             *scan != NULL && snapshot->count < 128;
+             scan++) {
+            const char* equals = strchr(*scan, '=');
+            size_t name_len;
+
+            if (equals == NULL) {
+                continue;
+            }
+            name_len = (size_t)(equals - *scan);
+            if (strncmp(*scan, "PEAK_", 5) != 0 &&
+                !(name_len == strlen("LD_PRELOAD") &&
+                  strncmp(*scan, "LD_PRELOAD", name_len) == 0)) {
+                continue;
+            }
+            snapshot->entries[snapshot->count].name =
+                strndup(*scan, name_len);
+            snapshot->entries[snapshot->count].value = strdup(equals + 1);
+            if (snapshot->entries[snapshot->count].name != NULL &&
+                snapshot->entries[snapshot->count].value != NULL) {
+                snapshot->count++;
+            } else {
+                free(snapshot->entries[snapshot->count].name);
+                free(snapshot->entries[snapshot->count].value);
+                snapshot->entries[snapshot->count].name = NULL;
+                snapshot->entries[snapshot->count].value = NULL;
+            }
+        }
+    }
+    for (size_t i = 0; i < snapshot->count; i++) {
+        unsetenv(snapshot->entries[i].name);
+    }
+}
+
+static void
+restore_peak_env_snapshot(EnvSnapshot* snapshot)
+{
+    if (snapshot == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < snapshot->count; i++) {
+        setenv(snapshot->entries[i].name, snapshot->entries[i].value, 1);
+        free(snapshot->entries[i].name);
+        free(snapshot->entries[i].value);
+        snapshot->entries[i].name = NULL;
+        snapshot->entries[i].value = NULL;
+    }
+    snapshot->count = 0;
+}
+
+static int
+wait_for_child(pid_t pid)
+{
+    int status;
+
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        perror("waitpid");
+        return 125;
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return 126;
+}
+
+static int
+count_libpeak_preload_entries(void)
+{
+    const char* preload = getenv("LD_PRELOAD");
+    int count = 0;
+
+    if (preload == NULL) {
+        return 0;
+    }
+    while (*preload != '\0') {
+        const char* start;
+        size_t len;
+
+        while (*preload == ':' || *preload == ' ' ||
+               *preload == '\t' || *preload == '\n') {
+            preload++;
+        }
+        start = preload;
+        while (*preload != '\0' && *preload != ':' &&
+               *preload != ' ' && *preload != '\t' &&
+               *preload != '\n') {
+            preload++;
+        }
+        len = (size_t)(preload - start);
+        if (len != 0 && memmem(start, len, "libpeak", strlen("libpeak")) != NULL) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+count_extra_preload_entries(void)
+{
+    const char* preload = getenv("LD_PRELOAD");
+    int count = 0;
+
+    if (preload == NULL) {
+        return 0;
+    }
+    while (*preload != '\0') {
+        const char* start;
+        size_t len;
+
+        while (*preload == ':' || *preload == ' ' ||
+               *preload == '\t' || *preload == '\n') {
+            preload++;
+        }
+        start = preload;
+        while (*preload != '\0' && *preload != ':' &&
+               *preload != ' ' && *preload != '\t' &&
+               *preload != '\n') {
+            preload++;
+        }
+        len = (size_t)(preload - start);
+        if ((len == strlen(EXTRA_PRELOAD_TOKEN_A) &&
+             strncmp(start, EXTRA_PRELOAD_TOKEN_A, len) == 0) ||
+            (len == strlen(EXTRA_PRELOAD_TOKEN_B) &&
+             strncmp(start, EXTRA_PRELOAD_TOKEN_B, len) == 0)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+count_ld_preload_env_entries(void)
+{
+    int count = 0;
+
+    if (environ == NULL) {
+        return 0;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        if (strncmp(*scan, "LD_PRELOAD=", strlen("LD_PRELOAD=")) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+run_child_basic(void)
+{
+    call_hot_target(7);
+    printf("exec_child_ok sink=%lu\n", peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_child_print_ld(void)
+{
+    const char* marker = getenv("EXEC_CHAIN_TEST_MARKER");
+    const char* peak_target = getenv("PEAK_TARGET");
+    const char* peak_stats = getenv("PEAK_STATSLOG_PATH");
+    const char* peak_exec_chain = getenv("PEAK_EXEC_CHAIN");
+    const char* peak_exec_checkpoint = getenv("PEAK_EXEC_CHECKPOINT");
+    const char* peak_exec_propagate = getenv("PEAK_EXEC_PROPAGATE_PEAK_ENV");
+
+    call_hot_target(7);
+    printf("ld_preload_libpeak_count=%d ld_preload_env_entries=%d "
+           "ld_preload_extra_count=%d peak_target=%s peak_statslog=%s "
+           "marker=%s peak_exec_chain=%s peak_exec_checkpoint=%s "
+           "peak_exec_propagate=%s\n",
+           count_libpeak_preload_entries(),
+           count_ld_preload_env_entries(),
+           count_extra_preload_entries(),
+           peak_target != NULL ? peak_target : "<missing>",
+           peak_stats != NULL ? peak_stats : "<missing>",
+           marker != NULL ? marker : "<missing>",
+           peak_exec_chain != NULL ? peak_exec_chain : "<missing>",
+           peak_exec_checkpoint != NULL ? peak_exec_checkpoint : "<missing>",
+           peak_exec_propagate != NULL ? peak_exec_propagate : "<missing>");
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_child_check_env(const char* name)
+{
+    const char* value = getenv(name);
+
+    call_hot_target(7);
+    printf("child_env_%s=%s\n", name, value != NULL ? value : "<missing>");
+    fflush(stdout);
+    return value != NULL ? 0 : 3;
+}
+
+static int
+run_child_stderr_sentinel(void)
+{
+    call_hot_target(7);
+    printf("child_stdout_after_stderr_close sink=%lu\n", peak_exec_chain_sink);
+    fflush(stdout);
+    fprintf(stderr, "child_stderr_sentinel_after_spawn_close\n");
+    fflush(stderr);
+    return 0;
+}
+
+static int
+run_execv_success(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    execv(self, argv);
+    perror("execv-success");
+    return 111;
+}
+
+static int
+run_execv_zero_call_checkpoint(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    execv(self, argv);
+    perror("execv-zero-call");
+    return 112;
+}
+
+static int
+run_execv_write_target_success(const char* self)
+{
+    static const char marker[] = "parent_write_before_exec\n";
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+
+    if (write(STDOUT_FILENO, marker, sizeof(marker) - 1) < 0) {
+        perror("write-before-exec");
+        return 142;
+    }
+    execv(self, argv);
+    perror("execv-write-target");
+    return 143;
+}
+
+static int
+run_execve_custom_env(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("custom-env");
+    execve(self, argv, envp);
+    perror("execve-custom-env");
+    return 113;
+}
+
+static int
+run_raw_syscall_execve_custom_env(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("raw-syscall-execve-env");
+
+    call_hot_target(5);
+    syscall(SYS_execve, self, argv, envp);
+    perror("raw-syscall-execve-custom-env");
+    return 215;
+}
+
+static int
+run_raw_syscall_execve_failure(void)
+{
+    char* const argv[] = {(char*)"/definitely/not/found", NULL};
+    int saved_errno;
+
+    call_hot_target(2);
+    errno = 0;
+    if (syscall(SYS_execve, "/definitely/not/found", argv, environ) != -1) {
+        return 216;
+    }
+    saved_errno = errno;
+    call_hot_target(4);
+    printf("raw_syscall_execve_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return saved_errno == ENOENT ? 0 : 217;
+}
+
+static int
+run_raw_syscall_nonexec_passthrough(void)
+{
+    long pid;
+    long close_rc;
+    const char marker[] = "raw_syscall_write=ok\n";
+    long write_rc;
+
+    errno = EALREADY;
+    pid = syscall(SYS_getpid);
+    errno = 0;
+    close_rc = syscall(SYS_close, -1);
+    if (close_rc != -1 || errno != EBADF) {
+        return 218;
+    }
+    errno = EALREADY;
+    write_rc = syscall(SYS_write, STDOUT_FILENO, marker, sizeof(marker) - 1);
+    printf("raw_syscall_getpid=%ld expected=%ld errno=%d\n",
+           pid,
+           (long)getpid(),
+           errno);
+    fflush(stdout);
+    return pid == (long)getpid() && write_rc == (long)(sizeof(marker) - 1) ?
+               0 :
+               219;
+}
+
+static int
+run_execve_child_peak_env_only(const char* self)
+{
+    EnvSnapshot parent_env;
+
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_child_peak_only_env();
+    snapshot_and_unset_peak_env(&parent_env);
+    execve(self, argv, envp);
+    perror("execve-child-peak-env-only");
+    return 145;
+}
+
+static int
+run_execve_null_env(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    execve(self, argv, NULL);
+    perror("execve-null-env");
+    return 114;
+}
+
+static int
+run_execve_large_env(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_large_child_env();
+    execve(self, argv, envp);
+    perror("execve-large-env");
+    return 115;
+}
+
+static int
+run_execve_bad_env_failure(void)
+{
+    char* const argv[] = {(char*)"/bin/true", NULL};
+    int result;
+    int saved_errno;
+
+    call_hot_target(3);
+    errno = 0;
+    result = execve("/bin/true", argv, invalid_envp_for_test());
+    saved_errno = errno;
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "execve_bad_env_bad_result result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 146;
+    }
+    call_hot_target(3);
+    printf("execve_bad_env_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_execve_bad_argv_failure(void)
+{
+    int result;
+    int saved_errno;
+
+    call_hot_target(3);
+    errno = 0;
+    result = execve("/bin/true", invalid_argv_for_test(), environ);
+    saved_errno = errno;
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "execve_bad_argv_bad_result result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 147;
+    }
+    call_hot_target(3);
+    printf("execve_bad_argv_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_execve_explicit_peak_env(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {
+        (char*)self,
+        (char*)"child-check-env",
+        (char*)"PEAK_TARGET",
+        NULL
+    };
+    char** envp = make_explicit_peak_env();
+    execve(self, argv, envp);
+    perror("execve-explicit-peak-env");
+    return 116;
+}
+
+static int
+run_execve_child_peak_control(const char* self,
+                              const char* name,
+                              const char* value)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_child_peak_control_env(name, value);
+
+    call_hot_target(5);
+    execve(self, argv, envp);
+    perror("execve-child-peak-control");
+    return 173;
+}
+
+static int
+run_exec_failure(void)
+{
+    char* const argv[] = {(char*)"/definitely/not/found", NULL};
+    int saved_errno;
+
+    call_hot_target(2);
+    errno = 0;
+    execv("/definitely/not/found", argv);
+    saved_errno = errno;
+    call_hot_target(4);
+    printf("exec_failure_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return saved_errno == ENOENT ? 0 : 117;
+}
+
+static int
+run_fexecve_custom_env(const char* self)
+{
+    int fd = open(self, O_RDONLY);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("fexecve-env");
+
+    if (fd < 0) {
+        perror("open-self");
+        return 118;
+    }
+    call_hot_target(5);
+    fexecve(fd, argv, envp);
+    perror("fexecve-custom-env");
+    close(fd);
+    return 119;
+}
+
+static int
+run_fexecve_bad_env_failure(const char* self)
+{
+    int fd = open(self, O_RDONLY);
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    int result;
+    int saved_errno;
+
+    if (fd < 0) {
+        perror("open-fexecve-bad-env");
+        return 148;
+    }
+    call_hot_target(2);
+    errno = 0;
+    result = fexecve(fd, argv, invalid_envp_for_test());
+    saved_errno = errno;
+    close(fd);
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "fexecve_bad_env_result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 149;
+    }
+    call_hot_target(4);
+    printf("fexecve_bad_env_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_fexecve_bad_argv_failure(const char* self)
+{
+    int fd = open(self, O_RDONLY);
+    int result;
+    int saved_errno;
+
+    if (fd < 0) {
+        perror("open-fexecve-bad-argv");
+        return 150;
+    }
+    call_hot_target(2);
+    errno = 0;
+    result = fexecve(fd, invalid_argv_for_test(), environ);
+    saved_errno = errno;
+    close(fd);
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "fexecve_bad_argv_result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 151;
+    }
+    call_hot_target(4);
+    printf("fexecve_bad_argv_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+static int
+run_execveat_custom_env(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("execveat-env");
+
+    call_hot_target(5);
+    execveat(AT_FDCWD, self, argv, envp, 0);
+    perror("execveat-custom-env");
+    return 120;
+}
+
+static int
+run_raw_syscall_execveat_custom_env(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("raw-syscall-execveat-env");
+
+    call_hot_target(5);
+    syscall(SYS_execveat, AT_FDCWD, self, argv, envp, 0);
+    perror("raw-syscall-execveat-custom-env");
+    return 219;
+}
+
+static int
+run_execveat_bad_env_failure(void)
+{
+    char* const argv[] = {(char*)"/bin/true", NULL};
+    int result;
+    int saved_errno;
+
+    call_hot_target(3);
+    errno = 0;
+    result = execveat(AT_FDCWD,
+                      "/bin/true",
+                      argv,
+                      invalid_envp_for_test(),
+                      0);
+    saved_errno = errno;
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "execveat_bad_env_result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 152;
+    }
+    call_hot_target(3);
+    printf("execveat_bad_env_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_execveat_bad_argv_failure(void)
+{
+    int result;
+    int saved_errno;
+
+    call_hot_target(3);
+    errno = 0;
+    result = execveat(AT_FDCWD,
+                      "/bin/true",
+                      invalid_argv_for_test(),
+                      environ,
+                      0);
+    saved_errno = errno;
+    if (result != -1 || saved_errno != EFAULT) {
+        fprintf(stderr,
+                "execveat_bad_argv_result=%d errno=%d\n",
+                result,
+                saved_errno);
+        return 153;
+    }
+    call_hot_target(3);
+    printf("execveat_bad_argv_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+#endif
+
+static int
+run_execl_success(const char* self)
+{
+    call_hot_target(5);
+    execl(self, self, "child-basic", NULL);
+    perror("execl-success");
+    return 121;
+}
+
+static int
+run_execlp_path_search(void)
+{
+    call_hot_target(5);
+    execlp("test_exec_chain", "test_exec_chain", "child-basic", NULL);
+    perror("execlp-path-search");
+    return 122;
+}
+
+static int
+run_execle_custom_env(const char* self)
+{
+    char** envp = make_minimal_child_env("execle-env");
+
+    call_hot_target(5);
+    execle(self, self, "child-print-ld", NULL, envp);
+    perror("execle-custom-env");
+    return 123;
+}
+
+static int
+run_execvp_path_search(void)
+{
+    call_hot_target(5);
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    execvp("test_exec_chain", argv);
+    perror("execvp-path-search");
+    return 124;
+}
+
+static int
+run_helper_named_exec(void)
+{
+    char* const argv[] = {
+        (char*)"peak_detach_helper",
+        (char*)"child-basic",
+        NULL
+    };
+
+    call_hot_target(5);
+    execvp("peak_detach_helper", argv);
+    perror("helper-named-exec");
+    return 144;
+}
+
+static int
+run_execvpe_child_env_path_ignored(void)
+{
+    call_hot_target(5);
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    char** envp = make_bad_path_child_env();
+    execvpe("test_exec_chain", argv, envp);
+    perror("execvpe-child-env-path-ignored");
+    return 125;
+}
+
+static int
+run_execvpe_child_env_path_used(void)
+{
+    call_hot_target(5);
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    char** envp = make_child_path_env();
+    execvpe("test_exec_chain", argv, envp);
+    perror("execvpe-child-env-path-used");
+    return 154;
+}
+
+static int
+run_execvpe_child_path_duplicate_preload(void)
+{
+    call_hot_target(5);
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-print-ld",
+        NULL
+    };
+    char** envp = make_child_path_duplicate_preload_env();
+    execvpe("test_exec_chain", argv, envp);
+    perror("execvpe-child-path-duplicate-preload");
+    return 155;
+}
+
+static int
+run_execvp_enoent(void)
+{
+    char* const argv[] = {(char*)"definitely_missing_peak_exec_chain", NULL};
+    int saved_errno;
+
+    call_hot_target(2);
+    errno = 0;
+    execvp("definitely_missing_peak_exec_chain", argv);
+    saved_errno = errno;
+    call_hot_target(4);
+    printf("execvp_enoent_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return saved_errno == ENOENT ? 0 : 126;
+}
+
+static int
+run_execvp_eacces(void)
+{
+    char* const argv[] = {(char*)"blocked-exec", NULL};
+    int saved_errno;
+
+    call_hot_target(2);
+    errno = 0;
+    execvp("blocked-exec", argv);
+    saved_errno = errno;
+    call_hot_target(4);
+    printf("execvp_eacces_errno=%d continued sink=%lu\n",
+           saved_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return saved_errno == EACCES ? 0 : 127;
+}
+
+static int
+run_execvp_enoexec(void)
+{
+    char* const argv[] = {(char*)"enoexec-script", NULL};
+
+    call_hot_target(5);
+    execvp("enoexec-script", argv);
+    perror("execvp-enoexec");
+    return 128;
+}
+
+static int
+run_duplicate_preload(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_duplicate_preload_env();
+    execve(self, argv, envp);
+    perror("duplicate-preload");
+    return 129;
+}
+
+static int
+run_whitespace_duplicate_preload(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_whitespace_duplicate_preload_env();
+    execve(self, argv, envp);
+    perror("duplicate-preload-whitespace");
+    return 156;
+}
+
+static int
+run_duplicate_preload_entry(const char* self)
+{
+    call_hot_target(5);
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_duplicate_preload_entry_env();
+    execve(self, argv, envp);
+    perror("duplicate-preload-entry");
+    return 157;
+}
+
+static int
+run_posix_spawn_custom_env(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("posix-spawn-env");
+    int result;
+
+    call_hot_target(5);
+    errno = EDOM;
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawn_custom_env_errno=%d\n", errno);
+        return 129;
+    }
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_custom_env_failed=%d\n", result);
+        return 130;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_null_env(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    int result;
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, NULL, NULL, argv, NULL);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_null_env_failed=%d\n", result);
+        return 131;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_bad_env(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    int result;
+
+    call_hot_target(2);
+    errno = EDOM;
+    result = posix_spawn(&pid,
+                         self,
+                         NULL,
+                         NULL,
+                         argv,
+                         invalid_envp_for_test());
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawn_bad_env_errno=%d\n", errno);
+        return 157;
+    }
+    if (result != EFAULT) {
+        fprintf(stderr, "posix_spawn_bad_env_result=%d\n", result);
+        return 158;
+    }
+    call_hot_target(4);
+    printf("posix_spawn_bad_env_result=%d continued sink=%lu\n",
+           result,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_bad_argv(const char* self)
+{
+    pid_t pid = -1;
+    int result;
+
+    call_hot_target(2);
+    errno = EDOM;
+    result = posix_spawn(&pid,
+                         self,
+                         NULL,
+                         NULL,
+                         invalid_argv_for_test(),
+                         environ);
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawn_bad_argv_errno=%d\n", errno);
+        return 158;
+    }
+    if (result != EFAULT) {
+        fprintf(stderr, "posix_spawn_bad_argv_result=%d\n", result);
+        return 159;
+    }
+    call_hot_target(4);
+    printf("posix_spawn_bad_argv_result=%d continued sink=%lu\n",
+           result,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_preflight_unavailable(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** envp = make_minimal_child_env("posix-spawn-preflight");
+    int result;
+    int wait_result;
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_preflight_unavailable_failed=%d\n",
+                result);
+        return 160;
+    }
+    wait_result = wait_for_child(pid);
+    if (wait_result != 0) {
+        return wait_result;
+    }
+    call_hot_target(4);
+    printf("posix_spawn_preflight_unavailable_ok sink=%lu\n",
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_duplicate_preload(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_duplicate_preload_entry_env();
+    int result;
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_duplicate_preload_failed=%d\n", result);
+        return 132;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_actions_attrs(const char* self)
+{
+    const char* output_path = getenv("EXEC_CHAIN_SPAWN_ACTIONS_OUT");
+    posix_spawn_file_actions_t actions;
+    posix_spawnattr_t attrs;
+    sigset_t empty_mask;
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_minimal_child_env("posix-spawn-actions");
+    int result;
+    int wait_result;
+
+    if (output_path == NULL || output_path[0] == '\0') {
+        fprintf(stderr, "missing EXEC_CHAIN_SPAWN_ACTIONS_OUT\n");
+        return 133;
+    }
+    result = posix_spawn_file_actions_init(&actions);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_file_actions_init_failed=%d\n", result);
+        return 134;
+    }
+    result = posix_spawn_file_actions_addopen(&actions,
+                                              STDOUT_FILENO,
+                                              output_path,
+                                              O_CREAT | O_TRUNC | O_WRONLY,
+                                              0600);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_file_actions_addopen_failed=%d\n", result);
+        posix_spawn_file_actions_destroy(&actions);
+        return 135;
+    }
+    result = posix_spawnattr_init(&attrs);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawnattr_init_failed=%d\n", result);
+        posix_spawn_file_actions_destroy(&actions);
+        return 136;
+    }
+    sigemptyset(&empty_mask);
+    posix_spawnattr_setsigmask(&attrs, &empty_mask);
+    posix_spawnattr_setflags(&attrs, POSIX_SPAWN_SETSIGMASK);
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, &actions, &attrs, argv, envp);
+    posix_spawnattr_destroy(&attrs);
+    posix_spawn_file_actions_destroy(&actions);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_actions_attrs_failed=%d\n", result);
+        return 137;
+    }
+    wait_result = wait_for_child(pid);
+    if (wait_result != 0) {
+        return wait_result;
+    }
+    printf("posix_spawn_actions_attrs_ok\n");
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_actions_close_stderr(const char* self)
+{
+    const char* output_path = getenv("EXEC_CHAIN_SPAWN_ACTIONS_OUT");
+    posix_spawn_file_actions_t actions;
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-stderr-sentinel", NULL};
+    char** envp = make_minimal_child_env("posix-spawn-close-stderr");
+    int result;
+    int wait_result;
+
+    if (output_path == NULL || output_path[0] == '\0') {
+        fprintf(stderr, "missing EXEC_CHAIN_SPAWN_ACTIONS_OUT\n");
+        return 161;
+    }
+    result = posix_spawn_file_actions_init(&actions);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_close_stderr_actions_init_failed=%d\n",
+                result);
+        return 162;
+    }
+    result = posix_spawn_file_actions_addopen(&actions,
+                                              STDOUT_FILENO,
+                                              output_path,
+                                              O_CREAT | O_TRUNC | O_WRONLY,
+                                              0600);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_close_stderr_addopen_failed=%d\n",
+                result);
+        posix_spawn_file_actions_destroy(&actions);
+        return 163;
+    }
+    result = posix_spawn_file_actions_addclose(&actions, STDERR_FILENO);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_close_stderr_addclose_failed=%d\n",
+                result);
+        posix_spawn_file_actions_destroy(&actions);
+        return 164;
+    }
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, &actions, NULL, argv, envp);
+    posix_spawn_file_actions_destroy(&actions);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_actions_close_stderr_failed=%d\n",
+                result);
+        return 165;
+    }
+    wait_result = wait_for_child(pid);
+    if (wait_result != 0) {
+        return wait_result;
+    }
+    printf("posix_spawn_actions_close_stderr_ok\n");
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_usevfork(const char* self)
+{
+#if defined(PEAK_TEST_HAVE_POSIX_SPAWN_USEVFORK)
+    posix_spawnattr_t attrs;
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** envp = make_minimal_child_env("posix-spawn-usevfork");
+    int result;
+    int wait_result;
+
+    result = posix_spawnattr_init(&attrs);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_usevfork_attr_init_failed=%d\n", result);
+        return 166;
+    }
+    result = posix_spawnattr_setflags(&attrs, POSIX_SPAWN_USEVFORK);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_usevfork_setflags_failed=%d\n", result);
+        posix_spawnattr_destroy(&attrs);
+        return 167;
+    }
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, NULL, &attrs, argv, envp);
+    posix_spawnattr_destroy(&attrs);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_usevfork_failed=%d\n", result);
+        return 168;
+    }
+    wait_result = wait_for_child(pid);
+    if (wait_result != 0) {
+        return wait_result;
+    }
+    printf("posix_spawn_usevfork_ok\n");
+    fflush(stdout);
+    return 0;
+#else
+    (void)self;
+    fprintf(stderr, "posix_spawn_usevfork_unavailable\n");
+    return 169;
+#endif
+}
+
+static int
+run_posix_spawn_child_peak_env_only(const char* self)
+{
+    EnvSnapshot parent_env;
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_child_peak_only_env();
+    int result;
+
+    call_hot_target(5);
+    snapshot_and_unset_peak_env(&parent_env);
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    restore_peak_env_snapshot(&parent_env);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_child_peak_env_only_failed=%d\n", result);
+        return 170;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_failure(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    int result;
+
+    call_hot_target(2);
+    result = posix_spawn(&pid,
+                         "/definitely/not/found",
+                         NULL,
+                         NULL,
+                         argv,
+                         environ);
+    if (result != ENOENT) {
+        fprintf(stderr, "posix_spawn_failure_bad_result=%d\n", result);
+        return 138;
+    }
+    call_hot_target(4);
+    printf("posix_spawn_failure_result=%d continued sink=%lu\n",
+           result,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawnp_path_search(void)
+{
+    pid_t pid = -1;
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    char** envp = make_minimal_child_env("posix-spawnp-env");
+    int result;
+
+    call_hot_target(5);
+    result = posix_spawnp(&pid, "test_exec_chain", NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawnp_path_search_failed=%d\n", result);
+        return 139;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawnp_child_env_path_ignored(void)
+{
+    pid_t pid = -1;
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    char** envp = make_bad_path_child_env();
+    int result;
+
+    call_hot_target(5);
+    result = posix_spawnp(&pid, "test_exec_chain", NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawnp_child_env_path_ignored_failed=%d\n",
+                result);
+        return 140;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawnp_bad_env(void)
+{
+    pid_t pid = -1;
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    int result;
+
+    call_hot_target(2);
+    errno = EDOM;
+    result = posix_spawnp(&pid,
+                          "test_exec_chain",
+                          NULL,
+                          NULL,
+                          argv,
+                          invalid_envp_for_test());
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawnp_bad_env_errno=%d\n", errno);
+        return 167;
+    }
+    if (result != EFAULT) {
+        fprintf(stderr, "posix_spawnp_bad_env_result=%d\n", result);
+        return 171;
+    }
+    call_hot_target(4);
+    printf("posix_spawnp_bad_env_result=%d continued sink=%lu\n",
+           result,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawnp_bad_argv(void)
+{
+    pid_t pid = -1;
+    int result;
+
+    call_hot_target(2);
+    errno = EDOM;
+    result = posix_spawnp(&pid,
+                          "test_exec_chain",
+                          NULL,
+                          NULL,
+                          invalid_argv_for_test(),
+                          environ);
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawnp_bad_argv_errno=%d\n", errno);
+        return 168;
+    }
+    if (result != EFAULT) {
+        fprintf(stderr, "posix_spawnp_bad_argv_result=%d\n", result);
+        return 172;
+    }
+    call_hot_target(4);
+    printf("posix_spawnp_bad_argv_result=%d continued sink=%lu\n",
+           result,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
+run_posix_spawn_explicit_peak_env(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {
+        (char*)self,
+        (char*)"child-check-env",
+        (char*)"PEAK_TARGET",
+        NULL
+    };
+    char** envp = make_explicit_peak_env();
+    int result;
+
+    call_hot_target(5);
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr, "posix_spawn_explicit_peak_env_failed=%d\n", result);
+        return 141;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_fork_child_exec_parent_exec(const char* self)
+{
+    pid_t pid = fork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("fork-child-exec-parent-exec");
+        return 174;
+    }
+    if (pid == 0) {
+        char* const child_argv[] = {
+            (char*)self,
+            (char*)"child-basic",
+            NULL
+        };
+        call_hot_target(2);
+        execv(self, child_argv);
+        _exit(175);
+    }
+
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "fork_child_exec_status=%d\n", child_status);
+        return 176;
+    }
+    call_hot_target(5);
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    execv(self, parent_argv);
+    perror("fork-parent-exec");
+    return 177;
+}
+
+static int
+run_vfork_child_exec_parent_exec(const char* self)
+{
+    char* const child_argv[] = {
+        (char*)self,
+        (char*)"child-basic",
+        NULL
+    };
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("vfork-child-exec-parent-exec");
+        return 178;
+    }
+    if (pid == 0) {
+        execv(self, child_argv);
+        _exit(179);
+    }
+
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "vfork_child_exec_status=%d\n", child_status);
+        return 180;
+    }
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("vfork-parent-exec");
+    return 181;
+}
+
+static int
+run_vfork_child_failed_exec_parent_exec(const char* self)
+{
+    char* const child_argv[] = {
+        (char*)"/definitely/not/found",
+        NULL
+    };
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("vfork-child-failed-exec-parent-exec");
+        return 182;
+    }
+    if (pid == 0) {
+        execv("/definitely/not/found", child_argv);
+        _exit(errno == ENOENT ? 0 : 183);
+    }
+
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "vfork_child_failed_exec_status=%d\n", child_status);
+        return 184;
+    }
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("vfork-failed-child-parent-exec");
+    return 185;
+}
+
+static int
+run_vfork_varargs_exec_parent_exec(const char* self, int mode)
+{
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("vfork-varargs-parent-exec");
+        return 187;
+    }
+    if (pid == 0) {
+        if (mode == 0) {
+            execl(self, self, "child-basic", (char*)NULL);
+        } else if (mode == 1) {
+            execlp(self, self, "child-basic", (char*)NULL);
+        } else {
+            execle(self,
+                   self,
+                   "child-basic",
+                   (char*)NULL,
+                   environ);
+        }
+        _exit(188);
+    }
+
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "vfork_varargs_child_status=%d mode=%d\n",
+                child_status,
+                mode);
+        return 189;
+    }
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("vfork-varargs-parent-exec");
+    return 190;
+}
+
+static int
+run_postfork_custom_env(const char* self,
+                        int use_vfork,
+                        int use_execle,
+                        int disable_chain,
+                        int use_raw_syscall)
+{
+    char* const child_argv[] = {
+        (char*)self,
+        (char*)"child-print-ld",
+        NULL
+    };
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    const char* parent_preload = getenv("LD_PRELOAD");
+    char* parent_preload_copy = parent_preload != NULL ? strdup(parent_preload) : NULL;
+    char** child_env = make_minimal_child_env(
+        disable_chain ? "postfork-custom-disabled" : "postfork-custom");
+    size_t child_env_count = 0;
+    pid_t pid;
+    int child_status;
+
+    if (parent_preload != NULL && parent_preload_copy == NULL) {
+        perror("postfork-custom-strdup");
+        return 191;
+    }
+    while (child_env[child_env_count] != NULL) {
+        child_env_count++;
+    }
+    if (disable_chain) {
+        child_env[child_env_count++] = make_env_entry("PEAK_EXEC_CHAIN", "0");
+        child_env[child_env_count] = NULL;
+    }
+
+    pid = use_vfork ? vfork() : fork();
+    if (pid < 0) {
+        perror("postfork-custom-env");
+        free(parent_preload_copy);
+        return 192;
+    }
+    if (pid == 0) {
+        if (use_execle) {
+            execle(self,
+                   self,
+                   "child-print-ld",
+                   (char*)NULL,
+                   child_env);
+        } else if (use_raw_syscall) {
+            (void)syscall(SYS_execve, self, child_argv, child_env);
+        } else {
+            execve(self, child_argv, child_env);
+        }
+        _exit(193);
+    }
+
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "postfork_custom_child_status=%d\n", child_status);
+        free(parent_preload_copy);
+        return 194;
+    }
+    if ((parent_preload == NULL && getenv("LD_PRELOAD") != NULL) ||
+        (parent_preload != NULL &&
+         strcmp(parent_preload_copy, getenv("LD_PRELOAD")) != 0)) {
+        fprintf(stderr, "parent_env_unchanged=0\n");
+        free(parent_preload_copy);
+        return 195;
+    }
+    printf("parent_env_unchanged=1\n");
+    fflush(stdout);
+    free(parent_preload_copy);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("postfork-custom-parent-exec");
+    return 196;
+}
+
+enum PostforkExecApi {
+    POSTFORK_EXECVPE,
+    POSTFORK_EXECVP,
+    POSTFORK_EXECLP,
+    POSTFORK_FEXECVE,
+    POSTFORK_EXECVEAT,
+    POSTFORK_RAW_EXECVEAT,
+};
+
+static int
+run_vfork_custom_env_api(const char* self, enum PostforkExecApi api)
+{
+    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** child_env = make_minimal_child_env("postfork-api-custom");
+    char** saved_environ = environ;
+    int fd = -1;
+    pid_t pid;
+    int child_status;
+
+    for (size_t index = 0; child_env[index] != NULL; index++) {
+        if (child_env[index + 1] == NULL) {
+            child_env[index + 1] = make_env_entry("PEAK_TARGET",
+                                                  "explicit_child_target");
+            child_env[index + 2] = NULL;
+            break;
+        }
+    }
+
+    if (api == POSTFORK_FEXECVE) {
+        fd = open(self, O_RDONLY);
+        if (fd < 0) {
+            perror("postfork-api-open");
+            return 210;
+        }
+    }
+    if (api == POSTFORK_EXECVP || api == POSTFORK_EXECLP) {
+        environ = child_env;
+    }
+    pid = vfork();
+    if (pid < 0) {
+        environ = saved_environ;
+        if (fd >= 0) {
+            close(fd);
+        }
+        perror("postfork-api-vfork");
+        return 211;
+    }
+    if (pid == 0) {
+        switch (api) {
+        case POSTFORK_EXECVPE:
+            execvpe(self, child_argv, child_env);
+            break;
+        case POSTFORK_EXECVP:
+            execvp(self, child_argv);
+            break;
+        case POSTFORK_EXECLP:
+            execlp(self, self, "child-print-ld", (char*)NULL);
+            break;
+        case POSTFORK_FEXECVE:
+            fexecve(fd, child_argv, child_env);
+            break;
+        case POSTFORK_EXECVEAT:
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+            execveat(AT_FDCWD, self, child_argv, child_env, 0);
+#endif
+            break;
+        case POSTFORK_RAW_EXECVEAT:
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+            (void)syscall(SYS_execveat,
+                          AT_FDCWD,
+                          self,
+                          child_argv,
+                          child_env,
+                          0);
+#endif
+            break;
+        }
+        _exit(212);
+    }
+    environ = saved_environ;
+    if (fd >= 0) {
+        close(fd);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "postfork_api_child_status=%d api=%d\n",
+                child_status,
+                (int)api);
+        return 213;
+    }
+    printf("postfork_api_parent_env_unchanged=%d\n", environ == saved_environ);
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("postfork-api-parent-exec");
+    return 214;
+}
+
+static int
+run_postfork_bad_env(const char* self, int use_vfork, int bad_string)
+{
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char* bad_string_env[] = {(char*)(uintptr_t)1, NULL};
+    char* const* envp = bad_string ? bad_string_env : invalid_envp_for_test();
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    pid_t pid = use_vfork ? vfork() : fork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("postfork-bad-env");
+        return 215;
+    }
+    if (pid == 0) {
+        execve(self, argv, (char* const*)envp);
+        _exit(errno == EFAULT ? 0 : 216);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "postfork_bad_env_child_status=%d\n", child_status);
+        return 217;
+    }
+    printf("postfork_bad_env_efault=1 kind=%s mode=%s\n",
+           bad_string ? "string" : "vector",
+           use_vfork ? "vfork" : "fork");
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("postfork-bad-env-parent-exec");
+    return 218;
+}
+
+static int
+run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
+{
+    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** envp = long_preload ? make_long_preload_child_env() :
+                                make_large_child_env();
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("postfork-capacity-vfork");
+        return 219;
+    }
+    if (pid == 0) {
+        execve(self, child_argv, envp);
+        _exit(220);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "postfork_capacity_child_status=%d\n", child_status);
+        return 221;
+    }
+    printf("postfork_capacity_passthrough=1 kind=%s\n",
+           long_preload ? "long-preload" : "env-slots");
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("postfork-capacity-parent-exec");
+    return 222;
+}
+
+typedef void (*PeakFiniFn)(void);
+typedef int (*PeakCheckpointFn)(const char*, char* const[]);
+typedef void (*PeakTestVoidFn)(void);
+typedef int (*PeakTestReadyFn)(void);
+
+static void*
+fini_thread_main(void* data)
+{
+    PeakFiniFn fini = data;
+
+    fini();
+    return NULL;
+}
+
+typedef struct {
+    const char* self;
+    PeakCheckpointFn checkpoint;
+} CheckpointThreadArgs;
+
+static void*
+checkpoint_thread_main(void* data)
+{
+    CheckpointThreadArgs* args = data;
+    char* const argv[] = {(char*)args->self, (char*)"child-basic", NULL};
+
+    (void)args->checkpoint(args->self, argv);
+    return NULL;
+}
+
+static int
+wait_for_test_hook(int (*hook)(void), const char* label)
+{
+    struct timespec deadline;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &deadline) != 0) {
+        perror("clock_gettime");
+        return -1;
+    }
+    deadline.tv_sec += 5;
+
+    for (;;) {
+        struct timespec now;
+
+        if (hook()) {
+            return 0;
+        }
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+            perror("clock_gettime");
+            return -1;
+        }
+        if (now.tv_sec > deadline.tv_sec ||
+            (now.tv_sec == deadline.tv_sec && now.tv_nsec >= deadline.tv_nsec)) {
+            break;
+        }
+        sched_yield();
+    }
+    fprintf(stderr, "timed out waiting for %s\n", label);
+    return -1;
+}
+
+static int
+join_test_thread(pthread_t thread, const char* label)
+{
+    int rc = pthread_join(thread, NULL);
+
+    if (rc == 0) {
+        return 0;
+    }
+    fprintf(stderr, "pthread_join %s failed: %s\n", label, strerror(rc));
+    return -1;
+}
+
+static int
+run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
+{
+    pthread_t fini_thread;
+    pthread_t checkpoint_thread;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    PeakTestReadyFn fini_waiting = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL ||
+        fini_waiting == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 180;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    int rc = pthread_create(&checkpoint_thread,
+                            NULL,
+                            checkpoint_thread_main,
+                            &checkpoint_args);
+    if (rc != 0) {
+        fprintf(stderr,
+                "pthread_create checkpoint reader failed: %s\n",
+                strerror(rc));
+        return 181;
+    }
+    if (wait_for_test_hook(reader_is_held,
+                           "checkpoint reader lifetime gate") != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   182 :
+                   185;
+    }
+    rc = pthread_create(&fini_thread, NULL, fini_thread_main, (void*)fini);
+    if (rc != 0) {
+        fprintf(stderr, "pthread_create fini failed: %s\n", strerror(rc));
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   183 :
+                   185;
+    }
+    if (wait_for_test_hook(fini_waiting,
+                           "fini waiting for checkpoint reader") != 0) {
+        reader_release();
+        int checkpoint_join =
+            join_test_thread(checkpoint_thread, "checkpoint reader");
+        int fini_join = join_test_thread(fini_thread, "fini");
+        return checkpoint_join == 0 && fini_join == 0 ? 184 : 185;
+    }
+    printf("checkpoint_reader_gate_held=1 fini_waiting=1\n");
+    fflush(stdout);
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "checkpoint reader") != 0 ||
+        join_test_thread(fini_thread, "fini") != 0) {
+        return 185;
+    }
+
+    char* const argv[] = {(char*)self, (char*)"child-basic", NULL};
+    execv(self, argv);
+    perror("exec-concurrent-fini-callbacks");
+    return 186;
+}
+
+int
+main(int argc, char** argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <mode>\n", argv[0]);
+        return 2;
+    }
+
+    if (strcmp(argv[1], "child-basic") == 0) {
+        return run_child_basic();
+    }
+    if (strcmp(argv[1], "child-print-ld") == 0) {
+        return run_child_print_ld();
+    }
+    if (strcmp(argv[1], "child-check-env") == 0 && argc >= 3) {
+        return run_child_check_env(argv[2]);
+    }
+    if (strcmp(argv[1], "child-stderr-sentinel") == 0) {
+        return run_child_stderr_sentinel();
+    }
+    if (strcmp(argv[1], "execv-success") == 0) {
+        return run_execv_success(argv[0]);
+    }
+    if (strcmp(argv[1], "execv-zero-call") == 0) {
+        return run_execv_zero_call_checkpoint(argv[0]);
+    }
+    if (strcmp(argv[1], "execv-write-target-success") == 0) {
+        return run_execv_write_target_success(argv[0]);
+    }
+    if (strcmp(argv[1], "execve-custom-env") == 0) {
+        return run_execve_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "raw-syscall-execve-custom-env") == 0) {
+        return run_raw_syscall_execve_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "raw-syscall-execve-failure") == 0) {
+        return run_raw_syscall_execve_failure();
+    }
+    if (strcmp(argv[1], "raw-syscall-nonexec") == 0) {
+        return run_raw_syscall_nonexec_passthrough();
+    }
+    if (strcmp(argv[1], "execve-child-peak-env-only") == 0) {
+        return run_execve_child_peak_env_only(argv[0]);
+    }
+    if (strcmp(argv[1], "execve-null-env") == 0) {
+        return run_execve_null_env(argv[0]);
+    }
+    if (strcmp(argv[1], "execve-large-env") == 0) {
+        return run_execve_large_env(argv[0]);
+    }
+    if (strcmp(argv[1], "execve-explicit-peak-env") == 0) {
+        return run_execve_explicit_peak_env(argv[0]);
+    }
+    if (strcmp(argv[1], "execve-child-chain-disabled") == 0) {
+        return run_execve_child_peak_control(argv[0], "PEAK_EXEC_CHAIN", "0");
+    }
+    if (strcmp(argv[1], "execve-child-checkpoint-disabled") == 0) {
+        return run_execve_child_peak_control(argv[0],
+                                            "PEAK_EXEC_CHECKPOINT",
+                                            "0");
+    }
+    if (strcmp(argv[1], "execve-child-propagate-disabled") == 0) {
+        return run_execve_child_peak_control(argv[0],
+                                            "PEAK_EXEC_PROPAGATE_PEAK_ENV",
+                                            "0");
+    }
+    if (strcmp(argv[1], "execve-bad-env") == 0) {
+        return run_execve_bad_env_failure();
+    }
+    if (strcmp(argv[1], "execve-bad-argv") == 0) {
+        return run_execve_bad_argv_failure();
+    }
+    if (strcmp(argv[1], "exec-failure") == 0) {
+        return run_exec_failure();
+    }
+    if (strcmp(argv[1], "fexecve-custom-env") == 0) {
+        return run_fexecve_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "fexecve-bad-env") == 0) {
+        return run_fexecve_bad_env_failure(argv[0]);
+    }
+    if (strcmp(argv[1], "fexecve-bad-argv") == 0) {
+        return run_fexecve_bad_argv_failure(argv[0]);
+    }
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    if (strcmp(argv[1], "execveat-custom-env") == 0) {
+        return run_execveat_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "raw-syscall-execveat-custom-env") == 0) {
+        return run_raw_syscall_execveat_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "execveat-bad-env") == 0) {
+        return run_execveat_bad_env_failure();
+    }
+    if (strcmp(argv[1], "execveat-bad-argv") == 0) {
+        return run_execveat_bad_argv_failure();
+    }
+#endif
+    if (strcmp(argv[1], "execl-success") == 0) {
+        return run_execl_success(argv[0]);
+    }
+    if (strcmp(argv[1], "execlp-path-search") == 0) {
+        return run_execlp_path_search();
+    }
+    if (strcmp(argv[1], "execle-custom-env") == 0) {
+        return run_execle_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "execvp-path-search") == 0) {
+        return run_execvp_path_search();
+    }
+    if (strcmp(argv[1], "helper-named-exec") == 0) {
+        return run_helper_named_exec();
+    }
+    if (strcmp(argv[1], "execvpe-child-env-path-ignored") == 0) {
+        return run_execvpe_child_env_path_ignored();
+    }
+    if (strcmp(argv[1], "execvpe-child-env-path-used") == 0) {
+        return run_execvpe_child_env_path_used();
+    }
+    if (strcmp(argv[1], "execvpe-child-path-duplicate-preload") == 0) {
+        return run_execvpe_child_path_duplicate_preload();
+    }
+    if (strcmp(argv[1], "execvp-enoent") == 0) {
+        return run_execvp_enoent();
+    }
+    if (strcmp(argv[1], "execvp-eacces") == 0) {
+        return run_execvp_eacces();
+    }
+    if (strcmp(argv[1], "execvp-enoexec") == 0) {
+        return run_execvp_enoexec();
+    }
+    if (strcmp(argv[1], "fork-child-exec-parent-exec") == 0) {
+        return run_fork_child_exec_parent_exec(argv[0]);
+    }
+    if (strcmp(argv[1], "vfork-child-exec-parent-exec") == 0) {
+        return run_vfork_child_exec_parent_exec(argv[0]);
+    }
+    if (strcmp(argv[1], "vfork-child-failed-exec-parent-exec") == 0) {
+        return run_vfork_child_failed_exec_parent_exec(argv[0]);
+    }
+    if (strcmp(argv[1], "vfork-execl-parent-exec") == 0) {
+        return run_vfork_varargs_exec_parent_exec(argv[0], 0);
+    }
+    if (strcmp(argv[1], "vfork-execlp-parent-exec") == 0) {
+        return run_vfork_varargs_exec_parent_exec(argv[0], 1);
+    }
+    if (strcmp(argv[1], "vfork-execle-parent-exec") == 0) {
+        return run_vfork_varargs_exec_parent_exec(argv[0], 2);
+    }
+    if (strcmp(argv[1], "fork-custom-env-execve") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 0);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-execve") == 0) {
+        return run_postfork_custom_env(argv[0], 1, 0, 0, 0);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-execle") == 0) {
+        return run_postfork_custom_env(argv[0], 1, 1, 0, 0);
+    }
+    if (strcmp(argv[1], "fork-custom-env-disabled") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 1, 0);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-disabled") == 0) {
+        return run_postfork_custom_env(argv[0], 1, 0, 1, 0);
+    }
+    if (strcmp(argv[1], "fork-raw-syscall-custom-env") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 1);
+    }
+    if (strcmp(argv[1], "fork-raw-syscall-chain-disabled") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 1, 1);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-execvpe") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVPE);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-execvp") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVP);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-execlp") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_EXECLP);
+    }
+    if (strcmp(argv[1], "vfork-custom-env-fexecve") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_FEXECVE);
+    }
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    if (strcmp(argv[1], "vfork-custom-env-execveat") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVEAT);
+    }
+    if (strcmp(argv[1], "vfork-raw-syscall-execveat") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_RAW_EXECVEAT);
+    }
+#endif
+    if (strcmp(argv[1], "fork-bad-env-vector") == 0) {
+        return run_postfork_bad_env(argv[0], 0, 0);
+    }
+    if (strcmp(argv[1], "vfork-bad-env-vector") == 0) {
+        return run_postfork_bad_env(argv[0], 1, 0);
+    }
+    if (strcmp(argv[1], "fork-bad-env-string") == 0) {
+        return run_postfork_bad_env(argv[0], 0, 1);
+    }
+    if (strcmp(argv[1], "vfork-bad-env-string") == 0) {
+        return run_postfork_bad_env(argv[0], 1, 1);
+    }
+    if (strcmp(argv[1], "vfork-env-slots-fallback") == 0) {
+        return run_vfork_child_env_capacity_fallback(argv[0], 0);
+    }
+    if (strcmp(argv[1], "vfork-long-preload-fallback") == 0) {
+        return run_vfork_child_env_capacity_fallback(argv[0], 1);
+    }
+    if (strcmp(argv[1], "duplicate-preload") == 0) {
+        return run_duplicate_preload(argv[0]);
+    }
+    if (strcmp(argv[1], "duplicate-preload-whitespace") == 0) {
+        return run_whitespace_duplicate_preload(argv[0]);
+    }
+    if (strcmp(argv[1], "duplicate-preload-entry") == 0) {
+        return run_duplicate_preload_entry(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-custom-env") == 0) {
+        return run_posix_spawn_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-null-env") == 0) {
+        return run_posix_spawn_null_env(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-bad-env") == 0) {
+        return run_posix_spawn_bad_env(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-bad-argv") == 0) {
+        return run_posix_spawn_bad_argv(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-preflight-unavailable") == 0) {
+        return run_posix_spawn_preflight_unavailable(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-duplicate-preload") == 0) {
+        return run_posix_spawn_duplicate_preload(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-actions-attrs") == 0) {
+        return run_posix_spawn_actions_attrs(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-actions-close-stderr") == 0) {
+        return run_posix_spawn_actions_close_stderr(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-usevfork-custom-env") == 0) {
+        return run_posix_spawn_usevfork(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-child-peak-env-only") == 0) {
+        return run_posix_spawn_child_peak_env_only(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-failure") == 0) {
+        return run_posix_spawn_failure(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawnp-path-search") == 0) {
+        return run_posix_spawnp_path_search();
+    }
+    if (strcmp(argv[1], "posix-spawnp-child-env-path-ignored") == 0) {
+        return run_posix_spawnp_child_env_path_ignored();
+    }
+    if (strcmp(argv[1], "posix-spawnp-bad-env") == 0) {
+        return run_posix_spawnp_bad_env();
+    }
+    if (strcmp(argv[1], "posix-spawnp-bad-argv") == 0) {
+        return run_posix_spawnp_bad_argv();
+    }
+    if (strcmp(argv[1], "posix-spawn-explicit-peak-env") == 0) {
+        return run_posix_spawn_explicit_peak_env(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-concurrent-fini-callbacks") == 0) {
+        return run_exec_checkpoint_concurrent_fini_callbacks(argv[0]);
+    }
+
+    fprintf(stderr, "unknown mode: %s\n", argv[1]);
+    return 2;
+}

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -109,6 +109,98 @@ make_minimal_child_env(const char* marker)
 }
 
 static char**
+make_minimal_child_env_without_loader(const char* marker)
+{
+    char** envp = calloc(6, sizeof(char*));
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    envp[0] = make_env_entry("PATH", env_or_default("PATH", "/bin:/usr/bin"));
+    envp[1] = make_env_entry("EXEC_CHAIN_TEST_MARKER", marker);
+    return envp;
+}
+
+static char**
+make_loader_path_child_env(const char* marker,
+                           const char* value,
+                           const char* second_value)
+{
+    char** envp = make_minimal_child_env_without_loader(marker);
+
+    if (value != NULL) {
+        envp[2] = make_env_entry("LD_LIBRARY_PATH", value);
+    }
+    if (second_value != NULL) {
+        envp[3] = make_env_entry("LD_LIBRARY_PATH", second_value);
+    }
+    return envp;
+}
+
+static char**
+make_preloaded_child_env(const char* marker)
+{
+    const char* preload = env_or_default("LD_PRELOAD", "");
+    size_t value_size = strlen(EXTRA_PRELOAD_TOKEN_A) + 1 + strlen(preload) + 1;
+    char* value = malloc(value_size);
+    char** envp = make_minimal_child_env_without_loader(marker);
+
+    if (value == NULL) {
+        perror("malloc");
+        exit(100);
+    }
+    snprintf(value, value_size, "%s:%s", EXTRA_PRELOAD_TOKEN_A, preload);
+    envp[2] = make_env_entry("LD_PRELOAD", value);
+    free(value);
+    return envp;
+}
+
+static char**
+make_child_control_env(const char* marker)
+{
+    char** envp = make_minimal_child_env_without_loader(marker);
+
+    envp[2] = make_env_entry("PEAK_EXEC_CHAIN", "1");
+    envp[3] = make_env_entry("PEAK_EXEC_PROPAGATE_PEAK_ENV", "1");
+    return envp;
+}
+
+static char**
+make_unterminated_nonpeak_env(void)
+{
+    const size_t entry_count = 256;
+    char** envp = calloc(entry_count + 1, sizeof(char*));
+    char name[64];
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    for (size_t index = 0; index < entry_count; index++) {
+        snprintf(name, sizeof(name), "PARENT_PAD_%04zu", index);
+        envp[index] = make_env_entry(name, "x");
+    }
+    return envp;
+}
+
+static char**
+make_preload_entries_without_terminator(void)
+{
+    const size_t entry_count = 256;
+    char** envp = calloc(entry_count + 1, sizeof(char*));
+
+    if (envp == NULL) {
+        perror("calloc");
+        exit(100);
+    }
+    for (size_t index = 0; index < entry_count; index++) {
+        envp[index] = make_env_entry("LD_PRELOAD", "");
+    }
+    return envp;
+}
+
+static char**
 make_bad_path_child_env(void)
 {
     char** envp = calloc(5, sizeof(char*));
@@ -139,7 +231,6 @@ make_large_child_env(void)
     }
     envp[index++] = make_env_entry("PATH",
                                    env_or_default("PATH", "/bin:/usr/bin"));
-    append_current_env_entry_if_present(envp, &index, "LD_LIBRARY_PATH");
     envp[index++] = make_env_entry("EXEC_CHAIN_TEST_MARKER", "large-env");
     for (size_t i = 0; i < pad_count; i++) {
         snprintf(name, sizeof(name), "CHILD_PAD_%04zu", i);
@@ -572,6 +663,39 @@ count_ld_preload_env_entries(void)
 }
 
 static int
+count_ld_library_path_env_entries(void)
+{
+    int count = 0;
+
+    if (environ == NULL) {
+        return 0;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        if (strncmp(*scan, "LD_LIBRARY_PATH=", strlen("LD_LIBRARY_PATH=")) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static const char*
+ld_library_path_env_value(size_t wanted)
+{
+    size_t found = 0;
+
+    if (environ == NULL) {
+        return NULL;
+    }
+    for (char** scan = environ; *scan != NULL; scan++) {
+        if (strncmp(*scan, "LD_LIBRARY_PATH=", strlen("LD_LIBRARY_PATH=")) == 0 &&
+            found++ == wanted) {
+            return *scan + strlen("LD_LIBRARY_PATH=");
+        }
+    }
+    return NULL;
+}
+
+static int
 run_child_basic(void)
 {
     call_hot_target(7);
@@ -589,12 +713,15 @@ run_child_print_ld(void)
     const char* peak_exec_chain = getenv("PEAK_EXEC_CHAIN");
     const char* peak_exec_checkpoint = getenv("PEAK_EXEC_CHECKPOINT");
     const char* peak_exec_propagate = getenv("PEAK_EXEC_PROPAGATE_PEAK_ENV");
+    const char* loader_path_0 = ld_library_path_env_value(0);
+    const char* loader_path_1 = ld_library_path_env_value(1);
 
     call_hot_target(7);
     printf("ld_preload_libpeak_count=%d ld_preload_env_entries=%d "
            "ld_preload_extra_count=%d peak_target=%s peak_statslog=%s "
            "marker=%s peak_exec_chain=%s peak_exec_checkpoint=%s "
-           "peak_exec_propagate=%s\n",
+           "peak_exec_propagate=%s ld_library_path_env_entries=%d "
+           "ld_library_path_0=%s ld_library_path_1=%s\n",
            count_libpeak_preload_entries(),
            count_ld_preload_env_entries(),
            count_extra_preload_entries(),
@@ -603,7 +730,10 @@ run_child_print_ld(void)
            marker != NULL ? marker : "<missing>",
            peak_exec_chain != NULL ? peak_exec_chain : "<missing>",
            peak_exec_checkpoint != NULL ? peak_exec_checkpoint : "<missing>",
-           peak_exec_propagate != NULL ? peak_exec_propagate : "<missing>");
+           peak_exec_propagate != NULL ? peak_exec_propagate : "<missing>",
+           count_ld_library_path_env_entries(),
+           loader_path_0 != NULL ? loader_path_0 : "<missing>",
+           loader_path_1 != NULL ? loader_path_1 : "<missing>");
     fflush(stdout);
     return 0;
 }
@@ -755,6 +885,49 @@ run_execve_null_env(const char* self)
     char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
     execve(self, argv, NULL);
     perror("execve-null-env");
+    return 114;
+}
+
+static int
+run_execve_loader_path_env(const char* self,
+                           const char* marker,
+                           const char* value,
+                           const char* second_value,
+                           int disable_chain)
+{
+    const char* child = self;
+    char* argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_loader_path_child_env(marker, value, second_value);
+    size_t index = 0;
+
+    while (envp[index] != NULL) {
+        index++;
+    }
+    if (disable_chain) {
+        const char* observer = getenv("EXEC_CHAIN_TEST_CHAIN_DISABLED_OBSERVER");
+
+        if (observer != NULL && observer[0] != '\0') {
+            child = observer;
+            argv[0] = (char*)child;
+        }
+        envp[index++] = make_env_entry("PEAK_EXEC_CHAIN", "0");
+        envp[index] = NULL;
+    }
+    call_hot_target(5);
+    execve(child, argv, envp);
+    perror("execve-loader-path-env");
+    return 114;
+}
+
+static int
+run_execve_preloaded_env(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_preloaded_child_env("loader-path-preload-present");
+
+    call_hot_target(5);
+    execve(self, argv, envp);
+    perror("execve-preloaded-env");
     return 114;
 }
 
@@ -1894,7 +2067,8 @@ run_postfork_custom_env(const char* self,
                         int use_vfork,
                         int use_execle,
                         int disable_chain,
-                        int use_raw_syscall)
+                        int use_raw_syscall,
+                        int omit_loader_path)
 {
     char* const child_argv[] = {
         (char*)self,
@@ -1904,8 +2078,10 @@ run_postfork_custom_env(const char* self,
     char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
     const char* parent_preload = getenv("LD_PRELOAD");
     char* parent_preload_copy = parent_preload != NULL ? strdup(parent_preload) : NULL;
-    char** child_env = make_minimal_child_env(
-        disable_chain ? "postfork-custom-disabled" : "postfork-custom");
+    char** child_env = omit_loader_path ?
+        make_minimal_child_env_without_loader("postfork-loader-path") :
+        make_minimal_child_env(disable_chain ? "postfork-custom-disabled" :
+                                             "postfork-custom");
     size_t child_env_count = 0;
     pid_t pid;
     int child_status;
@@ -1963,6 +2139,67 @@ run_postfork_custom_env(const char* self,
     execv(self, parent_argv);
     perror("postfork-custom-parent-exec");
     return 196;
+}
+
+static int
+run_vfork_preloaded_env(const char* self)
+{
+    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** child_env = make_preloaded_child_env("loader-path-preload-present");
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("vfork-preloaded-env");
+        return 227;
+    }
+    if (pid == 0) {
+        execve(self, child_argv, child_env);
+        _exit(228);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "vfork_preloaded_child_status=%d\n", child_status);
+        return 229;
+    }
+    printf("vfork_preloaded_parent_ok=1\n");
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("vfork-preloaded-parent-exec");
+    return 230;
+}
+
+static int
+run_fork_parent_env_exhaustion(const char* self)
+{
+    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** child_env = make_child_control_env("parent-env-exhaustion");
+    pid_t pid = fork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("fork-parent-env-exhaustion");
+        return 231;
+    }
+    if (pid == 0) {
+        environ = make_unterminated_nonpeak_env();
+        execve(self, child_argv, child_env);
+        _exit(232);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "parent_env_exhaustion_child_status=%d\n", child_status);
+        return 233;
+    }
+    printf("parent_env_exhaustion_passthrough=1\n");
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("parent-env-exhaustion-parent-exec");
+    return 234;
 }
 
 enum PostforkExecApi {
@@ -2127,6 +2364,36 @@ run_vfork_child_env_capacity_fallback(const char* self, int long_preload)
     execv(self, parent_argv);
     perror("postfork-capacity-parent-exec");
     return 222;
+}
+
+static int
+run_vfork_preload_entries_fallback(const char* self)
+{
+    char* const child_argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char** envp = make_preload_entries_without_terminator();
+    pid_t pid = vfork();
+    int child_status;
+
+    if (pid < 0) {
+        perror("postfork-preload-entries-vfork");
+        return 223;
+    }
+    if (pid == 0) {
+        execve(self, child_argv, envp);
+        _exit(224);
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr, "postfork_preload_entries_child_status=%d\n", child_status);
+        return 225;
+    }
+    printf("postfork_preload_entries_passthrough=1\n");
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("postfork-preload-entries-parent-exec");
+    return 226;
 }
 
 typedef void (*PeakFiniFn)(void);
@@ -2449,6 +2716,40 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "execve-null-env") == 0) {
         return run_execve_null_env(argv[0]);
     }
+    if (strcmp(argv[1], "execve-loader-path-missing") == 0) {
+        return run_execve_loader_path_env(argv[0], "loader-path-missing",
+                                          NULL, NULL, 0);
+    }
+    if (strcmp(argv[1], "execve-loader-path-explicit") == 0) {
+        return run_execve_loader_path_env(argv[0], "loader-path-explicit",
+                                          env_or_default(
+                                              "EXEC_CHAIN_TEST_CHILD_LOADER_PATH",
+                                              "/tmp/child-loader"),
+                                          NULL, 0);
+    }
+    if (strcmp(argv[1], "execve-loader-path-empty") == 0) {
+        return run_execve_loader_path_env(argv[0], "loader-path-empty",
+                                          "", NULL, 0);
+    }
+    if (strcmp(argv[1], "execve-loader-path-duplicate") == 0) {
+        return run_execve_loader_path_env(
+            argv[0], "loader-path-duplicate",
+            env_or_default("EXEC_CHAIN_TEST_CHILD_LOADER_PATH", "/tmp/child-loader"),
+            env_or_default("EXEC_CHAIN_TEST_CHILD_LOADER_PATH_SECOND",
+                           "/tmp/child-loader-second"),
+            0);
+    }
+    if (strcmp(argv[1], "execve-loader-path-chain-disabled") == 0) {
+        return run_execve_loader_path_env(argv[0], "loader-path-disabled",
+                                          NULL, NULL, 1);
+    }
+    if (strcmp(argv[1], "execve-loader-path-secure") == 0) {
+        return run_execve_loader_path_env(argv[0], "loader-path-secure",
+                                          NULL, NULL, 0);
+    }
+    if (strcmp(argv[1], "execve-loader-path-preload-present") == 0) {
+        return run_execve_preloaded_env(argv[0]);
+    }
     if (strcmp(argv[1], "execve-large-env") == 0) {
         return run_execve_large_env(argv[0]);
     }
@@ -2552,25 +2853,43 @@ main(int argc, char** argv)
         return run_vfork_varargs_exec_parent_exec(argv[0], 2);
     }
     if (strcmp(argv[1], "fork-custom-env-execve") == 0) {
-        return run_postfork_custom_env(argv[0], 0, 0, 0, 0);
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 0, 0);
     }
     if (strcmp(argv[1], "vfork-custom-env-execve") == 0) {
-        return run_postfork_custom_env(argv[0], 1, 0, 0, 0);
+        return run_postfork_custom_env(argv[0], 1, 0, 0, 0, 0);
     }
     if (strcmp(argv[1], "vfork-custom-env-execle") == 0) {
-        return run_postfork_custom_env(argv[0], 1, 1, 0, 0);
+        return run_postfork_custom_env(argv[0], 1, 1, 0, 0, 0);
     }
     if (strcmp(argv[1], "fork-custom-env-disabled") == 0) {
-        return run_postfork_custom_env(argv[0], 0, 0, 1, 0);
+        return run_postfork_custom_env(argv[0], 0, 0, 1, 0, 0);
     }
     if (strcmp(argv[1], "vfork-custom-env-disabled") == 0) {
-        return run_postfork_custom_env(argv[0], 1, 0, 1, 0);
+        return run_postfork_custom_env(argv[0], 1, 0, 1, 0, 0);
     }
     if (strcmp(argv[1], "fork-raw-syscall-custom-env") == 0) {
-        return run_postfork_custom_env(argv[0], 0, 0, 0, 1);
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 1, 0);
     }
     if (strcmp(argv[1], "fork-raw-syscall-chain-disabled") == 0) {
-        return run_postfork_custom_env(argv[0], 0, 0, 1, 1);
+        return run_postfork_custom_env(argv[0], 0, 0, 1, 1, 0);
+    }
+    if (strcmp(argv[1], "fork-loader-path") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 0, 1);
+    }
+    if (strcmp(argv[1], "vfork-loader-path") == 0) {
+        return run_postfork_custom_env(argv[0], 1, 0, 0, 0, 1);
+    }
+    if (strcmp(argv[1], "fork-loader-path-secure") == 0) {
+        return run_postfork_custom_env(argv[0], 0, 0, 0, 0, 1);
+    }
+    if (strcmp(argv[1], "vfork-loader-path-secure") == 0) {
+        return run_postfork_custom_env(argv[0], 1, 0, 0, 0, 1);
+    }
+    if (strcmp(argv[1], "vfork-loader-path-preload-present") == 0) {
+        return run_vfork_preloaded_env(argv[0]);
+    }
+    if (strcmp(argv[1], "fork-parent-env-exhaustion") == 0) {
+        return run_fork_parent_env_exhaustion(argv[0]);
     }
     if (strcmp(argv[1], "vfork-custom-env-execvpe") == 0) {
         return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVPE);
@@ -2609,6 +2928,9 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "vfork-long-preload-fallback") == 0) {
         return run_vfork_child_env_capacity_fallback(argv[0], 1);
+    }
+    if (strcmp(argv[1], "vfork-preload-entries-fallback") == 0) {
+        return run_vfork_preload_entries_fallback(argv[0]);
     }
     if (strcmp(argv[1], "duplicate-preload") == 0) {
         return run_duplicate_preload(argv[0]);

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -406,7 +406,9 @@ invalid_envp_for_test(void)
 static char* const*
 invalid_argv_for_test(void)
 {
-    return (char* const*)(uintptr_t)1;
+    static char* const argv[] = {(char*)(uintptr_t)1, NULL};
+
+    return argv;
 }
 
 static void
@@ -1254,6 +1256,58 @@ run_posix_spawn_null_env(const char* self)
 }
 
 static int
+finish_spawn_observation(const char* operation,
+                         int result,
+                         int saved_errno,
+                         pid_t pid)
+{
+    int status = -1;
+    int wait_errno = 0;
+    int child_created = result == 0;
+    int invalid_success = 0;
+    int child_exit = -1;
+    int child_signal = 0;
+
+    if (child_created && pid <= 0) {
+        invalid_success = 1;
+    } else if (child_created) {
+        while (waitpid(pid, &status, 0) < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            wait_errno = errno;
+            status = -1;
+            break;
+        }
+        if (status >= 0) {
+            if (WIFEXITED(status)) {
+                child_exit = WEXITSTATUS(status);
+            } else if (WIFSIGNALED(status)) {
+                child_signal = WTERMSIG(status);
+            }
+        }
+    }
+
+    call_hot_target(4);
+    printf("spawn_observation operation=%s result=%d errno=%d "
+           "pid_created=%d invalid_success=%d wait_status=%d "
+           "child_exit=%d child_signal=%d "
+           "wait_errno=%d continued_sink=%lu\n",
+           operation,
+           result,
+           saved_errno,
+           child_created,
+           invalid_success,
+           status,
+           child_exit,
+           child_signal,
+           wait_errno,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
+}
+
+static int
 run_posix_spawn_bad_env(const char* self)
 {
     pid_t pid = -1;
@@ -1268,20 +1322,7 @@ run_posix_spawn_bad_env(const char* self)
                          NULL,
                          argv,
                          invalid_envp_for_test());
-    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
-        fprintf(stderr, "posix_spawn_bad_env_errno=%d\n", errno);
-        return 157;
-    }
-    if (result != EFAULT) {
-        fprintf(stderr, "posix_spawn_bad_env_result=%d\n", result);
-        return 158;
-    }
-    call_hot_target(4);
-    printf("posix_spawn_bad_env_result=%d continued sink=%lu\n",
-           result,
-           peak_exec_chain_sink);
-    fflush(stdout);
-    return 0;
+    return finish_spawn_observation("posix_spawn_bad_env", result, errno, pid);
 }
 
 static int
@@ -1298,20 +1339,7 @@ run_posix_spawn_bad_argv(const char* self)
                          NULL,
                          invalid_argv_for_test(),
                          environ);
-    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
-        fprintf(stderr, "posix_spawn_bad_argv_errno=%d\n", errno);
-        return 158;
-    }
-    if (result != EFAULT) {
-        fprintf(stderr, "posix_spawn_bad_argv_result=%d\n", result);
-        return 159;
-    }
-    call_hot_target(4);
-    printf("posix_spawn_bad_argv_result=%d continued sink=%lu\n",
-           result,
-           peak_exec_chain_sink);
-    fflush(stdout);
-    return 0;
+    return finish_spawn_observation("posix_spawn_bad_argv", result, errno, pid);
 }
 
 static int
@@ -1546,22 +1574,14 @@ run_posix_spawn_failure(const char* self)
     int result;
 
     call_hot_target(2);
+    errno = EDOM;
     result = posix_spawn(&pid,
                          "/definitely/not/found",
                          NULL,
                          NULL,
                          argv,
                          environ);
-    if (result != ENOENT) {
-        fprintf(stderr, "posix_spawn_failure_bad_result=%d\n", result);
-        return 138;
-    }
-    call_hot_target(4);
-    printf("posix_spawn_failure_result=%d continued sink=%lu\n",
-           result,
-           peak_exec_chain_sink);
-    fflush(stdout);
-    return 0;
+    return finish_spawn_observation("posix_spawn_failure", result, errno, pid);
 }
 
 static int
@@ -1583,6 +1603,72 @@ run_posix_spawnp_path_search(void)
         return 139;
     }
     return wait_for_child(pid);
+}
+
+static int
+run_posix_spawnp_custom_env(void)
+{
+    pid_t pid = -1;
+    char* const argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-print-ld",
+        NULL
+    };
+    char** envp = make_minimal_child_env("posix-spawnp-env");
+    int result;
+
+    call_hot_target(5);
+    errno = EDOM;
+    result = posix_spawnp(&pid, "test_exec_chain", NULL, NULL, argv, envp);
+    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
+        fprintf(stderr, "posix_spawnp_custom_env_errno=%d\n", errno);
+        return 173;
+    }
+    if (result != 0) {
+        fprintf(stderr, "posix_spawnp_custom_env_failed=%d\n", result);
+        return 174;
+    }
+    return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_resolver_null(const char* self, int use_path_search)
+{
+    pid_t pid = -1;
+    char* const spawn_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    char* const spawnp_argv[] = {
+        (char*)"test_exec_chain",
+        (char*)"child-basic",
+        NULL
+    };
+    int result;
+
+    call_hot_target(2);
+    errno = EDOM;
+    result = use_path_search ?
+        posix_spawnp(&pid,
+                     "test_exec_chain",
+                     NULL,
+                     NULL,
+                     spawnp_argv,
+                     environ) :
+        posix_spawn(&pid, self, NULL, NULL, spawn_argv, environ);
+    if (result != ENOSYS || errno != EDOM || pid != -1) {
+        fprintf(stderr,
+                "posix_spawn_resolver_null_bad result=%d errno=%d pid=%ld "
+                "path_search=%d\n",
+                result,
+                errno,
+                (long)pid,
+                use_path_search);
+        return 175;
+    }
+    call_hot_target(4);
+    printf("posix_spawn_resolver_null_ok path_search=%d sink=%lu\n",
+           use_path_search,
+           peak_exec_chain_sink);
+    fflush(stdout);
+    return 0;
 }
 
 static int
@@ -1626,20 +1712,7 @@ run_posix_spawnp_bad_env(void)
                           NULL,
                           argv,
                           invalid_envp_for_test());
-    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
-        fprintf(stderr, "posix_spawnp_bad_env_errno=%d\n", errno);
-        return 167;
-    }
-    if (result != EFAULT) {
-        fprintf(stderr, "posix_spawnp_bad_env_result=%d\n", result);
-        return 171;
-    }
-    call_hot_target(4);
-    printf("posix_spawnp_bad_env_result=%d continued sink=%lu\n",
-           result,
-           peak_exec_chain_sink);
-    fflush(stdout);
-    return 0;
+    return finish_spawn_observation("posix_spawnp_bad_env", result, errno, pid);
 }
 
 static int
@@ -1656,20 +1729,7 @@ run_posix_spawnp_bad_argv(void)
                           NULL,
                           invalid_argv_for_test(),
                           environ);
-    if (getenv("PEAK_TARGET") != NULL && errno != EDOM) {
-        fprintf(stderr, "posix_spawnp_bad_argv_errno=%d\n", errno);
-        return 168;
-    }
-    if (result != EFAULT) {
-        fprintf(stderr, "posix_spawnp_bad_argv_result=%d\n", result);
-        return 172;
-    }
-    call_hot_target(4);
-    printf("posix_spawnp_bad_argv_result=%d continued sink=%lu\n",
-           result,
-           peak_exec_chain_sink);
-    fflush(stdout);
-    return 0;
+    return finish_spawn_observation("posix_spawnp_bad_argv", result, errno, pid);
 }
 
 static int
@@ -2467,6 +2527,15 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "posix-spawnp-path-search") == 0) {
         return run_posix_spawnp_path_search();
+    }
+    if (strcmp(argv[1], "posix-spawnp-custom-env") == 0) {
+        return run_posix_spawnp_custom_env();
+    }
+    if (strcmp(argv[1], "posix-spawn-resolver-null") == 0) {
+        return run_posix_spawn_resolver_null(argv[0], 0);
+    }
+    if (strcmp(argv[1], "posix-spawnp-resolver-null") == 0) {
+        return run_posix_spawn_resolver_null(argv[0], 1);
     }
     if (strcmp(argv[1], "posix-spawnp-child-env-path-ignored") == 0) {
         return run_posix_spawnp_child_env_path_ignored();

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <linux/sched.h>
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
@@ -32,6 +33,92 @@ extern char** environ;
 #define CONTROLLER_QUIESCE_ARG "--quiesce-controller"
 
 static volatile unsigned long peak_exec_chain_sink;
+static const char* peak_signal_exec_path;
+static const char* peak_signal_exec_command;
+static char* const peak_signal_exec_argv[] = {(char*)"missing-exec", NULL};
+static char* const peak_signal_exec_envp[] = {NULL};
+static unsigned char peak_signal_stack[16384];
+static volatile sig_atomic_t peak_signal_exec_seen;
+static volatile sig_atomic_t peak_signal_exec_result;
+static volatile sig_atomic_t peak_signal_exec_errno;
+
+static int wait_for_child(pid_t pid);
+
+static void
+print_default_bypass_case(const char* name, int result, int error_number)
+{
+    printf("default_bypass_case=%s result=%d errno=%d\n",
+           name, result, error_number);
+}
+
+static int
+run_default_disabled_family_bypass(void)
+{
+    static const char missing_path[] =
+        "/definitely/missing/peak-default-bypass";
+    static const char missing_command[] =
+        "peak-default-bypass-command-does-not-exist";
+    char* const argv[] = {(char*)missing_command, NULL};
+    char* const opt_in_env[] = {
+        (char*)"PEAK_EXEC_CHAIN=1",
+        (char*)"PEAK_EXEC_CHECKPOINT=1",
+        NULL,
+    };
+    pid_t pid = -1;
+    int result;
+
+#define RUN_DEFAULT_BYPASS_CASE(name, expression) \
+    do { \
+        errno = EALREADY; \
+        result = (expression); \
+        print_default_bypass_case((name), result, errno); \
+    } while (0)
+
+    RUN_DEFAULT_BYPASS_CASE("execv", execv(missing_path, argv));
+    RUN_DEFAULT_BYPASS_CASE(
+        "execvpe", execvpe(missing_command, argv, opt_in_env));
+    RUN_DEFAULT_BYPASS_CASE(
+        "execl", execl(missing_path, missing_command, (char*)NULL));
+    RUN_DEFAULT_BYPASS_CASE(
+        "execle",
+        execle(missing_path,
+               missing_command,
+               (char*)NULL,
+               opt_in_env));
+    RUN_DEFAULT_BYPASS_CASE(
+        "fexecve", fexecve(INT_MAX, argv, opt_in_env));
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    RUN_DEFAULT_BYPASS_CASE(
+        "execveat",
+        execveat(AT_FDCWD, missing_path, argv, opt_in_env, 0));
+#endif
+    RUN_DEFAULT_BYPASS_CASE(
+        "posix_spawnp",
+        posix_spawnp(&pid,
+                     missing_command,
+                     NULL,
+                     NULL,
+                     argv,
+                     opt_in_env));
+#if defined(PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED)
+    RUN_DEFAULT_BYPASS_CASE(
+        "raw_execve",
+        (int)syscall(SYS_execve, missing_path, argv, opt_in_env));
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    RUN_DEFAULT_BYPASS_CASE(
+        "raw_execveat",
+        (int)syscall(SYS_execveat,
+                     AT_FDCWD,
+                     missing_path,
+                     argv,
+                     opt_in_env,
+                     0));
+#endif
+#endif
+#undef RUN_DEFAULT_BYPASS_CASE
+    puts("default_disabled_family_bypass=1");
+    return 0;
+}
 
 typedef struct {
     char* name;
@@ -56,6 +143,124 @@ call_hot_target(int loops)
     for (int i = 0; i < loops; i++) {
         peak_exec_chain_hot_target(i);
     }
+}
+
+static void
+signal_handler_execve_missing(int signal_number)
+{
+    int saved_errno = errno;
+    int result;
+    int exec_errno;
+
+    (void)signal_number;
+    result = execve(peak_signal_exec_path,
+                    peak_signal_exec_argv,
+                    peak_signal_exec_envp);
+    exec_errno = errno;
+    if (result == -1 && exec_errno == ENOENT) {
+        result = execl(peak_signal_exec_path,
+                       peak_signal_exec_path,
+                       (char*)NULL);
+        exec_errno = errno;
+    }
+    if (result == -1 && exec_errno == ENOENT) {
+        result = execlp(peak_signal_exec_command,
+                        peak_signal_exec_command,
+                        (char*)NULL);
+        exec_errno = errno;
+    }
+    if (result == -1 && exec_errno == ENOENT) {
+        result = execle(peak_signal_exec_path,
+                        peak_signal_exec_path,
+                        (char*)NULL,
+                        peak_signal_exec_envp);
+        exec_errno = errno;
+    }
+    peak_signal_exec_result = (sig_atomic_t)result;
+    peak_signal_exec_errno = (sig_atomic_t)exec_errno;
+    peak_signal_exec_seen = 1;
+    errno = saved_errno;
+}
+
+static int
+run_signal_handler_execve_default_bypass(void)
+{
+    struct sigaction action;
+    struct sigaction old_action;
+    sigset_t blocked;
+    sigset_t old_mask;
+    sigset_t wait_mask;
+    int signal_error;
+    int result = 0;
+    stack_t signal_stack;
+    stack_t old_signal_stack;
+
+    peak_signal_exec_path = "/definitely/missing/peak-signal-exec";
+    peak_signal_exec_command = "peak-signal-exec-command-does-not-exist";
+    peak_signal_exec_seen = 0;
+    peak_signal_exec_result = 0;
+    peak_signal_exec_errno = 0;
+    signal_stack.ss_sp = peak_signal_stack;
+    signal_stack.ss_size = sizeof(peak_signal_stack);
+    signal_stack.ss_flags = 0;
+    if (syscall(SYS_sigaltstack, &signal_stack, &old_signal_stack) != 0) {
+        perror("sigaltstack");
+        return 219;
+    }
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGUSR1);
+    if (sigprocmask(SIG_BLOCK, &blocked, &old_mask) != 0) {
+        perror("sigprocmask-block");
+        (void)syscall(SYS_sigaltstack, &old_signal_stack, NULL);
+        return 220;
+    }
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = signal_handler_execve_missing;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART | SA_ONSTACK;
+    if (sigaction(SIGUSR1, &action, &old_action) != 0) {
+        perror("sigaction");
+        (void)sigprocmask(SIG_SETMASK, &old_mask, NULL);
+        (void)syscall(SYS_sigaltstack, &old_signal_stack, NULL);
+        return 221;
+    }
+    signal_error = pthread_kill(pthread_self(), SIGUSR1);
+    if (signal_error != 0) {
+        errno = signal_error;
+        perror("pthread-kill-self");
+        result = 222;
+        goto out;
+    }
+    wait_mask = old_mask;
+    sigdelset(&wait_mask, SIGUSR1);
+    while (!peak_signal_exec_seen) {
+        (void)sigsuspend(&wait_mask);
+    }
+    if (peak_signal_exec_result != -1 ||
+        peak_signal_exec_errno != ENOENT) {
+        fprintf(stderr,
+                "signal_handler_execve_result=%d errno=%d\n",
+                (int)peak_signal_exec_result,
+                (int)peak_signal_exec_errno);
+        result = 223;
+        goto out;
+    }
+    printf("signal_handler_execve_default_bypass=1\n");
+
+out:
+    if (sigaction(SIGUSR1, &old_action, NULL) != 0 && result == 0) {
+        perror("sigaction-restore");
+        result = 224;
+    }
+    if (sigprocmask(SIG_SETMASK, &old_mask, NULL) != 0 && result == 0) {
+        perror("sigprocmask-restore");
+        result = 225;
+    }
+    if (syscall(SYS_sigaltstack, &old_signal_stack, NULL) != 0 && result == 0) {
+        perror("sigaltstack-restore");
+        result = 226;
+    }
+    return result;
 }
 
 static void
@@ -179,6 +384,16 @@ make_child_control_env(const char* marker)
 
     envp[2] = make_env_entry("PEAK_EXEC_CHAIN", "1");
     envp[3] = make_env_entry("PEAK_EXEC_PROPAGATE_PEAK_ENV", "1");
+    return envp;
+}
+
+static char**
+make_call_specific_optin_env(const char* marker)
+{
+    char** envp = make_minimal_child_env_without_loader(marker);
+
+    envp[2] = make_env_entry("PEAK_EXEC_CHAIN", "1");
+    envp[3] = make_env_entry("PEAK_EXEC_CHECKPOINT", "1");
     return envp;
 }
 
@@ -829,6 +1044,17 @@ run_execve_custom_env(const char* self)
 }
 
 static int
+run_execve_call_env_optin_default_bypass(const char* self)
+{
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_call_specific_optin_env("call-env-optin-execve");
+
+    execve(self, argv, envp);
+    perror("execve-call-env-optin-default-bypass");
+    return 226;
+}
+
+static int
 run_raw_syscall_execve_custom_env(const char* self)
 {
     char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
@@ -858,6 +1084,41 @@ run_raw_syscall_execve_failure(void)
            peak_exec_chain_sink);
     fflush(stdout);
     return saved_errno == ENOENT ? 0 : 217;
+}
+
+static int
+run_raw_syscall_execve_observer_bypass(void)
+{
+    static const char missing_path[] =
+        "/definitely/missing/peak-raw-observer-exec";
+    char* const argv[] = {(char*)missing_path, NULL};
+    typedef int (*observer_count_fn)(void);
+    observer_count_fn observer_count;
+    void* observer_symbol;
+    long result;
+    int saved_errno;
+    int observed_calls;
+
+    errno = EALREADY;
+    result = syscall(SYS_execve, missing_path, argv, environ);
+    saved_errno = errno;
+    observer_symbol = dlsym(RTLD_DEFAULT,
+                            "peak_test_execve_observer_count");
+    if (observer_symbol == NULL) {
+        fputs("missing execve observer\n", stderr);
+        return 230;
+    }
+    memcpy(&observer_count, &observer_symbol, sizeof(observer_count));
+    observed_calls = observer_count();
+    printf("raw_execve_observer_bypass=%d result=%ld errno=%d "
+           "observed_execve_calls=%d\n",
+           result == -1 && saved_errno == ENOENT && observed_calls == 0,
+           result,
+           saved_errno,
+           observed_calls);
+    return result == -1 && saved_errno == ENOENT && observed_calls == 0 ?
+               0 :
+               231;
 }
 
 static int
@@ -1429,6 +1690,40 @@ run_posix_spawn_custom_env(const char* self)
         return 130;
     }
     return wait_for_child(pid);
+}
+
+static int
+run_posix_spawn_call_env_optin_default_bypass(const char* self)
+{
+    pid_t pid = -1;
+    char* const argv[] = {(char*)self, (char*)"child-print-ld", NULL};
+    char** envp = make_call_specific_optin_env("call-env-optin-spawn");
+    int result;
+    int child_status;
+
+    errno = EDOM;
+    result = posix_spawn(&pid, self, NULL, NULL, argv, envp);
+    if (result != 0) {
+        fprintf(stderr,
+                "posix_spawn_call_env_optin_default_bypass_failed=%d\n",
+                result);
+        return 227;
+    }
+    if (errno != EDOM) {
+        fprintf(stderr,
+                "posix_spawn_call_env_optin_default_bypass_errno=%d\n",
+                errno);
+        return 228;
+    }
+    child_status = wait_for_child(pid);
+    if (child_status != 0) {
+        fprintf(stderr,
+                "posix_spawn_call_env_optin_default_bypass_status=%d\n",
+                child_status);
+        return 229;
+    }
+    printf("posix_spawn_call_env_optin_default_bypass=1\n");
+    return 0;
 }
 
 static int
@@ -2046,6 +2341,306 @@ run_vfork_child_failed_exec_parent_exec(const char* self)
     perror("vfork-failed-child-parent-exec");
     return 185;
 }
+
+typedef struct {
+    const char* self;
+} CloneExecContext;
+
+typedef struct {
+    char** environ_pointer;
+    char* entry_bytes;
+    size_t entry_count;
+    size_t byte_count;
+    uint64_t fingerprint;
+} ParentEnvironmentSnapshot;
+
+static int
+snapshot_parent_environment(ParentEnvironmentSnapshot* snapshot)
+{
+    static const uint64_t fnv_offset = UINT64_C(1469598103934665603);
+    static const uint64_t fnv_prime = UINT64_C(1099511628211);
+    char* output;
+
+    memset(snapshot, 0, sizeof(*snapshot));
+    snapshot->environ_pointer = environ;
+    snapshot->fingerprint = fnv_offset;
+    if (environ == NULL) {
+        return 0;
+    }
+    while (environ[snapshot->entry_count] != NULL) {
+        size_t length = strlen(environ[snapshot->entry_count]) + 1;
+
+        if (snapshot->byte_count > SIZE_MAX - length) {
+            errno = EOVERFLOW;
+            return -1;
+        }
+        snapshot->byte_count += length;
+        snapshot->entry_count++;
+    }
+    snapshot->entry_bytes = malloc(snapshot->byte_count == 0 ?
+                                       1 : snapshot->byte_count);
+    if (snapshot->entry_bytes == NULL) {
+        return -1;
+    }
+    output = snapshot->entry_bytes;
+    for (size_t index = 0; index < snapshot->entry_count; index++) {
+        size_t length = strlen(environ[index]) + 1;
+
+        memcpy(output, environ[index], length);
+        for (size_t byte = 0; byte < length; byte++) {
+            snapshot->fingerprint ^= (unsigned char)output[byte];
+            snapshot->fingerprint *= fnv_prime;
+        }
+        output += length;
+    }
+    return 0;
+}
+
+static int
+parent_environment_matches(const ParentEnvironmentSnapshot* snapshot)
+{
+    const char* expected = snapshot->entry_bytes;
+
+    if (environ != snapshot->environ_pointer) {
+        return 0;
+    }
+    if (environ == NULL) {
+        return snapshot->entry_count == 0;
+    }
+    for (size_t index = 0; index < snapshot->entry_count; index++) {
+        size_t length;
+
+        if (environ[index] == NULL) {
+            return 0;
+        }
+        length = strlen(expected) + 1;
+        if (strlen(environ[index]) + 1 != length ||
+            memcmp(environ[index], expected, length) != 0) {
+            return 0;
+        }
+        expected += length;
+    }
+    return environ[snapshot->entry_count] == NULL &&
+           (size_t)(expected - snapshot->entry_bytes) == snapshot->byte_count;
+}
+
+static void
+destroy_parent_environment_snapshot(ParentEnvironmentSnapshot* snapshot)
+{
+    free(snapshot->entry_bytes);
+    snapshot->entry_bytes = NULL;
+}
+
+static int
+clone_private_child_exec(void* data)
+{
+    const CloneExecContext* context = data;
+    char* const missing_argv[] = {
+        (char*)"/definitely/not/found/peak-clone-exec",
+        NULL
+    };
+    char* const success_argv[] = {
+        (char*)context->self,
+        (char*)"child-clone-private-success",
+        NULL
+    };
+
+    if (execv(missing_argv[0], missing_argv) != -1 || errno != ENOENT) {
+        _exit(241);
+    }
+    execv(context->self, success_argv);
+    _exit(242);
+}
+
+static int
+clone_shared_vm_child_raw_exec(void* data)
+{
+    const CloneExecContext* context = data;
+    char* const argv[] = {(char*)context->self, (char*)"child-basic", NULL};
+
+    (void)syscall(SYS_execve, context->self, argv, environ);
+    (void)syscall(SYS_exit, 243);
+    __builtin_unreachable();
+}
+
+static int
+finish_clone_parent(const char* self,
+                    pid_t pid,
+                    const ParentEnvironmentSnapshot* snapshot,
+                    const char* mode)
+{
+    char* const parent_argv[] = {(char*)self, (char*)"child-basic", NULL};
+    int child_status = wait_for_child(pid);
+
+    if (child_status != 0) {
+        fprintf(stderr, "clone_child_status=%d mode=%s\n", child_status, mode);
+        return 244;
+    }
+    if (!parent_environment_matches(snapshot)) {
+        fprintf(stderr,
+                "clone_parent_environment_invariant=0 mode=%s\n",
+                mode);
+        return 245;
+    }
+    printf("clone_parent_environment_invariant=1 "
+           "environ_pointer_unchanged=1 entries=%zu bytes=%zu "
+           "fingerprint=%016llx mode=%s parent_pid=%ld\n",
+           snapshot->entry_count,
+           snapshot->byte_count,
+           (unsigned long long)snapshot->fingerprint,
+           mode,
+           (long)getpid());
+    fflush(stdout);
+    call_hot_target(5);
+    execv(self, parent_argv);
+    perror("clone-parent-exec");
+    return 246;
+}
+
+static int
+run_libc_clone_exec(const char* self, int flags)
+{
+    enum { clone_stack_size = 64 * 1024 };
+    _Alignas(16) char stack[clone_stack_size];
+    ParentEnvironmentSnapshot snapshot;
+    CloneExecContext context = {self};
+    int shared_vm = (flags & CLONE_VM) != 0;
+    pid_t pid;
+    int result;
+
+    if (snapshot_parent_environment(&snapshot) != 0) {
+        perror("clone-parent-environment-snapshot");
+        return 247;
+    }
+    pid = clone(shared_vm ? clone_shared_vm_child_raw_exec :
+                            clone_private_child_exec,
+                stack + sizeof(stack), flags | SIGCHLD, &context);
+    if (pid < 0) {
+        perror("libc-clone");
+        destroy_parent_environment_snapshot(&snapshot);
+        return 248;
+    }
+    result = finish_clone_parent(self,
+                                 pid,
+                                 &snapshot,
+                                 (flags & CLONE_VFORK) != 0 ? "clone-vfork" :
+                                     (shared_vm ? "clone-vm" :
+                                                  "clone-private-vm"));
+    destroy_parent_environment_snapshot(&snapshot);
+    return result;
+}
+
+#if defined(SYS_clone)
+static int
+run_raw_clone_exec(const char* self, int raw_exec)
+{
+    ParentEnvironmentSnapshot snapshot;
+    char* const missing_argv[] = {
+        (char*)"/definitely/not/found/peak-raw-clone-exec",
+        NULL
+    };
+    char* const success_argv[] = {
+        (char*)self,
+        (char*)"child-clone-private-success",
+        NULL
+    };
+    long result;
+    int finish_result;
+
+    if (snapshot_parent_environment(&snapshot) != 0) {
+        perror("raw-clone-parent-environment-snapshot");
+        return 251;
+    }
+    result = syscall(SYS_clone, SIGCHLD, NULL, NULL, NULL, 0);
+    if (result < 0) {
+        perror("raw-clone");
+        destroy_parent_environment_snapshot(&snapshot);
+        return 252;
+    }
+    if (result == 0) {
+        if (raw_exec) {
+            if (syscall(SYS_execve,
+                        missing_argv[0],
+                        missing_argv,
+                        environ) != -1 || errno != ENOENT) {
+                _exit(253);
+            }
+            (void)syscall(SYS_execve, self, success_argv, environ);
+            (void)syscall(SYS_exit, 254);
+        } else {
+            if (execv(missing_argv[0], missing_argv) != -1 ||
+                errno != ENOENT) {
+                _exit(255);
+            }
+            execv(self, success_argv);
+            _exit(256);
+        }
+        __builtin_unreachable();
+    }
+    finish_result = finish_clone_parent(
+        self,
+        (pid_t)result,
+        &snapshot,
+        raw_exec ? "raw-clone-raw-exec" : "raw-clone-libc-exec");
+    destroy_parent_environment_snapshot(&snapshot);
+    return finish_result;
+}
+#endif
+
+#if defined(PEAK_TEST_HAVE_SYS_CLONE3) && defined(SYS_clone3)
+static int
+run_clone3_exec(const char* self)
+{
+    struct clone_args args;
+    ParentEnvironmentSnapshot snapshot;
+    char* const missing_argv[] = {
+        (char*)"/definitely/not/found/peak-clone3-exec",
+        NULL
+    };
+    char* const success_argv[] = {
+        (char*)self,
+        (char*)"child-clone-private-success",
+        NULL
+    };
+    long result;
+    int finish_result;
+
+    if (snapshot_parent_environment(&snapshot) != 0) {
+        perror("clone3-parent-environment-snapshot");
+        return 257;
+    }
+    memset(&args, 0, sizeof(args));
+    args.exit_signal = SIGCHLD;
+    result = syscall(SYS_clone3, &args, sizeof(args));
+    if (result < 0 && errno == ENOSYS) {
+        puts("clone3_skip_enosys=1");
+        destroy_parent_environment_snapshot(&snapshot);
+        return 0;
+    }
+    if (result < 0) {
+        perror("clone3");
+        destroy_parent_environment_snapshot(&snapshot);
+        return 258;
+    }
+    if (result == 0) {
+        if (syscall(SYS_execve,
+                    missing_argv[0],
+                    missing_argv,
+                    environ) != -1 || errno != ENOENT) {
+            _exit(259);
+        }
+        (void)syscall(SYS_execve, self, success_argv, environ);
+        (void)syscall(SYS_exit, 260);
+        __builtin_unreachable();
+    }
+    finish_result = finish_clone_parent(self,
+                                        (pid_t)result,
+                                        &snapshot,
+                                        "clone3");
+    destroy_parent_environment_snapshot(&snapshot);
+    return finish_result;
+}
+#endif
 
 static int
 run_vfork_varargs_exec_parent_exec(const char* self, int mode)
@@ -2922,6 +3517,10 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "child-basic") == 0) {
         return run_child_basic();
     }
+    if (strcmp(argv[1], "child-clone-private-success") == 0) {
+        puts("clone_private_failed_exec_enoent=1");
+        return run_child_basic();
+    }
     if (strcmp(argv[1], "child-print-ld") == 0) {
         return run_child_print_ld();
     }
@@ -2934,6 +3533,12 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "execv-success") == 0) {
         return run_execv_success(argv[0]);
     }
+    if (strcmp(argv[1], "signal-handler-execve") == 0) {
+        return run_signal_handler_execve_default_bypass();
+    }
+    if (strcmp(argv[1], "default-disabled-family-bypass") == 0) {
+        return run_default_disabled_family_bypass();
+    }
     if (strcmp(argv[1], "execv-zero-call") == 0) {
         return run_execv_zero_call_checkpoint(argv[0]);
     }
@@ -2943,11 +3548,17 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "execve-custom-env") == 0) {
         return run_execve_custom_env(argv[0]);
     }
+    if (strcmp(argv[1], "execve-call-env-optin-default-bypass") == 0) {
+        return run_execve_call_env_optin_default_bypass(argv[0]);
+    }
     if (strcmp(argv[1], "raw-syscall-execve-custom-env") == 0) {
         return run_raw_syscall_execve_custom_env(argv[0]);
     }
     if (strcmp(argv[1], "raw-syscall-execve-failure") == 0) {
         return run_raw_syscall_execve_failure();
+    }
+    if (strcmp(argv[1], "raw-syscall-execve-observer-bypass") == 0) {
+        return run_raw_syscall_execve_observer_bypass();
     }
     if (strcmp(argv[1], "raw-syscall-nonexec") == 0) {
         return run_raw_syscall_nonexec_passthrough();
@@ -3085,6 +3696,28 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "vfork-child-failed-exec-parent-exec") == 0) {
         return run_vfork_child_failed_exec_parent_exec(argv[0]);
     }
+    if (strcmp(argv[1], "clone-private-vm-exec") == 0) {
+        return run_libc_clone_exec(argv[0], 0);
+    }
+    if (strcmp(argv[1], "clone-vm-exec") == 0) {
+        return run_libc_clone_exec(argv[0], CLONE_VM);
+    }
+    if (strcmp(argv[1], "clone-vfork-exec") == 0) {
+        return run_libc_clone_exec(argv[0], CLONE_VM | CLONE_VFORK);
+    }
+#if defined(SYS_clone)
+    if (strcmp(argv[1], "raw-clone-libc-exec") == 0) {
+        return run_raw_clone_exec(argv[0], 0);
+    }
+    if (strcmp(argv[1], "raw-clone-raw-exec") == 0) {
+        return run_raw_clone_exec(argv[0], 1);
+    }
+#endif
+#if defined(PEAK_TEST_HAVE_SYS_CLONE3) && defined(SYS_clone3)
+    if (strcmp(argv[1], "clone3-exec") == 0) {
+        return run_clone3_exec(argv[0]);
+    }
+#endif
     if (strcmp(argv[1], "vfork-execl-parent-exec") == 0) {
         return run_vfork_varargs_exec_parent_exec(argv[0], 0);
     }
@@ -3139,6 +3772,9 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "vfork-custom-env-execvp") == 0) {
         return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVP);
     }
+    if (strcmp(argv[1], "vfork-execvp-native-fallback") == 0) {
+        return run_vfork_custom_env_api(argv[0], POSTFORK_EXECVP);
+    }
     if (strcmp(argv[1], "vfork-custom-env-execlp") == 0) {
         return run_vfork_custom_env_api(argv[0], POSTFORK_EXECLP);
     }
@@ -3185,6 +3821,9 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "posix-spawn-custom-env") == 0) {
         return run_posix_spawn_custom_env(argv[0]);
+    }
+    if (strcmp(argv[1], "posix-spawn-call-env-optin-default-bypass") == 0) {
+        return run_posix_spawn_call_env_optin_default_bypass(argv[0]);
     }
     if (strcmp(argv[1], "posix-spawn-null-env") == 0) {
         return run_posix_spawn_null_env(argv[0]);

--- a/test/exec_chain/test_exec_chain_check_contracts.py
+++ b/test/exec_chain/test_exec_chain_check_contracts.py
@@ -15,18 +15,28 @@ class ExecChainCheckContractsTest(unittest.TestCase):
         checker.check_common(args, proc, workdir)
 
     def test_capacity_passthrough_requires_native_env_and_no_checkpoint(self):
-        output = (
-            "ld_preload_libpeak_count=0 ld_preload_env_entries=1 "
-            "ld_preload_extra_count=0 peak_target=<missing> "
-            "peak_statslog=<missing> marker=postfork-long-preload "
-            "peak_exec_chain=<missing> peak_exec_checkpoint=<missing> "
-            "peak_exec_propagate=<missing> ld_library_path_env_entries=0 "
-            "ld_library_path_0=<missing> ld_library_path_1=<missing>\n"
-            "postfork_capacity_passthrough=1 kind=long-preload\n"
-            "exec_child_ok sink=0\n"
-        )
         with tempfile.TemporaryDirectory() as directory:
             workdir = Path(directory)
+            output = (
+                "ld_preload_libpeak_count=0 ld_preload_env_entries=1 "
+                "ld_preload_extra_count=0 peak_target=<missing> "
+                "peak_statslog=<missing> marker=postfork-long-preload "
+                "peak_exec_chain=<missing> peak_exec_checkpoint=<missing> "
+                "peak_exec_propagate=<missing> ld_library_path_env_entries=0 "
+                "ld_library_path_0=<missing> ld_library_path_1=<missing> "
+                f"path={workdir / 'no-external-commands'} "
+                "observer_mode=capacity-long-preload "
+                "child_pad_validated_count=0 child_pad_mismatch_count=0 "
+                "ld_preload_length=8192 ld_preload_all_x=1 "
+                "loader_observer=<missing> secure_test_hook=<missing>\n"
+                "postfork_capacity_passthrough=1 kind=long-preload "
+                "input_entries=3 input_pad_validated_count=0 "
+                "input_pad_mismatch_count=0 input_preload_entries=1 "
+                "input_preload_length=8192 input_preload_all_x=1 "
+                "input_path_entries=1 input_loader_path_entries=0 "
+                "input_terminator_null=1\n"
+                "exec_child_ok sink=0\n"
+            )
             self.check_mode("vfork_long_preload_fallback", output, workdir)
             (workdir / "peak_stats-p1-exec1.csv").write_text(
                 "function,count\npeak_exec_chain_hot_target,7\n",

--- a/test/exec_chain/test_exec_chain_check_contracts.py
+++ b/test/exec_chain/test_exec_chain_check_contracts.py
@@ -20,7 +20,8 @@ class ExecChainCheckContractsTest(unittest.TestCase):
             "ld_preload_extra_count=0 peak_target=<missing> "
             "peak_statslog=<missing> marker=postfork-long-preload "
             "peak_exec_chain=<missing> peak_exec_checkpoint=<missing> "
-            "peak_exec_propagate=<missing>\n"
+            "peak_exec_propagate=<missing> ld_library_path_env_entries=0 "
+            "ld_library_path_0=<missing> ld_library_path_1=<missing>\n"
             "postfork_capacity_passthrough=1 kind=long-preload\n"
             "exec_child_ok sink=0\n"
         )

--- a/test/exec_chain/test_exec_chain_check_contracts.py
+++ b/test/exec_chain/test_exec_chain_check_contracts.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+import run_exec_chain_check as checker
+
+
+class ExecChainCheckContractsTest(unittest.TestCase):
+    def check_mode(self, mode, output, workdir):
+        proc = argparse.Namespace(returncode=0, stdout=output)
+        args = argparse.Namespace(mode=mode)
+        checker.check_common(args, proc, workdir)
+
+    def test_capacity_passthrough_requires_native_env_and_no_checkpoint(self):
+        output = (
+            "ld_preload_libpeak_count=0 ld_preload_env_entries=1 "
+            "ld_preload_extra_count=0 peak_target=<missing> "
+            "peak_statslog=<missing> marker=postfork-long-preload "
+            "peak_exec_chain=<missing> peak_exec_checkpoint=<missing> "
+            "peak_exec_propagate=<missing>\n"
+            "postfork_capacity_passthrough=1 kind=long-preload\n"
+            "exec_child_ok sink=0\n"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            self.check_mode("vfork_long_preload_fallback", output, workdir)
+            (workdir / "peak_stats-p1-exec1.csv").write_text(
+                "function,count\npeak_exec_chain_hot_target,7\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(AssertionError):
+                self.check_mode("vfork_long_preload_fallback", output, workdir)
+
+    def test_injected_path_still_requires_an_exec_checkpoint(self):
+        output = "exec_child_ok sink=0\n"
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            with self.assertRaises(AssertionError):
+                self.check_mode("execv_success_checkpoint", output, workdir)
+            (workdir / "peak_stats-p1-exec1.csv").write_text(
+                "function,count\npeak_exec_chain_hot_target,5\n",
+                encoding="utf-8",
+            )
+            self.check_mode("execv_success_checkpoint", output, workdir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/exec_chain/test_exec_chain_platform_contract.cmake
+++ b/test/exec_chain/test_exec_chain_platform_contract.cmake
@@ -1,0 +1,33 @@
+if(NOT DEFINED PEAK_SOURCE_ROOT)
+    message(FATAL_ERROR "PEAK_SOURCE_ROOT is required")
+endif()
+
+include("${PEAK_SOURCE_ROOT}/cmake/exec-platform.cmake")
+
+function(assert_exec_platform system_name system_processor raw_expected helper_expected)
+    set(CMAKE_SYSTEM_NAME "${system_name}")
+    set(CMAKE_SYSTEM_PROCESSOR "${system_processor}")
+    peak_exec_configure_platform_support()
+    if(NOT "${PEAK_EXEC_RAW_SYSCALL_SUPPORTED}" STREQUAL "${raw_expected}")
+        message(FATAL_ERROR
+            "raw-syscall predicate mismatch: system=${system_name} "
+            "processor=${system_processor} expected=${raw_expected} "
+            "actual=${PEAK_EXEC_RAW_SYSCALL_SUPPORTED}")
+    endif()
+    if(NOT "${PEAK_DETACH_HELPER_SUPPORTED}" STREQUAL "${helper_expected}")
+        message(FATAL_ERROR
+            "detach-helper predicate mismatch: system=${system_name} "
+            "processor=${system_processor} expected=${helper_expected} "
+            "actual=${PEAK_DETACH_HELPER_SUPPORTED}")
+    endif()
+endfunction()
+
+assert_exec_platform("Linux" "x86_64" "ON" "ON")
+assert_exec_platform("Linux" "AMD64" "ON" "ON")
+assert_exec_platform("Linux" "aarch64" "ON" "ON")
+assert_exec_platform("Linux" "arm64" "ON" "ON")
+assert_exec_platform("Darwin" "arm64" "OFF" "OFF")
+assert_exec_platform("Linux" "ppc64le" "OFF" "OFF")
+assert_exec_platform("Windows" "x86_64" "OFF" "OFF")
+
+message("exec_chain_platform_contract_ok")

--- a/test/exec_chain/test_exec_preinit.c
+++ b/test/exec_chain/test_exec_preinit.c
@@ -1,0 +1,495 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+enum PeakPreinitCase {
+    PEAK_PREINIT_EXECVE,
+    PEAK_PREINIT_EXECV,
+    PEAK_PREINIT_EXECL,
+    PEAK_PREINIT_EXECLE,
+    PEAK_PREINIT_EXECVP,
+    PEAK_PREINIT_EXECVP_EACCES_ELOOP,
+    PEAK_PREINIT_EXECLP,
+    PEAK_PREINIT_EXECVPE,
+    PEAK_PREINIT_FEXECVE,
+    PEAK_PREINIT_EXECVEAT,
+    PEAK_PREINIT_RAW_EXECVE,
+    PEAK_PREINIT_RAW_EXECVEAT,
+    PEAK_PREINIT_POSIX_SPAWN,
+    PEAK_PREINIT_POSIX_SPAWNP,
+    PEAK_PREINIT_CASE_COUNT,
+};
+
+typedef struct {
+    const char* name;
+    int result;
+    int error_number;
+} PeakPreinitResult;
+
+static PeakPreinitResult peak_preinit_results[PEAK_PREINIT_CASE_COUNT] = {
+    [PEAK_PREINIT_EXECVE] = {"execve", 0, 0},
+    [PEAK_PREINIT_EXECV] = {"execv", 0, 0},
+    [PEAK_PREINIT_EXECL] = {"execl", 0, 0},
+    [PEAK_PREINIT_EXECLE] = {"execle", 0, 0},
+    [PEAK_PREINIT_EXECVP] = {"execvp", 0, 0},
+    [PEAK_PREINIT_EXECVP_EACCES_ELOOP] = {
+        "execvp_eacces_eloop", 0, 0
+    },
+    [PEAK_PREINIT_EXECLP] = {"execlp", 0, 0},
+#if defined(PEAK_TEST_HAVE_EXECVPE)
+    [PEAK_PREINIT_EXECVPE] = {"execvpe", 0, 0},
+#endif
+#if defined(PEAK_TEST_HAVE_FEXECVE)
+    [PEAK_PREINIT_FEXECVE] = {"fexecve", 0, 0},
+#endif
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    [PEAK_PREINIT_EXECVEAT] = {"execveat", 0, 0},
+#endif
+#if defined(PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED)
+    [PEAK_PREINIT_RAW_EXECVE] = {"raw_execve", 0, 0},
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    [PEAK_PREINIT_RAW_EXECVEAT] = {"raw_execveat", 0, 0},
+#endif
+#endif
+    [PEAK_PREINIT_POSIX_SPAWN] = {"posix_spawn", 0, 0},
+    [PEAK_PREINIT_POSIX_SPAWNP] = {"posix_spawnp", 0, 0},
+};
+
+static char* const peak_preinit_argv[] = {
+    (char*)"peak-preinit-command-does-not-exist",
+    NULL,
+};
+static char* const peak_preinit_envp[] = {NULL};
+static char* const peak_preinit_eacces_eloop_argv[] = {
+    (char*)"peak-preinit-eacces-eloop",
+    NULL,
+};
+static PeakPreinitResult peak_resolver_reentry = {
+    "execve", 0, 0
+};
+static PeakPreinitResult peak_spawn_resolver_reentry[] = {
+    {"posix_spawn", 0, 0},
+    {"posix_spawnp", 0, 0},
+};
+static PeakPreinitResult peak_spawn_publication_reentry[] = {
+    {"posix_spawn", 0, 0},
+    {"posix_spawnp", 0, 0},
+};
+static pthread_mutex_t peak_spawn_publication_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_spawn_publication_cond = PTHREAD_COND_INITIALIZER;
+static pthread_t peak_spawn_publication_workers[2];
+static int peak_spawn_publication_worker_created[2];
+static int peak_spawn_publication_waiter_entered[2];
+static int peak_spawn_publication_worker_done[2];
+static int peak_spawn_publication_waited[2];
+static int peak_spawn_raw_fork_child_ok[] = {0, 0};
+static int peak_resolver_raw_fork_child_ok;
+
+static pid_t
+peak_test_raw_fork(void)
+{
+#if defined(SYS_fork) && !defined(PEAK_TEST_FORCE_CLONE_RAW_FORK)
+    return (pid_t)syscall(SYS_fork);
+#elif defined(SYS_clone)
+    /* SIGCHLD without CLONE_VM gives fork-like private address-space semantics. */
+    return (pid_t)syscall(SYS_clone,
+                          (unsigned long)SIGCHLD,
+                          NULL,
+                          NULL,
+                          NULL,
+                          0UL);
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+static void
+peak_preinit_record(enum PeakPreinitCase preinit_case,
+                    int result,
+                    int error_number)
+{
+    peak_preinit_results[preinit_case].result = result;
+    peak_preinit_results[preinit_case].error_number = error_number;
+}
+
+static void
+peak_exec_from_preinit(int argc, char** argv, char** envp)
+{
+    static const char missing_path[] =
+        "/definitely/missing/peak-preinit-exec";
+    static const char missing_command[] =
+        "peak-preinit-command-does-not-exist";
+    pid_t pid = -1;
+    int result;
+    int saved_errno;
+
+    (void)argc;
+    (void)argv;
+    environ = envp;
+
+    errno = EALREADY;
+    result = execve(missing_path, peak_preinit_argv, peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECVE, result, saved_errno);
+
+    errno = EALREADY;
+    result = execv(missing_path, peak_preinit_argv);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECV, result, saved_errno);
+
+    errno = EALREADY;
+    result = execl(missing_path, missing_command, (char*)NULL);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECL, result, saved_errno);
+
+    errno = EALREADY;
+    result = execle(missing_path,
+                    missing_command,
+                    (char*)NULL,
+                    peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECLE, result, saved_errno);
+
+    errno = EALREADY;
+    result = execvp(missing_command, peak_preinit_argv);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECVP, result, saved_errno);
+
+    errno = EALREADY;
+    result = execvp("peak-preinit-eacces-eloop",
+                    peak_preinit_eacces_eloop_argv);
+    saved_errno = errno;
+    peak_preinit_record(
+        PEAK_PREINIT_EXECVP_EACCES_ELOOP, result, saved_errno);
+
+    errno = EALREADY;
+    result = execlp(missing_command, missing_command, (char*)NULL);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECLP, result, saved_errno);
+
+#if defined(PEAK_TEST_HAVE_EXECVPE)
+    errno = EALREADY;
+    result = execvpe(missing_command, peak_preinit_argv, peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECVPE, result, saved_errno);
+#endif
+
+#if defined(PEAK_TEST_HAVE_FEXECVE)
+    errno = EALREADY;
+    result = fexecve(INT_MAX, peak_preinit_argv, peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_FEXECVE, result, saved_errno);
+#endif
+
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    errno = EALREADY;
+    result = execveat(AT_FDCWD,
+                      missing_path,
+                      peak_preinit_argv,
+                      peak_preinit_envp,
+                      0);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_EXECVEAT, result, saved_errno);
+#endif
+
+#if defined(PEAK_TEST_EXEC_RAW_SYSCALL_SUPPORTED)
+    errno = EALREADY;
+    result = (int)syscall(SYS_execve,
+                          missing_path,
+                          peak_preinit_argv,
+                          peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_RAW_EXECVE, result, saved_errno);
+#if defined(PEAK_TEST_HAVE_EXECVEAT)
+    errno = EALREADY;
+    result = (int)syscall(SYS_execveat,
+                          AT_FDCWD,
+                          missing_path,
+                          peak_preinit_argv,
+                          peak_preinit_envp,
+                          0);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_RAW_EXECVEAT, result, saved_errno);
+#endif
+#endif
+
+    errno = EALREADY;
+    result = posix_spawn(&pid,
+                         missing_path,
+                         NULL,
+                         NULL,
+                         peak_preinit_argv,
+                         peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_POSIX_SPAWN, result, saved_errno);
+
+    errno = EALREADY;
+    result = posix_spawnp(&pid,
+                          missing_command,
+                          NULL,
+                          NULL,
+                          peak_preinit_argv,
+                          peak_preinit_envp);
+    saved_errno = errno;
+    peak_preinit_record(PEAK_PREINIT_POSIX_SPAWNP, result, saved_errno);
+}
+
+__attribute__((visibility("default"), used))
+void
+peak_test_exec_resolver_reentry_hook(void)
+{
+    static const char missing_path[] =
+        "/definitely/missing/peak-resolver-reentry-exec";
+    pid_t pid;
+    pid_t waited;
+    int status;
+
+    errno = EALREADY;
+    peak_resolver_reentry.result =
+        execve(missing_path, peak_preinit_argv, peak_preinit_envp);
+    peak_resolver_reentry.error_number = errno;
+
+    pid = peak_test_raw_fork();
+    if (pid == 0) {
+        alarm(2);
+        errno = EALREADY;
+        if (execve(missing_path,
+                   peak_preinit_argv,
+                   peak_preinit_envp) == -1 && errno == ENOENT) {
+            _exit(0);
+        }
+        _exit(1);
+    }
+    if (pid < 0) {
+        return;
+    }
+    status = 0;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    peak_resolver_raw_fork_child_ok =
+        waited == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+__attribute__((visibility("default"), used))
+void
+peak_test_exec_spawn_resolver_reentry_hook(int path_search)
+{
+    static const char missing_path[] =
+        "/definitely/missing/peak-spawn-resolver-reentry";
+    PeakPreinitResult* result = &peak_spawn_resolver_reentry[path_search != 0];
+    pid_t pid = -1;
+
+    errno = EALREADY;
+    if (path_search) {
+        result->result = posix_spawnp(&pid,
+                                      "peak-spawn-resolver-reentry",
+                                      NULL,
+                                      NULL,
+                                      peak_preinit_argv,
+                                      peak_preinit_envp);
+    } else {
+        result->result = posix_spawn(&pid,
+                                     missing_path,
+                                     NULL,
+                                     NULL,
+                                     peak_preinit_argv,
+                                     peak_preinit_envp);
+    }
+    result->error_number = errno;
+}
+
+typedef struct {
+    int path_search;
+    PeakPreinitResult result;
+} PeakSpawnPublicationThread;
+
+static void*
+peak_spawn_publication_thread(void* opaque)
+{
+    PeakSpawnPublicationThread* thread = opaque;
+    pid_t pid = -1;
+
+    errno = EALREADY;
+    if (thread->path_search) {
+        thread->result.result = posix_spawnp(&pid,
+                                             "peak-publication-reentry",
+                                             NULL,
+                                             NULL,
+                                             peak_preinit_argv,
+                                             peak_preinit_envp);
+    } else {
+        thread->result.result = posix_spawn(&pid,
+                                            "/definitely/missing/peak-publication-reentry",
+                                            NULL,
+                                            NULL,
+                                            peak_preinit_argv,
+                                            peak_preinit_envp);
+    }
+    thread->result.error_number = errno;
+    (void)pthread_mutex_lock(&peak_spawn_publication_lock);
+    peak_spawn_publication_reentry[thread->path_search] = thread->result;
+    peak_spawn_publication_worker_done[thread->path_search] = 1;
+    (void)pthread_cond_broadcast(&peak_spawn_publication_cond);
+    (void)pthread_mutex_unlock(&peak_spawn_publication_lock);
+    return NULL;
+}
+
+__attribute__((visibility("default"), used))
+void
+peak_test_exec_spawn_waiter_hook(int path_search)
+{
+    int index = path_search != 0;
+
+    (void)pthread_mutex_lock(&peak_spawn_publication_lock);
+    peak_spawn_publication_waiter_entered[index] = 1;
+    (void)pthread_cond_broadcast(&peak_spawn_publication_cond);
+    (void)pthread_mutex_unlock(&peak_spawn_publication_lock);
+}
+
+__attribute__((visibility("default"), used))
+void
+peak_test_exec_spawn_publication_hook(int path_search)
+{
+    int index = path_search != 0;
+    int pipefd[2];
+    pid_t pid;
+    pid_t waited;
+    int status = 0;
+    int child_result[2] = {0, 0};
+
+    peak_spawn_publication_reentry[index] = (PeakPreinitResult){
+        path_search ? "posix_spawnp" : "posix_spawn", 0, 0};
+    peak_spawn_publication_waiter_entered[index] = 0;
+    peak_spawn_publication_worker_done[index] = 0;
+    peak_spawn_publication_waited[index] = 0;
+    {
+        static PeakSpawnPublicationThread threads[2];
+
+        threads[index] = (PeakSpawnPublicationThread){
+            .path_search = index,
+            .result = {path_search ? "posix_spawnp" : "posix_spawn", 0, 0},
+        };
+        if (pthread_create(&peak_spawn_publication_workers[index],
+                           NULL,
+                           peak_spawn_publication_thread,
+                           &threads[index]) == 0) {
+            peak_spawn_publication_worker_created[index] = 1;
+            (void)pthread_mutex_lock(&peak_spawn_publication_lock);
+            while (!peak_spawn_publication_waiter_entered[index] &&
+                   !peak_spawn_publication_worker_done[index]) {
+                (void)pthread_cond_wait(&peak_spawn_publication_cond,
+                                        &peak_spawn_publication_lock);
+            }
+            peak_spawn_publication_waited[index] =
+                peak_spawn_publication_waiter_entered[index] &&
+                !peak_spawn_publication_worker_done[index];
+            (void)pthread_mutex_unlock(&peak_spawn_publication_lock);
+        }
+    }
+
+    if (pipe(pipefd) != 0) {
+        return;
+    }
+    pid = peak_test_raw_fork();
+    if (pid == 0) {
+        pid_t child_pid = -1;
+
+        (void)close(pipefd[0]);
+        errno = EALREADY;
+        child_result[0] = path_search ?
+            posix_spawnp(&child_pid,
+                         "peak-raw-fork-resolver",
+                         NULL,
+                         NULL,
+                         peak_preinit_argv,
+                         peak_preinit_envp) :
+            posix_spawn(&child_pid,
+                        "/definitely/missing/peak-raw-fork-resolver",
+                        NULL,
+                        NULL,
+                        peak_preinit_argv,
+                        peak_preinit_envp);
+        child_result[1] = errno;
+        (void)write(pipefd[1], child_result, sizeof(child_result));
+        _exit(0);
+    }
+    (void)close(pipefd[1]);
+    if (pid > 0 && read(pipefd[0], child_result, sizeof(child_result)) ==
+                       (ssize_t)sizeof(child_result)) {
+        do {
+            waited = waitpid(pid, &status, 0);
+        } while (waited < 0 && errno == EINTR);
+        peak_spawn_raw_fork_child_ok[path_search != 0] =
+            waited == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0 &&
+            child_result[0] == ENOSYS && child_result[1] == EALREADY;
+    }
+    (void)close(pipefd[0]);
+}
+
+__attribute__((section(".preinit_array"), used))
+static void (*const peak_exec_preinit_entry)(int, char**, char**) =
+    peak_exec_from_preinit;
+
+int
+main(void)
+{
+    (void)setvbuf(stdout, NULL, _IONBF, 0);
+    printf("resolver_reentry_case=%s result=%d errno=%d\n",
+           peak_resolver_reentry.name,
+           peak_resolver_reentry.result,
+           peak_resolver_reentry.error_number);
+    for (size_t index = 0;
+         index < sizeof(peak_spawn_resolver_reentry) /
+                     sizeof(peak_spawn_resolver_reentry[0]);
+         index++) {
+        const PeakPreinitResult* result = &peak_spawn_resolver_reentry[index];
+
+        printf("spawn_resolver_reentry_case=%s result=%d errno=%d\n",
+               result->name, result->result, result->error_number);
+    }
+    printf("resolver_raw_fork_child_ok=%d\n",
+           peak_resolver_raw_fork_child_ok);
+    for (size_t index = 0;
+         index < sizeof(peak_spawn_publication_workers) /
+                     sizeof(peak_spawn_publication_workers[0]);
+         index++) {
+        if (peak_spawn_publication_worker_created[index]) {
+            (void)pthread_join(peak_spawn_publication_workers[index], NULL);
+        }
+    }
+    for (size_t index = 0; index < PEAK_PREINIT_CASE_COUNT; index++) {
+        const PeakPreinitResult* result = &peak_preinit_results[index];
+
+        if (result->name != NULL) {
+            printf("preinit_case=%s result=%d errno=%d\n",
+                   result->name,
+                   result->result,
+                   result->error_number);
+        }
+    }
+    for (size_t index = 0;
+         index < sizeof(peak_spawn_publication_reentry) /
+                     sizeof(peak_spawn_publication_reentry[0]);
+         index++) {
+        const PeakPreinitResult* result = &peak_spawn_publication_reentry[index];
+
+        printf("spawn_publication_waited_case=%s ok=%d\n",
+               result->name, peak_spawn_publication_waited[index]);
+
+        printf("spawn_publication_reentry_case=%s result=%d errno=%d\n",
+               result->name, result->result, result->error_number);
+        printf("spawn_raw_fork_child_case=%s ok=%d\n",
+               result->name, peak_spawn_raw_fork_child_ok[index]);
+    }
+    return 0;
+}

--- a/test/exec_chain/test_execve_observer.c
+++ b/test/exec_chain/test_execve_observer.c
@@ -1,0 +1,38 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <unistd.h>
+
+typedef int (*peak_test_execve_fn)(const char*,
+                                   char* const[],
+                                   char* const[]);
+
+static peak_test_execve_fn peak_test_real_execve;
+static int peak_test_execve_calls;
+
+__attribute__((constructor))
+static void
+peak_test_execve_observer_init(void)
+{
+    peak_test_real_execve =
+        (peak_test_execve_fn)dlsym(RTLD_NEXT, "execve");
+}
+
+__attribute__((visibility("default")))
+int
+execve(const char* path, char* const argv[], char* const envp[])
+{
+    peak_test_execve_calls++;
+    if (peak_test_real_execve == NULL) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return peak_test_real_execve(path, argv, envp);
+}
+
+__attribute__((visibility("default")))
+int
+peak_test_execve_observer_count(void)
+{
+    return peak_test_execve_calls;
+}

--- a/test/static_checks/check_arm_detach_support.py
+++ b/test/static_checks/check_arm_detach_support.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -13,6 +15,14 @@ def read(root, rel):
     return (root / rel).read_text(encoding="utf-8")
 
 
+def cmake_function_body(cmake, function_name):
+    match = re.search(
+        rf"function\({function_name}\b[\s\S]*?\nendfunction\(\)", cmake
+    )
+    require(match is not None, f"missing CMake function: {function_name}")
+    return match.group(0)
+
+
 def main():
     if len(sys.argv) != 2:
         raise SystemExit("usage: check_arm_detach_support.py <repo-root>")
@@ -23,9 +33,41 @@ def main():
     peak_api = read(root, "cmake/peak-gum/frida-gum-peak-api.h")
     gum_overlay = read(root, "cmake/peak-gum/gum_peak_pc_api.c")
     helper = read(root, "src/detach_helper.c")
+    platform_cmake = read(root, "cmake/exec-platform.cmake")
+    source_cmake = read(root, "src/CMakeLists.txt")
+    detach_tests_cmake = read(root, "test/detach_controller/CMakeLists.txt")
 
-    require("aarch64" in top_cmake and "arm64" in top_cmake,
-            "top-level CMake must enable the detach helper on Linux arm64/aarch64")
+    require("peak_exec_configure_platform_support()" in top_cmake and
+            "set(PEAK_DETACH_HELPER_SUPPORTED" not in top_cmake,
+            "top-level CMake must use the shared raw-syscall/detach wiring")
+    raw_predicate = cmake_function_body(
+        platform_cmake, "peak_exec_raw_syscall_supported")
+    helper_predicate = cmake_function_body(
+        platform_cmake, "peak_detach_helper_supported")
+    require("PEAK_EXEC_RAW_SYSCALL_SUPPORTED" not in helper_predicate and
+            "peak_exec_raw_syscall_supported" not in helper_predicate,
+            "detach-helper support must not derive from raw-syscall support")
+    require("aarch64" in raw_predicate and "aarch64" in helper_predicate,
+            "raw syscall and detach-helper predicates must retain Linux arm64")
+    require("if(PEAK_DETACH_HELPER_SUPPORTED)" in source_cmake,
+            "detach-helper construction must use its dedicated predicate")
+    require("if(PEAK_EXEC_RAW_SYSCALL_SUPPORTED)" in detach_tests_cmake and
+            "if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)"
+            in detach_tests_cmake,
+            "detach lifecycle tests must retain separate raw and helper gates")
+    cmake = shutil.which("cmake")
+    require(cmake is not None, "cmake is required to evaluate the platform predicate")
+    platform_contract = root / "test/exec_chain/test_exec_chain_platform_contract.cmake"
+    predicate = subprocess.run(
+        [cmake, f"-DPEAK_SOURCE_ROOT={root}", "-P", str(platform_contract)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    require(predicate.returncode == 0 and
+            "exec_chain_platform_contract_ok" in predicate.stdout,
+            "shared exec/detach platform predicate failed:\n" + predicate.stdout)
     require("aarch64" in frida_cmake and "arm64" in frida_cmake,
             "Frida Gum auto-patch selection must include Linux arm64/aarch64")
     require("GUM_PEAK_PC_ABI_FRIDA_GUM_17_15_3_LINUX_ARM64" in peak_api,

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1307,6 +1307,9 @@ def check_signal_backend_strict_invariants(repo_root):
     signal_policy = (repo_root / "src/signal_policy.c").read_text(
         encoding="utf-8"
     )
+    syscall_trampoline = (
+        repo_root / "src/exec_raw_syscall_trampoline.S"
+    ).read_text(encoding="utf-8")
     signal_public_header = (
         repo_root / "include/signal_policy.h"
     ).read_text(encoding="utf-8")
@@ -1475,8 +1478,9 @@ def check_signal_backend_strict_invariants(repo_root):
         require(f'__attribute__((visibility("default"))) int\n{wrapper}' in signal_policy or
                 f'__attribute__((visibility("default"))) void (*{wrapper}' in signal_policy,
                 f"signal policy must export {wrapper}")
-    require('__asm__("syscall")' in signal_policy and
-            "peak_signal_policy_syscall" in signal_policy and
+    require("peak_signal_policy_syscall_dispatch" in signal_policy and
+            ".globl syscall" in syscall_trampoline and
+            "peak_signal_policy_syscall_dispatch" in syscall_trampoline and
             "peak_signal_policy_safe_read" in signal_policy and
             "/proc/self/maps" not in signal_policy and
             "SYS_pread64" in signal_policy and


### PR DESCRIPTION
## Summary

- checkpoint rank-local profiling output before a direct exec attempt without
  finalizing PEAK or mutating hook state
- propagate PEAK configuration and deduplicated loader state across supported
  exec, spawn, fork, vfork, clone, and raw-exec paths
- preserve explicit child environments and honor `PEAK_EXEC_CHAIN=0`
- isolate the internal detach helper from recursive exec-chain preload
- provide deterministic concurrency, fallback, and lifecycle coverage

## Stack And State-Machine Boundary

PR #47 has merged into `main` as
`b3674793370611c09be7accbf80255cff014f64c`. This PR has been rebased onto
that commit and now contains only its 10 exec-chain commits.

The heartbeat/controller hook states, request coalescing,
prepare/mutate/finish ordering, retry and cooldown behavior, rollback,
mutation-guard ownership, and Gum mutation ordering are unchanged from PR #47.
PR48 does not modify `controller.inc` or `controller_state.inc`; its only
detach-controller behavior change sanitizes `PEAK_EXEC_CHAIN=0` for the
internal helper. PR #46 is abandoned and must not be merged or mechanically
copied.

## Final Head

- head: `fc575adc55b2368770bd405b724cecb174b171ff`
- history: 10 logical commits on merged PR #47 / current `main`
- all 10 patches map one-to-one across the rebase, and the source tree is
  identical to pre-rebase head `ba14992ffe40e6dce9cebea9abc8e8075130c6e9`
- local and remote heads match; worktree is clean
- GCC and Clang each pass all 148 exec-chain tests and 305/305
  non-timing-sensitive repository tests
- all hosted GCC, Clang, Intel MPI, MPICH, and OpenMPI checks were green on
  the identical pre-rebase tree; checks for the rebased commit identities are
  running
- exact Frontera prebuild `7856927` completed `0:0`, including 136/136
  registered exec-chain tests with the GNU MPI toolchain

## Final 1024-Node Validation

Run-only job `7856937` validated pre-rebase head `ba14992` and completed `0:0`
in 34:05. Rebased head `fc575ad` has the identical source tree, so the rebase
changed commit identity but no product bits. The job used 1024 nodes, 4096
ranks, OMP13, the exact scratch2 gauge,
`milc_func_list_cpu` with 832 targets, a 60-second cooldown, no tracing, and
B0/auto x3/signal x3/Bend. No compilation occurred in the large allocation.

All eight arms completed with launcher status 0. Every PEAK arm produced 4096
rank markers, a nonempty approximately 35.5 KB CSV, 247 profiled targets,
valid accounting, zero failed windows, complete PEAK output, and no timeout,
MPI abort, hang, or SIGKILL. Transition coverage was 38-39 detached, 37-38
reattached, and 27-28 revisited targets.

This exact-product-tree run closes the previous lifecycle gap from `7856618`.
Historical SIGKILL events are neither PR48-exclusive nor 1024-node-exclusive,
and no such event occurred here.

## Overhead Interpretation

Application times were B0 173.5786 s; auto 179.0752/183.5281/181.2488 s;
signal 188.2081/193.1605/181.9215 s; and Bend 154.7470 s. Bend was 10.849%
faster than B0, so the run fails the 2% baseline-drift gate and cannot support
an external B-A-B overhead claim.

Internal per-rank maxima are reported separately:

- auto mean: raw profile+control 2.3659%, risk 2.4071%, management 1.8911%
- signal mean: raw profile+control 2.6216%, risk 2.9187%, management 1.8284%

Risk and management are independent maxima. Their sums are only conservative
upper-bound diagnostics, not measured application overhead. This PR makes no
claim of exact 5% or MPI-wide overhead control, and the 60-second cooldown is
a tested conservative policy rather than a validated optimum.

## Final Review

Two independent GPT-5.6 Sol reviews found no code-level merge blocker,
confirmed the protected hook state-machine boundary, and accepted PR47's
later evidence-backed heartbeat-policy scope with the limitations above.
PR48 is merge-ready on current `main`.
