### PR TITLE
Harden target configuration parsing

### DIFF
--- a/include/utils/target_config.h
+++ b/include/utils/target_config.h
@@ -17,7 +17,8 @@ extern "C" {
  *
  * An unset or empty value stores NULL in @p result and returns zero. Otherwise
  * the environment string is duplicated before tokenization and is not
- * modified. A single trailing delimiter is ignored.
+ * modified. Tokens are trimmed; leading, consecutive, trailing, and
+ * whitespace-only fields are ignored.
  *
  * Assuming all required allocations succeed, both the array and every token
  * are newly allocated. The caller owns them and must pass the returned count
@@ -27,69 +28,45 @@ extern "C" {
  * @param[in] a_delim Non-NUL delimiter character.
  * @param[out] result Receives the newly allocated token array, or NULL for an
  *                    unset or empty value.
- * @return Zero for an unset or empty value; otherwise the number of owned
- *         strings in @p result for supported input.
+ * @return The number of successfully appended owned strings. Allocation
+ *         failures return the successfully appended prefix.
  * @pre @p env_var and @p result are not NULL.
  * @pre @p a_delim is not @c '\0'.
- * @pre A nonempty environment value contains at least one @p a_delim, does not
- *      begin with it, and does not contain adjacent delimiters. Delimiter-free,
- *      leading-delimiter, and adjacent-delimiter forms are outside the current
- *      implementation's supported input.
- * @pre Every required allocation succeeds; allocation failure has no reliable,
- *      recoverable result contract in the current implementation.
  */
 size_t parse_env_w_delim(const char* env_var, const char a_delim, char*** result);
 
 /**
  * @brief Appends target symbols from an external configuration file.
  *
- * The environment variable named by config_file supplies the file path. Each
- * line is copied, with its newline removed, and appended at @p existing_count.
- * Assuming all required allocations succeed, the caller retains ownership of
- * the reallocated array and all strings and must eventually release them with
- * free_parsed_result(). An unset or empty path, or a file-open failure, returns
- * zero without appending entries.
+ * The environment variable named by config_file supplies the file path. Lines
+ * are read with getline(), trimmed (including CRLF), and empty lines are
+ * ignored. The caller retains ownership of the reallocated array and all
+ * strings and must eventually release them with free_parsed_result().
  *
  * @param[in] config_file Name of the environment variable containing the path.
  * @param[in,out] result Address of a heap-allocated string array to extend.
  * @param[in] existing_count Number of initialized entries already in @p result.
- * @return Zero when no entries are appended; otherwise the number of appended
- *         file lines for supported input.
+ * @return The actual number of successfully appended target names.
  * @pre @p config_file and @p result are not NULL.
  * @pre @p *result is NULL or a realloc-compatible allocation; its first
  *      @p existing_count entries are initialized, heap-owned strings.
- * @pre The configuration file is nonempty, contains no consecutive newline
- *      bytes or embedded NUL bytes, remains unchanged across the counting and
- *      reading passes, and each logical line is consumed by one successful
- *      fgets() call with a 256-byte buffer (at most 254 bytes before a newline,
- *      or 255 bytes for a final line without a newline). fgetc() and rewind()
- *      must also succeed. Other file shapes and I/O failures are outside the
- *      loader's supported input because its two passes can disagree.
- * @pre Size arithmetic does not overflow and every required realloc() and
- *      strdup() succeeds; allocation failure has no reliable recovery contract.
  */
 size_t load_profiling_symbols(const char* config_file, char*** result, size_t existing_count);
 
 /**
  * @brief Appends symbols from the built-in target groups selected by an environment variable.
  *
- * Selection uses case-sensitive substring searches in the fixed order BLAS,
- * LAPACK, PBLAS, ScaLAPACK, and FFTW. Consequently @c PBLAS also selects BLAS,
- * and @c ScaLAPACK also selects LAPACK. Each selected symbol is duplicated and
- * appended at @p existing_count. Assuming all allocations succeed, the caller
- * owns the reallocated array and all appended strings and must eventually use
- * free_parsed_result().
+ * Selection uses exact, case-sensitive comma-separated group names: BLAS,
+ * LAPACK, PBLAS, ScaLAPACK, and FFTW. Tokens are trimmed and each selected
+ * symbol is duplicated and appended at @p existing_count.
  *
  * @param[in] env_var Name of the environment variable selecting target groups.
  * @param[in,out] result Address of a heap-allocated string array to extend.
  * @param[in] existing_count Number of initialized entries already in @p result.
- * @return Zero if the value is unset or contains no recognized substring;
- *         otherwise the number of appended symbols.
+ * @return The number of successfully appended symbols.
  * @pre @p env_var and @p result are not NULL.
  * @pre @p *result is NULL or a realloc-compatible allocation; its first
  *      @p existing_count entries are initialized, heap-owned strings.
- * @pre Size arithmetic does not overflow and every required realloc() and
- *      strdup() succeeds; allocation failure has no reliable recovery contract.
  */
 size_t load_symbols_from_array(const char* env_var, char*** result, size_t existing_count);
 
@@ -108,6 +85,15 @@ size_t load_symbols_from_array(const char* env_var, char*** result, size_t exist
  *      @p count entries that may each be passed to free().
  */
 void free_parsed_result(char** result, size_t count);
+
+#ifdef PEAK_TARGET_CONFIG_TESTING
+/** Fail allocations after @p successful_allocations allocation attempts. */
+void peak_target_config_test_fail_allocations_after(size_t successful_allocations);
+/** Reset the target-parser warning counters used by unit tests. */
+void peak_target_config_test_reset_warning_counts(void);
+/** Return the number of empty-token warnings emitted since the last reset. */
+size_t peak_target_config_test_empty_token_warning_count(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ set(sources_peak
     peak.c
     detach_controller.c
     jit_provider.c
-    logging.c
     signal_policy.c
     pthread_listener.c
     syscall_interceptor.c

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,6 +2,7 @@
 # the PEAK library merely by appearing in this directory.
 set(sources_utils_c
     env_parser.c
+    ../logging.c
     mpi_utils.c
     parent_registry.c
     process_filter.c
@@ -18,5 +19,8 @@ set(sources_utils_cxx
 add_library(utils_c OBJECT ${sources_utils_c})
 add_library(utils_cxx OBJECT ${sources_utils_cxx})
 
-target_include_directories(utils_c PUBLIC ${PROJECT_SOURCE_DIR}/include/utils)
+target_include_directories(utils_c PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/utils)
 target_include_directories(utils_cxx PUBLIC ${PROJECT_SOURCE_DIR}/include/utils)
+target_link_libraries(utils_c PUBLIC Threads::Threads)

--- a/src/utils/target_config.c
+++ b/src/utils/target_config.c
@@ -1,179 +1,405 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include "target_config.h"
 
+#include "logging.h"
 #include "source_target.h"
 
-#include <assert.h>
+#include <ctype.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-size_t parse_env_w_delim(const char* env_var, const char a_delim, char*** result)
+typedef struct {
+    char** items;
+    size_t count;
+    size_t capacity;
+    bool allocation_failed;
+} TargetBuilder;
+
+#ifdef PEAK_TARGET_CONFIG_TESTING
+static size_t target_config_successful_allocations = SIZE_MAX;
+static size_t target_config_empty_token_warning_count;
+
+void
+peak_target_config_test_fail_allocations_after(size_t successful_allocations)
 {
-    char* a_str = getenv(env_var);
-    if (a_str == NULL || a_str[0] == '\0') {
-        *result = NULL;
+    target_config_successful_allocations = successful_allocations;
+}
+
+void
+peak_target_config_test_reset_warning_counts(void)
+{
+    target_config_empty_token_warning_count = 0;
+}
+
+size_t
+peak_target_config_test_empty_token_warning_count(void)
+{
+    return target_config_empty_token_warning_count;
+}
+
+static bool
+target_config_allocation_allowed(void)
+{
+    if (target_config_successful_allocations == 0) {
+        return false;
+    }
+    if (target_config_successful_allocations != SIZE_MAX) {
+        target_config_successful_allocations--;
+    }
+    return true;
+}
+#else
+static bool
+target_config_allocation_allowed(void)
+{
+    return true;
+}
+#endif
+
+static void*
+target_config_malloc(size_t bytes)
+{
+    return target_config_allocation_allowed() ? malloc(bytes) : NULL;
+}
+
+static void*
+target_config_realloc(void* pointer, size_t bytes)
+{
+    return target_config_allocation_allowed() ? realloc(pointer, bytes) : NULL;
+}
+
+static bool
+checked_add_size(size_t left, size_t right, size_t* result)
+{
+    if (right > SIZE_MAX - left) {
+        return false;
+    }
+    *result = left + right;
+    return true;
+}
+
+static bool
+checked_mul_size(size_t left, size_t right, size_t* result)
+{
+    if (left != 0 && right > SIZE_MAX / left) {
+        return false;
+    }
+    *result = left * right;
+    return true;
+}
+
+static void
+target_config_warn_empty_once(bool* warned)
+{
+    if (!*warned) {
+        peak_log_warn("[peak] warning: ignoring empty target token\n");
+#ifdef PEAK_TARGET_CONFIG_TESTING
+        target_config_empty_token_warning_count++;
+#endif
+        *warned = true;
+    }
+}
+
+static void
+target_config_warn_allocation_once(TargetBuilder* builder)
+{
+    if (!builder->allocation_failed) {
+        peak_log_warn("[peak] warning: unable to append target; out of memory or target list is too large\n");
+        builder->allocation_failed = true;
+    }
+}
+
+static char*
+trim_token(char* token)
+{
+    char* end;
+
+    while (isspace((unsigned char)*token)) {
+        token++;
+    }
+    end = token + strlen(token);
+    while (end != token && isspace((unsigned char)end[-1])) {
+        *--end = '\0';
+    }
+    return token;
+}
+
+static bool
+target_builder_grow(TargetBuilder* builder, size_t required)
+{
+    size_t capacity;
+    size_t bytes;
+    char** expanded;
+
+    if (required <= builder->capacity) {
+        return true;
+    }
+
+    capacity = builder->capacity == 0 ? 8 : builder->capacity;
+    while (capacity < required) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = required;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (!checked_mul_size(capacity, sizeof(*builder->items), &bytes)) {
+        target_config_warn_allocation_once(builder);
+        return false;
+    }
+
+    expanded = target_config_realloc(builder->items, bytes);
+    if (expanded == NULL) {
+        target_config_warn_allocation_once(builder);
+        return false;
+    }
+    builder->items = expanded;
+    builder->capacity = capacity;
+    return true;
+}
+
+static bool
+target_builder_append(TargetBuilder* builder, const char* token)
+{
+    size_t length;
+    size_t bytes;
+    size_t required;
+    char* copy;
+
+    length = strlen(token);
+    if (!checked_add_size(length, 1, &bytes) ||
+        !checked_add_size(builder->count, 1, &required)) {
+        target_config_warn_allocation_once(builder);
+        return false;
+    }
+    copy = target_config_malloc(bytes);
+    if (copy == NULL) {
+        target_config_warn_allocation_once(builder);
+        return false;
+    }
+    memcpy(copy, token, bytes);
+
+    if (!target_builder_grow(builder, required)) {
+        free(copy);
+        return false;
+    }
+    builder->items[builder->count++] = copy;
+    return true;
+}
+
+static char*
+target_config_duplicate(TargetBuilder* builder, const char* value)
+{
+    size_t bytes;
+    char* copy;
+
+    if (!checked_add_size(strlen(value), 1, &bytes)) {
+        target_config_warn_allocation_once(builder);
+        return NULL;
+    }
+    copy = target_config_malloc(bytes);
+    if (copy == NULL) {
+        target_config_warn_allocation_once(builder);
+        return NULL;
+    }
+    memcpy(copy, value, bytes);
+    return copy;
+}
+
+static TargetBuilder
+target_builder_from_result(char*** result, size_t existing_count)
+{
+    TargetBuilder builder = {
+        .items = *result,
+        .count = existing_count,
+        .capacity = existing_count,
+        .allocation_failed = false,
+    };
+    return builder;
+}
+
+static size_t
+target_builder_finish(TargetBuilder* builder, char*** result, size_t initial_count)
+{
+    *result = builder->items;
+    return builder->count - initial_count;
+}
+
+static bool
+append_trimmed_token(TargetBuilder* builder, char* token, bool* warned_empty)
+{
+    token = trim_token(token);
+    if (*token == '\0') {
+        target_config_warn_empty_once(warned_empty);
+        return true;
+    }
+    return target_builder_append(builder, token);
+}
+
+size_t
+parse_env_w_delim(const char* env_var, const char a_delim, char*** result)
+{
+    const char* value;
+    TargetBuilder builder;
+    char* copy;
+    char* token;
+    char* next;
+    bool warned_empty = false;
+
+    if (result == NULL || env_var == NULL || a_delim == '\0') {
+        return 0;
+    }
+    *result = NULL;
+    value = getenv(env_var);
+    if (value == NULL || *value == '\0') {
         return 0;
     }
 
-    *result = 0;
-    size_t count = 0;
-    char* tmp = a_str;
-    char* last_comma = 0;
-    char delim[2];
-    delim[0] = a_delim;
-    delim[1] = 0;
-
-    /* Count how many elements will be extracted. */
-    while (*tmp) {
-        if (a_delim == *tmp) {
-            count++;
-            last_comma = tmp;
-        }
-        tmp++;
+    /* Duplicate once so delimiters can be replaced without modifying getenv(). */
+    builder = target_builder_from_result(result, 0);
+    copy = target_config_duplicate(&builder, value);
+    if (copy == NULL) {
+        return target_builder_finish(&builder, result, 0);
     }
-
-    /* Add space for trailing token. */
-    count += last_comma < (a_str + strlen(a_str) - 1);
-    char* a_str_dup = strdup(a_str);
-
-    *result = malloc(sizeof(char*) * count);
-
-    if (*result) {
-        size_t idx = 0;
-        char* token = strtok(a_str_dup, delim);
-
-        while (token) {
-            assert(idx < count);
-            *(*result + idx++) = strdup(token);
-            token = strtok(0, delim);
+    token = copy;
+    do {
+        next = strchr(token, a_delim);
+        if (next != NULL) {
+            *next++ = '\0';
         }
-    }
-    free(a_str_dup);
-
-    return count;
+        if (!append_trimmed_token(&builder, token, &warned_empty)) {
+            break;
+        }
+        token = next;
+    } while (token != NULL);
+    free(copy);
+    return target_builder_finish(&builder, result, 0);
 }
 
-static size_t count_lines_in_file(FILE* file) {
-    size_t lines = 0;
-    int ch;
-    int prev_ch = '\0';
-    while ((ch = fgetc(file)) != EOF) {
-        if (ch == '\n' && prev_ch != '\n') {
-            lines++;
-        }
-        prev_ch = ch;
-    }
+size_t
+load_profiling_symbols(const char* config_file, char*** result, size_t existing_count)
+{
+    const char* path;
+    FILE* file;
+    TargetBuilder builder;
+    char* line = NULL;
+    size_t line_capacity = 0;
+    ssize_t line_length;
+    bool warned_empty = false;
 
-    // If the last character read wasn't a newline, then we have one last line
-    if (prev_ch != '\n' && prev_ch != EOF) {
-        lines++;
-    }
-    rewind(file);
-    return lines;
-}
-
-size_t load_profiling_symbols(const char* config_file, char*** result, size_t existing_count) {
-    char* a_str = getenv(config_file);
-    if (a_str == NULL || a_str[0] == '\0') {
+    if (result == NULL || config_file == NULL) {
         return 0;
     }
-    FILE* file = fopen(a_str, "r");
-    if (!file) {
-        printf("Can't find the configuration file!\n");
+    path = getenv(config_file);
+    if (path == NULL || *path == '\0') {
         return 0;
     }
-    char line[256];
-    size_t count = 0;
-    size_t capacity = count_lines_in_file(file);
-    *result = realloc(*result, sizeof(char*) * (existing_count + capacity));
-    if (*result) {
-        while (fgets(line, sizeof(line), file)) {
-            line[strcspn(line, "\n")] = 0;
-            (*result)[count + existing_count] = strdup(line);
-            count ++;
-        }
-        fclose(file);
-        return capacity;
-    }
-    return 0;
-}
-
-size_t load_symbols_from_array(const char* env_var, char*** result, size_t existing_count) {
-    char* a_str = getenv(env_var);
-    if (a_str == NULL) {
+    file = fopen(path, "r");
+    if (file == NULL) {
+        peak_log_warn("[peak] warning: cannot open target configuration file '%s'\n", path);
         return 0;
     }
 
-    size_t source_count = 0;
-    if (strstr(a_str, "BLAS")) {
-        *result = realloc(*result, sizeof(char*) * (existing_count + source_count_BLAS));
-        for (size_t i = 0; i < source_count_BLAS; i++) {
-            (*result)[i + existing_count] = strdup(source_target_array_BLAS[i]);
-            if ((*result)[existing_count + i] == NULL) {
-                printf("Failed to duplicate string!\n");
-                return i + source_count;
-            }
+    builder = target_builder_from_result(result, existing_count);
+    while ((line_length = getline(&line, &line_capacity, file)) != -1) {
+        (void)line_length;
+        if (!append_trimmed_token(&builder, line, &warned_empty)) {
+            break;
         }
-        source_count += source_count_BLAS;
-        existing_count += source_count_BLAS;
     }
-
-    if (strstr(a_str, "LAPACK")) {
-        *result = realloc(*result, sizeof(char*) * (existing_count + source_count_LAPACK));
-        for (size_t i = 0; i < source_count_LAPACK; i++) {
-            (*result)[i + existing_count] = strdup(source_target_array_LAPACK[i]);
-            if ((*result)[existing_count + i] == NULL) {
-                printf("Failed to duplicate string!\n");
-                return i + source_count;
-            }
-        }
-        source_count += source_count_LAPACK;
-        existing_count += source_count_LAPACK;
+    if (ferror(file)) {
+        peak_log_warn("[peak] warning: failed while reading target configuration file '%s'\n", path);
     }
-
-    if (strstr(a_str, "PBLAS")) {
-        *result = realloc(*result, sizeof(char*) * (existing_count + source_count_PBLAS));
-        for (size_t i = 0; i < source_count_PBLAS; i++) {
-            (*result)[i + existing_count] = strdup(source_target_array_PBLAS[i]);
-            if ((*result)[existing_count + i] == NULL) {
-                printf("Failed to duplicate string!\n");
-                return i + source_count;
-            }
-        }
-        source_count += source_count_PBLAS;
-        existing_count += source_count_PBLAS;
-    }
-
-    if (strstr(a_str, "ScaLAPACK")) {
-        *result = realloc(*result, sizeof(char*) * (existing_count + source_count_ScaLAPACK));
-        for (size_t i = 0; i < source_count_ScaLAPACK; i++) {
-            (*result)[i + existing_count] = strdup(source_target_array_ScaLAPACK[i]);
-            if ((*result)[existing_count + i] == NULL) {
-                printf("Failed to duplicate string!\n");
-                return i + source_count;
-            }
-        }
-        source_count += source_count_ScaLAPACK;
-        existing_count += source_count_ScaLAPACK;
-    }
-
-    if (strstr(a_str, "FFTW")) {
-        *result = realloc(*result, sizeof(char*) * (existing_count + source_count_FFTW));
-        for (size_t i = 0; i < source_count_FFTW; i++) {
-            (*result)[i + existing_count] = strdup(source_target_array_FFTW[i]);
-            if ((*result)[existing_count + i] == NULL) {
-                printf("Failed to duplicate string!\n");
-                return i + source_count;
-            }
-        }
-        source_count += source_count_FFTW;
-        existing_count += source_count_FFTW;
-    }
-
-    return source_count;
+    free(line);
+    fclose(file);
+    return target_builder_finish(&builder, result, existing_count);
 }
 
-void free_parsed_result(char** result, size_t count)
+typedef struct {
+    const char* name;
+    char** symbols;
+    size_t* count;
+} TargetGroup;
+
+static const TargetGroup target_groups[] = {
+    {"BLAS", source_target_array_BLAS, &source_count_BLAS},
+    {"LAPACK", source_target_array_LAPACK, &source_count_LAPACK},
+    {"PBLAS", source_target_array_PBLAS, &source_count_PBLAS},
+    {"ScaLAPACK", source_target_array_ScaLAPACK, &source_count_ScaLAPACK},
+    {"FFTW", source_target_array_FFTW, &source_count_FFTW},
+};
+
+static const TargetGroup*
+find_target_group(const char* name)
+{
+    for (size_t i = 0; i < sizeof(target_groups) / sizeof(target_groups[0]); i++) {
+        if (strcmp(name, target_groups[i].name) == 0) {
+            return &target_groups[i];
+        }
+    }
+    return NULL;
+}
+
+size_t
+load_symbols_from_array(const char* env_var, char*** result, size_t existing_count)
+{
+    const char* value;
+    TargetBuilder builder;
+    char* copy;
+    char* token;
+    char* next;
+    bool warned_empty = false;
+
+    if (result == NULL || env_var == NULL) {
+        return 0;
+    }
+    value = getenv(env_var);
+    if (value == NULL || *value == '\0') {
+        return 0;
+    }
+    builder = target_builder_from_result(result, existing_count);
+    copy = target_config_duplicate(&builder, value);
+    if (copy == NULL) {
+        return target_builder_finish(&builder, result, existing_count);
+    }
+
+    token = copy;
+    do {
+        const TargetGroup* group;
+
+        next = strchr(token, ',');
+        if (next != NULL) {
+            *next++ = '\0';
+        }
+        token = trim_token(token);
+        if (*token == '\0') {
+            target_config_warn_empty_once(&warned_empty);
+        } else if ((group = find_target_group(token)) != NULL) {
+            for (size_t i = 0; i < *group->count; i++) {
+                if (!target_builder_append(&builder, group->symbols[i])) {
+                    break;
+                }
+            }
+        } else {
+            peak_log_warn("[peak] warning: ignoring unknown target group '%s'\n", token);
+        }
+        if (builder.allocation_failed) {
+            break;
+        }
+        token = next;
+    } while (token != NULL);
+
+    free(copy);
+    return target_builder_finish(&builder, result, existing_count);
+}
+
+void
+free_parsed_result(char** result, size_t count)
 {
     for (size_t i = 0; i < count; i++) {
         free(result[i]);

--- a/test/detach_controller/CMakeLists.txt
+++ b/test/detach_controller/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(test_detach_controller
   test_detach_controller.c
   ${PROJECT_SOURCE_DIR}/src/detach_controller.c
-  ${PROJECT_SOURCE_DIR}/src/logging.c
   ${PROJECT_SOURCE_DIR}/src/signal_policy.c
   ${PROJECT_SOURCE_DIR}/src/unsafe_gum_prologue.c
   ${PROJECT_SOURCE_DIR}/src/exec_raw_syscall.c
@@ -22,7 +21,6 @@ if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)
     ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/socket_report_transport.c
     ${PROJECT_SOURCE_DIR}/src/jit_provider.c
-    ${PROJECT_SOURCE_DIR}/src/logging.c
     ${PROJECT_SOURCE_DIR}/src/unsafe_gum_prologue.c
     ${PROJECT_SOURCE_DIR}/src/pthread_listener.c
     ${PROJECT_SOURCE_DIR}/src/detach_controller.c

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -2,13 +2,68 @@ add_executable(test_command_filter test_command_filter.c)
 target_include_directories(test_command_filter PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/include/utils)
-target_link_libraries(test_command_filter PRIVATE $<TARGET_OBJECTS:utils_c>)
+target_link_libraries(test_command_filter PRIVATE
+    $<TARGET_OBJECTS:utils_c>
+    Threads::Threads)
 
 add_test(NAME test_command_filter
     COMMAND test_command_filter)
 set_tests_properties(test_command_filter
     PROPERTIES
         PASS_REGULAR_EXPRESSION "command_filter_ok")
+
+add_executable(test_target_config
+    test_target_config.c
+    ${PROJECT_SOURCE_DIR}/src/utils/target_config.c
+    ${PROJECT_SOURCE_DIR}/src/utils/source_target.c
+    ${PROJECT_SOURCE_DIR}/src/logging.c)
+target_compile_definitions(test_target_config PRIVATE PEAK_TARGET_CONFIG_TESTING=1)
+target_include_directories(test_target_config PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/utils)
+target_link_libraries(test_target_config PRIVATE Threads::Threads)
+add_test(NAME test_target_config_parser COMMAND test_target_config)
+set_tests_properties(test_target_config_parser
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION "target_config_ok"
+        ENVIRONMENT "PEAK_VERBOSITY=silent")
+
+option(PEAK_BUILD_FUZZ_TESTS "Build libFuzzer target-parser harnesses" OFF)
+if(PEAK_BUILD_FUZZ_TESTS)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        add_executable(fuzz_target_config
+            fuzz_target_config.c
+            ${PROJECT_SOURCE_DIR}/src/utils/target_config.c
+            ${PROJECT_SOURCE_DIR}/src/utils/source_target.c
+            ${PROJECT_SOURCE_DIR}/src/logging.c)
+        target_include_directories(fuzz_target_config PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/include/utils)
+        target_compile_options(fuzz_target_config PRIVATE -fsanitize=fuzzer,address,undefined)
+        target_link_options(fuzz_target_config PRIVATE -fsanitize=fuzzer,address,undefined)
+        target_link_libraries(fuzz_target_config PRIVATE Threads::Threads)
+    else()
+        message(WARNING "PEAK_BUILD_FUZZ_TESTS requires a Clang C compiler")
+    endif()
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        set(_PEAK_TARGET_CONFIG_PRELOAD_ENV LD_PRELOAD)
+    else()
+        set(_PEAK_TARGET_CONFIG_PRELOAD_ENV DYLD_INSERT_LIBRARIES)
+    endif()
+    add_test(NAME test_target_config_verbosity
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_target_config_verbosity_check.py
+                --exe $<TARGET_FILE:test_command_filter>
+                --libpeak $<TARGET_FILE:peak>
+                --preload-env ${_PEAK_TARGET_CONFIG_PRELOAD_ENV})
+    set_tests_properties(test_target_config_verbosity
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "target_config_verbosity_check_ok"
+            TIMEOUT 30)
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_executable(test_parent_registry

--- a/test/utils/fuzz_target_config.c
+++ b/test/utils/fuzz_target_config.c
@@ -1,0 +1,75 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "target_config.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int
+LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    char value[4097];
+    char path[] = "/tmp/peak-target-config-fuzz-XXXXXX";
+    char** names = NULL;
+    FILE* file;
+    int fd;
+    size_t count;
+
+    size_t payload_offset = size == 0 ? 0 : 1;
+    size_t payload_size = size > payload_offset ? size - payload_offset : 0;
+    unsigned int route = size == 0 ? 0U : data[0] % 3U;
+
+    /* Fuzzing malformed input must not turn each generated case into stderr. */
+    setenv("PEAK_VERBOSITY", "silent", 1);
+    if (payload_size > sizeof(value) - 1) payload_size = sizeof(value) - 1;
+    for (size_t i = 0; i < payload_size; i++) {
+        unsigned char byte = data[i + payload_offset];
+        value[i] = byte == '\0' ? ',' : (char)byte;
+    }
+    value[payload_size] = '\0';
+
+    if (route == 0U) {
+        setenv("PEAK_TARGET_CONFIG_FUZZ", value, 1);
+        count = parse_env_w_delim("PEAK_TARGET_CONFIG_FUZZ", ',', &names);
+        free_parsed_result(names, count);
+        return 0;
+    }
+
+    if (route == 1U) {
+        fd = mkstemp(path);
+        if (fd >= 0 && (file = fdopen(fd, "w")) != NULL) {
+            fwrite(value, 1, payload_size, file);
+            fclose(file);
+            setenv("PEAK_TARGET_CONFIG_FUZZ_FILE", path, 1);
+            count = load_profiling_symbols("PEAK_TARGET_CONFIG_FUZZ_FILE", &names, 0);
+            free_parsed_result(names, count);
+            unlink(path);
+        } else if (fd >= 0) {
+            close(fd);
+            unlink(path);
+        }
+        return 0;
+    }
+
+    switch (payload_size == 0 ? 0U : data[payload_offset] % 4U) {
+    case 0:
+        setenv("PEAK_TARGET_CONFIG_FUZZ_GROUP", "BLAS", 1);
+        break;
+    case 1:
+        setenv("PEAK_TARGET_CONFIG_FUZZ_GROUP", ", PBLAS ,, BLAS ,", 1);
+        break;
+    case 2:
+        setenv("PEAK_TARGET_CONFIG_FUZZ_GROUP", "PBLASX, ScaLAPACKX", 1);
+        break;
+    default:
+        setenv("PEAK_TARGET_CONFIG_FUZZ_GROUP", value, 1);
+        break;
+    }
+    names = NULL;
+    count = load_symbols_from_array("PEAK_TARGET_CONFIG_FUZZ_GROUP", &names, 0);
+    free_parsed_result(names, count);
+    return 0;
+}

--- a/test/utils/run_target_config_verbosity_check.py
+++ b/test/utils/run_target_config_verbosity_check.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Verify malformed target-list warnings honor PEAK_VERBOSITY."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+WARNING = "[peak] warning: ignoring empty target token"
+
+
+def run_mode(exe: str, library: str, preload_env: str, mode: str, expected: int) -> None:
+    env = os.environ.copy()
+    existing_preload = env.get(preload_env, "")
+    env[preload_env] = library if not existing_preload else f"{library}:{existing_preload}"
+    env.update(
+        {
+            "PEAK_TARGET": ",peak_target_config_missing,,",
+            "PEAK_TARGET_FILE": "",
+            "PEAK_TARGET_GROUP": "",
+            "PEAK_HEARTBEAT_INTERVAL": "0",
+            "PEAK_VERBOSITY": mode,
+        }
+    )
+    completed = subprocess.run(
+        [exe], env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=25
+    )
+    output = completed.stdout + completed.stderr
+    if completed.returncode != 0:
+        raise RuntimeError(f"{mode}: command failed ({completed.returncode})\n{output}")
+    actual = output.count(WARNING)
+    if actual != expected:
+        raise RuntimeError(f"{mode}: warning count {actual}, expected {expected}\n{output}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--libpeak", required=True)
+    parser.add_argument("--preload-env", required=True)
+    args = parser.parse_args()
+    try:
+        run_mode(args.exe, args.libpeak, args.preload_env, "quiet", 0)
+        run_mode(args.exe, args.libpeak, args.preload_env, "silent", 0)
+        run_mode(args.exe, args.libpeak, args.preload_env, "warn", 1)
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+        print(f"target_config_verbosity_check_failed: {error}", file=sys.stderr)
+        return 1
+    print("target_config_verbosity_check_ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/utils/test_target_config.c
+++ b/test/utils/test_target_config.c
@@ -1,0 +1,265 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "source_target.h"
+#include "target_config.h"
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int
+expect_names(char** names, size_t count, const char* const* expected, size_t expected_count)
+{
+    if (count != expected_count) {
+        fprintf(stderr, "count mismatch: got %zu expected %zu\n", count, expected_count);
+        return 0;
+    }
+    for (size_t i = 0; i < count; i++) {
+        if (strcmp(names[i], expected[i]) != 0) {
+            fprintf(stderr, "name %zu mismatch: got '%s' expected '%s'\n", i, names[i], expected[i]);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+expect_prefix(char** names, size_t count, const char* const* expected, size_t expected_count)
+{
+    if (count != expected_count) {
+        fprintf(stderr, "prefix count mismatch: got %zu expected %zu\n", count, expected_count);
+        return 0;
+    }
+    for (size_t i = 0; i < count; i++) {
+        if (strcmp(names[i], expected[i]) != 0) {
+            fprintf(stderr, "prefix name %zu mismatch: got '%s' expected '%s'\n", i, names[i], expected[i]);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+test_environment_tokens(void)
+{
+    static const char* const expected[] = {"alpha", "beta"};
+    char** names = NULL;
+    size_t count;
+    int ok;
+
+    peak_target_config_test_reset_warning_counts();
+    setenv("PEAK_TEST_TARGETS", ", alpha ,, beta, \t", 1);
+    count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+    ok = expect_names(names, count, expected, 2) &&
+         peak_target_config_test_empty_token_warning_count() == 1;
+    free_parsed_result(names, count);
+
+    setenv("PEAK_TEST_TARGETS", "duplicate,duplicate", 1);
+    names = NULL;
+    count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+    ok &= expect_names(names, count, (const char* const[]){"duplicate", "duplicate"}, 2);
+    free_parsed_result(names, count);
+    unsetenv("PEAK_TEST_TARGETS");
+    return ok;
+}
+
+static int
+test_target_file(void)
+{
+    char path[] = "/tmp/peak-target-config-XXXXXX";
+    char long_name[4097];
+    char** names = NULL;
+    int fd;
+    FILE* file;
+    size_t count;
+    int ok;
+
+    memset(long_name, 'x', sizeof(long_name) - 1);
+    long_name[sizeof(long_name) - 1] = '\0';
+    fd = mkstemp(path);
+    if (fd < 0 || (file = fdopen(fd, "w")) == NULL) {
+        perror("target config temporary file");
+        if (fd >= 0) {
+            close(fd);
+            unlink(path);
+        }
+        return 0;
+    }
+    if (fputs("\r\n  alpha  \r\n\n", file) == EOF ||
+        fputs(long_name, file) == EOF || fputs("\r\nalpha\n", file) == EOF ||
+        fclose(file) != 0) {
+        perror("writing target config temporary file");
+        unlink(path);
+        return 0;
+    }
+
+    setenv("PEAK_TEST_TARGET_FILE", path, 1);
+    count = load_profiling_symbols("PEAK_TEST_TARGET_FILE", &names, 0);
+    ok = count == 3 && strcmp(names[0], "alpha") == 0 &&
+         strlen(names[1]) == strlen(long_name) && strcmp(names[2], "alpha") == 0;
+    if (!ok) fprintf(stderr, "file parser did not preserve expected nonempty lines\n");
+    free_parsed_result(names, count);
+    unsetenv("PEAK_TEST_TARGET_FILE");
+    unlink(path);
+    return ok;
+}
+
+static int
+test_exact_groups(void)
+{
+    char** names = NULL;
+    size_t count;
+    int ok = 1;
+
+    setenv("PEAK_TEST_TARGET_GROUP", "PBLAS", 1);
+    count = load_symbols_from_array("PEAK_TEST_TARGET_GROUP", &names, 0);
+    ok &= count == source_count_PBLAS && strcmp(names[0], source_target_array_PBLAS[0]) == 0;
+    free_parsed_result(names, count);
+
+    setenv("PEAK_TEST_TARGET_GROUP", "PBLASX, ScaLAPACKX", 1);
+    names = NULL;
+    count = load_symbols_from_array("PEAK_TEST_TARGET_GROUP", &names, 0);
+    ok &= count == 0 && names == NULL;
+    free_parsed_result(names, count);
+
+    setenv("PEAK_TEST_TARGET_GROUP", ", PBLAS ,, BLAS ,", 1);
+    names = NULL;
+    count = load_symbols_from_array("PEAK_TEST_TARGET_GROUP", &names, 0);
+    ok &= count == source_count_PBLAS + source_count_BLAS;
+    free_parsed_result(names, count);
+    unsetenv("PEAK_TEST_TARGET_GROUP");
+    if (!ok) fprintf(stderr, "group parser did not use exact comma-separated matching\n");
+    return ok;
+}
+
+static int
+test_allocation_failure(void)
+{
+    static const char* const env_expected[] = {"alpha", "beta", "gamma"};
+    static const size_t env_counts[] = {0, 0, 0, 1, 2, 3, 3};
+    static const char* const long_env_expected[] = {
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    };
+    static const size_t file_counts[] = {0, 0, 1, 2, 2};
+    static const char* const file_expected[] = {"alpha", "beta"};
+    static const size_t group_counts[] = {0, 0, 0, 1, 1, 2};
+    char path[] = "/tmp/peak-target-config-fail-XXXXXX";
+    char** names = NULL;
+    char** original;
+    FILE* file;
+    int fd;
+    size_t count;
+    int ok = 1;
+
+    setenv("PEAK_TEST_TARGETS", "alpha,beta,gamma", 1);
+    for (size_t allowed = 0; allowed < sizeof(env_counts) / sizeof(env_counts[0]); allowed++) {
+        names = NULL;
+        peak_target_config_test_fail_allocations_after(allowed);
+        count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+        ok &= expect_prefix(names, count, env_expected, env_counts[allowed]);
+        free_parsed_result(names, count);
+    }
+
+    setenv("PEAK_TEST_TARGETS", "a,b,c,d,e,f,g,h,i", 1);
+    names = NULL;
+    peak_target_config_test_fail_allocations_after(10);
+    count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+    ok &= expect_prefix(names, count, long_env_expected, 8);
+    free_parsed_result(names, count);
+    names = NULL;
+    peak_target_config_test_fail_allocations_after(11);
+    count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+    ok &= expect_prefix(names, count, long_env_expected, 8);
+    free_parsed_result(names, count);
+    names = NULL;
+    peak_target_config_test_fail_allocations_after(12);
+    count = parse_env_w_delim("PEAK_TEST_TARGETS", ',', &names);
+    ok &= expect_prefix(names, count, long_env_expected, 9);
+    free_parsed_result(names, count);
+
+    fd = mkstemp(path);
+    if (fd < 0 || (file = fdopen(fd, "w")) == NULL) {
+        perror("target config failure temporary file");
+        if (fd >= 0) {
+            close(fd);
+            unlink(path);
+        }
+        return 0;
+    }
+    if (fputs("alpha\nbeta\n", file) == EOF || fclose(file) != 0) {
+        perror("writing target config failure temporary file");
+        unlink(path);
+        return 0;
+    }
+    setenv("PEAK_TEST_TARGET_FILE", path, 1);
+    for (size_t allowed = 0; allowed < sizeof(file_counts) / sizeof(file_counts[0]); allowed++) {
+        names = NULL;
+        peak_target_config_test_fail_allocations_after(allowed);
+        count = load_profiling_symbols("PEAK_TEST_TARGET_FILE", &names, 0);
+        ok &= expect_prefix(names, count, file_expected, file_counts[allowed]);
+        free_parsed_result(names, count);
+    }
+
+    peak_target_config_test_fail_allocations_after(SIZE_MAX);
+    names = malloc(sizeof(*names));
+    if (names == NULL) return 0;
+    names[0] = strdup("existing");
+    if (names[0] == NULL) {
+        free(names);
+        return 0;
+    }
+    original = names;
+    peak_target_config_test_fail_allocations_after(1);
+    count = load_profiling_symbols("PEAK_TEST_TARGET_FILE", &names, 1);
+    ok &= count == 0 && names == original && strcmp(names[0], "existing") == 0;
+    peak_target_config_test_fail_allocations_after(SIZE_MAX);
+    free_parsed_result(names, 1);
+
+    setenv("PEAK_TEST_TARGET_GROUP", "PBLAS", 1);
+    for (size_t allowed = 0; allowed < sizeof(group_counts) / sizeof(group_counts[0]); allowed++) {
+        peak_target_config_test_fail_allocations_after(SIZE_MAX);
+        names = malloc(sizeof(*names));
+        if (names == NULL) return 0;
+        names[0] = strdup("existing");
+        if (names[0] == NULL) {
+            free(names);
+            return 0;
+        }
+        original = names;
+        peak_target_config_test_fail_allocations_after(allowed);
+        count = load_symbols_from_array("PEAK_TEST_TARGET_GROUP", &names, 1);
+        ok &= count == group_counts[allowed] && names != NULL &&
+              strcmp(names[0], "existing") == 0;
+        for (size_t i = 0; i < count; i++) {
+            ok &= strcmp(names[i + 1], source_target_array_PBLAS[i]) == 0;
+        }
+        if (allowed == 2) {
+            /* The first grow failure cannot replace or lose the original array. */
+            ok &= names == original;
+        }
+        peak_target_config_test_fail_allocations_after(SIZE_MAX);
+        free_parsed_result(names, count + 1);
+    }
+    peak_target_config_test_fail_allocations_after(SIZE_MAX);
+    unsetenv("PEAK_TEST_TARGETS");
+    unsetenv("PEAK_TEST_TARGET_GROUP");
+    unsetenv("PEAK_TEST_TARGET_FILE");
+    unlink(path);
+    if (!ok) fprintf(stderr, "allocation failure did not preserve initialized targets\n");
+    return ok;
+}
+
+int
+main(void)
+{
+    int ok = test_environment_tokens();
+    ok &= test_target_file();
+    ok &= test_exact_groups();
+    ok &= test_allocation_failure();
+    if (!ok) return EXIT_FAILURE;
+    puts("target_config_ok");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- replace the target environment, file, and built-in group parsers with one checked append builder
- trim and skip sparse/empty inputs with verbosity-aware one-time warnings
- read target files with `getline()` and report actual successful insertions
- use exact comma-separated group matching and failure-safe checked allocation growth
- add exhaustive parser unit/failure-injection coverage, verbosity integration coverage, and a Clang libFuzzer + ASan/UBSan harness

## Root cause

The old parser pre-counted entries using rules that did not match tokenization or fixed-size file reads. Sparse delimiter input, empty/long file lines, and failed direct `realloc()` assignments could make the reported count diverge from initialized storage or lose the original array. Built-in group selection also used substring matching.

## Impact

Malformed target configuration now fails safely without reading or freeing uninitialized entries. Partial allocation success preserves a valid owned prefix, target-file counts reflect actual insertions, and group names resolve deterministically.

## Validation

- independent implementation by GPT-5.6 Terra High
- independent full-diff review by GPT-5.6 Sol High: ACCEPT, P0/P1/P2/P3 = 0 after follow-up fixes
- primary-agent full-diff review: approved
- GCC/Clang strict builds
- Clang ASan/UBSan/LeakSanitizer parser tests
- libFuzzer smoke and 20,000-run independent review
- `peak`, `test_command_filter`, and both detach-controller utility consumers build
- parser, warning-verbosity, BLAS/FFTW group, duplicate-target, and detach-link integration tests pass
- `git diff --check`

Fixes #62