### PR TITLE
Make memory profiler event logging bounds-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,10 @@ semantics, module lifetime, and supported boundaries.
 | `PEAK_GPU_TARGET` | Comma-separated demangled base kernel names. |
 | `PEAK_GPU_TARGET_FILE` | File containing one GPU kernel name per line. |
 | `PEAK_GPU_MONITOR_ALL` | Profile every observed GPU kernel. |
-| `PEAK_MEMORY_PROFILE` | Enable beta memory allocation profiling for selected CPU targets. |
+| `PEAK_MEMORY_PROFILE` | Enable experimental memory allocation profiling for selected CPU targets. |
 | `PEAK_MEMORY_TRACK_ALL` | Track all allocation events instead of filtering by target backtraces. |
 | `PEAK_MEMLOG_PATH` | Memory CSV output prefix. Default: `./peak_memlog`. |
-| `PEAK_MEMLOG_CHUNK_EVENTS` | Virtual-memory event-buffer growth size. Values greater than `1000` are accepted. |
+| `PEAK_MEMLOG_CHUNK_EVENTS` | Experimental memory-profiler fixed event capacity. A positive decimal value allocates that many slots once; when full, new events are dropped and reported at finalization. The mapping never grows or moves. |
 | `PEAK_MEMLOG_OTF2_DIR` | Override the directory for memory-profile OTF2 output. |
 
 ### Legacy Controls

--- a/include/malloc_interceptor.h
+++ b/include/malloc_interceptor.h
@@ -53,6 +53,14 @@ typedef struct {
     uint8_t  op;        /**< 1=add/allocation, 2=remove/free; realloc emits those operations. */
 } __attribute__((packed)) PeakMemEvent;
 
+/** Explicit lifecycle for the experimental memory-event log. */
+typedef enum {
+    PEAK_MEMLOG_UNINITIALIZED = 0,
+    PEAK_MEMLOG_ACTIVE,
+    PEAK_MEMLOG_DISABLED,
+    PEAK_MEMLOG_FINALIZED,
+} PeakMemLogState;
+
 /** Fixed metadata at the start of a PEAK binary memory log. */
 typedef struct {
     char     magic[8];       /**< The eight bytes `PEAKMEM\0`. */
@@ -68,14 +76,16 @@ typedef struct {
 typedef struct {
     int      fd;                  /**< Descriptor for the temporary binary log. */
     void    *map;                 /**< Mapping base containing header followed by events. */
-    size_t   map_bytes;           /**< Current mapping size, in bytes. */
+    size_t   map_bytes;           /**< Fixed mapping size, in bytes. */
     size_t   header_bytes;        /**< Page-aligned event-region offset. */
-    size_t   capacity_events;     /**< Number of event slots in the current mapping. */
-    size_t   chunk_events;        /**< Event-slot increment used when growing the mapping. */
-    _Atomic size_t index;         /**< Next event slot reserved by producers. */
-    pthread_mutex_t resize_mutex; /**< Protects `ftruncate()` plus `mremap()`. */
+    size_t   capacity_events;     /**< Number of event slots in the fixed mapping. */
+    size_t   ready_offset;        /**< Offset of one-byte atomic ready flags after events. */
+    _Atomic size_t reserved;      /**< Successfully reserved event slots. */
+    _Atomic size_t committed;     /**< Slots whose payload publication completed. */
+    _Atomic size_t dropped;       /**< Events rejected after capacity is exhausted. */
+    _Atomic size_t active_writers;/**< Writers admitted before DISABLED. */
+    _Atomic PeakMemLogState state;/**< UNINITIALIZED, ACTIVE, DISABLED, or FINALIZED. */
     uint64_t t0_ns;               /**< Log-open `CLOCK_MONOTONIC_RAW` time, in nanoseconds. */
-    int      initialized;         /**< Nonzero after the one-shot open attempt. */
     char     tmp_path[512];       /**< Temporary mapped-file path, unlinked after export. */
     char     csv_path[512];       /**< Final CSV output path. */
     char     otf2_prefix[512];    /**< Final OTF2 archive prefix for this rank and process. */
@@ -116,6 +126,62 @@ int malloc_interceptor_attach();
  * exports, and closes, unmaps, and unlinks the module-owned temporary log.
  */
 void malloc_interceptor_detach();
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+#define PEAK_MALLOC_TEST_API __attribute__((visibility("default")))
+
+typedef enum {
+    PEAK_MEMLOG_TEST_FAIL_NONE = 0,
+    PEAK_MEMLOG_TEST_FAIL_CREATE,
+    PEAK_MEMLOG_TEST_FAIL_SIZING,
+    PEAK_MEMLOG_TEST_FAIL_MAPPING,
+    PEAK_MEMLOG_TEST_FAIL_ALLOCATION,
+} PeakMemLogTestFailure;
+
+typedef struct {
+    PeakMemLogState state;
+    size_t capacity;
+    size_t reserved;
+    size_t committed;
+    size_t dropped;
+    size_t active_writers;
+    size_t exported;
+    int mapping_live;
+} PeakMemLogTestSnapshot;
+
+PEAK_MALLOC_TEST_API void
+peak_memlog_test_set_failure(PeakMemLogTestFailure failure);
+
+PEAK_MALLOC_TEST_API int
+peak_memlog_test_open(size_t capacity_events);
+
+PEAK_MALLOC_TEST_API void
+peak_memlog_test_log_event(uint64_t ts, int64_t delta, uint64_t current, uint8_t op);
+
+PEAK_MALLOC_TEST_API size_t
+peak_memlog_test_ready_records(void);
+
+PEAK_MALLOC_TEST_API int
+peak_memlog_test_read_event(size_t index, PeakMemEvent* out);
+
+PEAK_MALLOC_TEST_API void
+peak_memlog_test_snapshot(PeakMemLogTestSnapshot* out);
+
+PEAK_MALLOC_TEST_API void
+peak_memlog_test_pause_before_commit(int enabled);
+
+PEAK_MALLOC_TEST_API int
+peak_memlog_test_writer_is_paused(void);
+
+PEAK_MALLOC_TEST_API void
+peak_memlog_test_finalize(void);
+
+PEAK_MALLOC_TEST_API int
+peak_malloc_test_failed_realloc_preserves_accounting(void);
+
+PEAK_MALLOC_TEST_API int
+peak_malloc_test_tracking_allocation_failure(void);
+#endif
 
 /** @} */
 

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -49,6 +49,10 @@
     "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DELAY_RANK"
 #define PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS_ENV \
     "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS"
+#ifdef PEAK_ENABLE_TEST_HOOKS
+#define PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS_ENV \
+    "PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS"
+#endif
 #define PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER_ENV \
     "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER"
 #define PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_AFTER_BYTES_ENV \
@@ -2416,6 +2420,7 @@ peak_socket_reduce_root_gather(
     int listener,
     int size,
     int progress_timeout_ms,
+    int gather_hard_timeout_ms,
     int64_t hard_deadline_us,
     PeakSocketGatherAggregate* aggregate,
     unsigned int* received_out)
@@ -2430,10 +2435,19 @@ peak_socket_reduce_root_gather(
     unsigned int completed = 0;
     int64_t progress_deadline_us;
     bool ok = true;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    bool startup_grace_active =
+        peak_socket_reduce_parse_positive_int_env(
+            PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS_ENV,
+            0) > 0;
+#endif
 
     if (received_out != NULL) {
         *received_out = 0;
     }
+#ifndef PEAK_ENABLE_TEST_HOOKS
+    (void)gather_hard_timeout_ms;
+#endif
     if (listener < 0 || size <= 1 || aggregate == NULL ||
         received_out == NULL) {
         return false;
@@ -2461,6 +2475,11 @@ peak_socket_reduce_root_gather(
     progress_deadline_us =
         peak_socket_reduce_refresh_progress_deadline_us(
             hard_deadline_us, progress_timeout_ms);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (startup_grace_active) {
+        progress_deadline_us = hard_deadline_us;
+    }
+#endif
 
     while (completed < peer_count &&
            peak_socket_reduce_remaining_ms(progress_deadline_us) > 0) {
@@ -2538,6 +2557,18 @@ peak_socket_reduce_root_gather(
                 connections[slot].fd = fd;
                 connections[slot].phase =
                     PEAK_SOCKET_GATHER_READING_HEADER;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+                if (startup_grace_active) {
+                    /* First transport progress restores the normal budget. */
+                    hard_deadline_us = peak_socket_reduce_deadline_us(
+                        gather_hard_timeout_ms);
+                    progress_deadline_us =
+                        peak_socket_reduce_refresh_progress_deadline_us(
+                            hard_deadline_us,
+                            progress_timeout_ms);
+                    startup_grace_active = false;
+                }
+#endif
                 accepted++;
                 active++;
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -2894,6 +2925,9 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     int gather_hard_timeout_ms;
     int release_wait_timeout_ms;
     int64_t deadline_us;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    int startup_grace_ms;
+#endif
     uint64_t session_token;
     PeakSocketReduceRecord* local_records = NULL;
     PeakSocketReduceHeader header;
@@ -2959,6 +2993,13 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
             timeout_budget.socket_gather_hard_timeout_ms);
     deadline_us =
         peak_socket_reduce_deadline_us(gather_hard_timeout_ms);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    startup_grace_ms = peak_socket_reduce_parse_positive_int_env(
+        PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS_ENV, 0);
+    if (startup_grace_ms > 0) {
+        deadline_us = peak_socket_reduce_deadline_us(startup_grace_ms);
+    }
+#endif
     if (rank == 0 && timeout_budget.socket_release_was_raised) {
         peak_log_info("[peak] Raised socket peer release timeout to %u ms to preserve the scaled gather/publication/release budget\n",
                       timeout_budget.socket_release_timeout_ms);
@@ -3107,6 +3148,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     failed = !peak_socket_reduce_root_gather(listener,
                                              size,
                                              timeout_ms,
+                                             gather_hard_timeout_ms,
                                              deadline_us,
                                              &gather_aggregate,
                                              &received);

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -2,6 +2,7 @@
 #include "malloc_interceptor.h"
 #include "malloc_otf2.h"
 #include "logging.h"
+#include <sched.h>
 
 /*=========================
   Types
@@ -13,10 +14,10 @@ typedef struct {
 } AllocationEntry;
 
 /*=========================
-  mmapped event buffer (binary)
+  mmapped event buffer (binary, fixed capacity)
 =========================*/
 #ifndef PEAK_MEMLOG_CHUNK_EVENTS
-#define PEAK_MEMLOG_CHUNK_EVENTS (1u * 500u * 1000u) // grow step (0.5M events)
+#define PEAK_MEMLOG_CHUNK_EVENTS (1u * 500u * 1000u) /* fixed event capacity */
 #endif
 
 /*=========================
@@ -28,6 +29,8 @@ extern char**              peak_hook_strings;
 static GumInterceptor*     malloc_interceptor;
 static pthread_mutex_t     track_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t     caller_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t     memlog_finalize_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t     memlog_admission_mutex = PTHREAD_MUTEX_INITIALIZER;
 static GumMetalHashTable*  track_table = NULL;
 static GumMetalHashTable*  memory_caller_target_table = NULL;
 static _Atomic int         cleanup_in_progress = 0;
@@ -40,9 +43,27 @@ static gpointer            calloc_addr = NULL;
 static gpointer            realloc_addr = NULL;
 static gpointer            aligned_alloc_addr = NULL;
 static gpointer            posix_memalign_addr = NULL;
-static PeakMemLog          g_memlog = {0};
+static PeakMemLog          g_memlog = {
+    .fd = -1,
+    .state = ATOMIC_VAR_INIT(PEAK_MEMLOG_UNINITIALIZED),
+};
 static __thread int        in_peak_alloc_hook = 0;
 static __thread int        in_backtrace = 0;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic PeakMemLogTestFailure g_memlog_test_failure = PEAK_MEMLOG_TEST_FAIL_NONE;
+static _Atomic int g_memlog_test_pause_before_commit = 0;
+static _Atomic int g_memlog_test_writer_paused = 0;
+static _Atomic size_t g_memlog_test_capacity_override = 0;
+static _Atomic size_t g_memlog_test_exported = 0;
+
+static void* peak_memlog_test_realloc_failure(void* ptr, size_t size) {
+    (void) ptr;
+    (void) size;
+    errno = ENOMEM;
+    return NULL;
+}
+#endif
 
 /*=========================
   Original function pointers
@@ -59,7 +80,20 @@ static int   (*original_posix_memalign)(void** memptr, size_t alignment, size_t 
   Internal alloc helpers (use originals)
 =========================*/
 
-static void* internal_malloc(size_t size) { return original_malloc(size); }
+static void* internal_malloc(size_t size) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    PeakMemLogTestFailure expected = PEAK_MEMLOG_TEST_FAIL_ALLOCATION;
+    if (atomic_compare_exchange_strong_explicit(&g_memlog_test_failure,
+                                                &expected,
+                                                PEAK_MEMLOG_TEST_FAIL_NONE,
+                                                memory_order_acq_rel,
+                                                memory_order_acquire)) {
+        errno = ENOMEM;
+        return NULL;
+    }
+#endif
+    return original_malloc(size);
+}
 static void  internal_free(void* ptr)     { original_free(ptr); }
 
 /*=========================
@@ -80,9 +114,61 @@ static inline uint64_t nsec_now(void) {
     return (uint64_t) ts.tv_sec * 1000000000ull + (uint64_t) ts.tv_nsec;
 }
 
-static size_t page_align_up(size_t v) {
-    size_t p = (size_t) sysconf(_SC_PAGESIZE);
-    return (v + p - 1) & ~(p - 1);
+static int checked_add_size(size_t a, size_t b, size_t* out) {
+    if (a > SIZE_MAX - b) return 0;
+    *out = a + b;
+    return 1;
+}
+
+static int checked_mul_size(size_t a, size_t b, size_t* out) {
+    if (a != 0 && b > SIZE_MAX / a) return 0;
+    *out = a * b;
+    return 1;
+}
+
+static int page_align_up(size_t v, size_t* out) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) return 0;
+    size_t p = (size_t) page_size;
+    size_t remainder = v % p;
+    if (remainder == 0) {
+        *out = v;
+        return 1;
+    }
+    return checked_add_size(v, p - remainder, out);
+}
+
+static int size_fits_off_t(size_t size) {
+    const unsigned int bits = (unsigned int) (sizeof(off_t) * CHAR_BIT);
+    uintmax_t max_off;
+
+    if (bits >= sizeof(uintmax_t) * CHAR_BIT) {
+        max_off = UINTMAX_MAX >> 1;
+    } else {
+        max_off = (UINTMAX_C(1) << (bits - 1)) - 1;
+    }
+    return (uintmax_t) size <= max_off;
+}
+
+static int parse_memlog_capacity(const char* value, size_t* out) {
+    char* end = NULL;
+    unsigned long long parsed;
+
+    if (!value || !*value || value[0] == '-') return 0;
+    errno = 0;
+    parsed = strtoull(value, &end, 10);
+    if (errno == ERANGE || end == value || *end != '\0' ||
+        parsed == 0 || parsed > SIZE_MAX) {
+        return 0;
+    }
+    *out = (size_t) parsed;
+    return 1;
+}
+
+static int size_to_event_delta(size_t size, int64_t* out) {
+    if ((uintmax_t) size > INT64_MAX) return 0;
+    *out = (int64_t) size;
+    return 1;
 }
 
 /*=========================
@@ -179,142 +265,259 @@ static void build_paths(char out_tmp[512], char out_csv[512], char out_otf2[512]
 }
 
 /*=========================
-  Memlog: open / grow / event / finalize
+  Memlog: fixed mapping / publish / finalize
 =========================*/
 
-static void peak_memlog_grow_if_needed(size_t want_index) {
-    if (want_index < g_memlog.capacity_events) return;
-
-    pthread_mutex_lock(&g_memlog.resize_mutex);
-
-    // Double-check now that we hold the lock: another thread might have
-    // already grown the mapping while we were waiting.
-    if (want_index < g_memlog.capacity_events) {
-        pthread_mutex_unlock(&g_memlog.resize_mutex);
-        return;
+static int peak_memlog_writer_enter(void) {
+    int admitted = 0;
+    pthread_mutex_lock(&memlog_admission_mutex);
+    if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) ==
+        PEAK_MEMLOG_ACTIVE) {
+        admitted = 1;
     }
-
-    size_t need_events = want_index + 1;
-    size_t cap         = g_memlog.capacity_events;
-    size_t chunk       = g_memlog.chunk_events;
-
-    size_t add_chunks = 0;
-    if (need_events > cap) {
-        add_chunks = (need_events - cap + chunk - 1) / chunk;
+    if (admitted) {
+        atomic_fetch_add_explicit(&g_memlog.active_writers, 1, memory_order_acq_rel);
     }
-    if (add_chunks == 0) {
-        pthread_mutex_unlock(&g_memlog.resize_mutex);
-        return;
+    pthread_mutex_unlock(&memlog_admission_mutex);
+    return admitted;
+}
+
+static void peak_memlog_writer_leave(void) {
+    atomic_fetch_sub_explicit(&g_memlog.active_writers, 1, memory_order_release);
+}
+
+static _Atomic uint8_t* peak_memlog_ready_flags(void) {
+    return (_Atomic uint8_t*) ((uint8_t*) g_memlog.map + g_memlog.ready_offset);
+}
+
+static int peak_memlog_reserve_slot(size_t* index_out) {
+    size_t reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_relaxed);
+
+    for (;;) {
+        if (reserved >= g_memlog.capacity_events) {
+            atomic_fetch_add_explicit(&g_memlog.dropped, 1, memory_order_relaxed);
+            return 0;
+        }
+        if (atomic_compare_exchange_weak_explicit(&g_memlog.reserved,
+                                                  &reserved,
+                                                  reserved + 1,
+                                                  memory_order_relaxed,
+                                                  memory_order_relaxed)) {
+            *index_out = reserved;
+            return 1;
+        }
     }
+}
 
-    size_t old_bytes  = g_memlog.map_bytes;
-    size_t new_events = cap + add_chunks * chunk;
-    size_t new_bytes  = g_memlog.header_bytes + new_events * sizeof(PeakMemEvent);
-
-    if (ftruncate(g_memlog.fd, (off_t) new_bytes) != 0) {
-        peak_log_warn("[peak] memlog: ftruncate grow failed: %s\n", strerror(errno));
-        pthread_mutex_unlock(&g_memlog.resize_mutex);
-        return;
+static int peak_memlog_ftruncate(int fd, size_t bytes) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (atomic_load_explicit(&g_memlog_test_failure, memory_order_acquire) ==
+        PEAK_MEMLOG_TEST_FAIL_SIZING) {
+        errno = ENOSPC;
+        return -1;
     }
-
-    void *new_map = mremap(g_memlog.map, old_bytes, new_bytes, MREMAP_MAYMOVE);
-    if (new_map == MAP_FAILED) {
-        peak_log_warn("[peak] memlog: mremap failed: %s (keeping old cap)\n", strerror(errno));
-        pthread_mutex_unlock(&g_memlog.resize_mutex);
-        return;
-    }
-
-    g_memlog.map             = new_map;
-    g_memlog.map_bytes       = new_bytes;
-    g_memlog.capacity_events = new_events;
-
-    pthread_mutex_unlock(&g_memlog.resize_mutex);
+#endif
+    return ftruncate(fd, (off_t) bytes);
 }
 
 static inline void peak_log_event(uint64_t ts, int64_t delta, uint64_t current, uint8_t op) {
-    if (!g_memlog.initialized || !g_memlog.map) return;
+    size_t index;
+    PeakMemEvent* event;
+    _Atomic uint8_t* ready;
+    uint8_t* base;
 
-    size_t i = atomic_fetch_add_explicit(&g_memlog.index, 1, memory_order_relaxed);
-    if (i >= g_memlog.capacity_events) {
-        peak_memlog_grow_if_needed(i);
-        if (i >= g_memlog.capacity_events) return; // growth failed (rare)
+    if (!peak_memlog_writer_enter()) return;
+    if (!peak_memlog_reserve_slot(&index)) {
+        peak_memlog_writer_leave();
+        return;
     }
 
-    uint8_t *base = (uint8_t *) g_memlog.map + g_memlog.header_bytes;
-    PeakMemEvent *e = (PeakMemEvent *) (base + i * sizeof(PeakMemEvent));
-    e->ts_ns   = ts;
-    e->delta   = delta;
-    e->current = current;
-    e->tid     = peak_gettid();
-    e->op      = op;
+    base = (uint8_t*) g_memlog.map + g_memlog.header_bytes;
+    event = (PeakMemEvent*) (base + index * sizeof(*event));
+    ready = peak_memlog_ready_flags();
+    event->ts_ns = ts;
+    event->delta = delta;
+    event->current = current;
+    event->tid = peak_gettid();
+    event->op = op;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (atomic_load_explicit(&g_memlog_test_pause_before_commit,
+                             memory_order_acquire)) {
+        atomic_store_explicit(&g_memlog_test_writer_paused, 1, memory_order_release);
+        while (atomic_load_explicit(&g_memlog_test_pause_before_commit,
+                                    memory_order_acquire)) {
+            sched_yield();
+        }
+        atomic_store_explicit(&g_memlog_test_writer_paused, 0, memory_order_release);
+    }
+#endif
+
+    /* Release publishes every payload field to an acquire scanner/exporter. */
+    atomic_store_explicit(&ready[index], 1, memory_order_release);
+    atomic_fetch_add_explicit(&g_memlog.committed, 1, memory_order_release);
+    peak_memlog_writer_leave();
+}
+
+static void peak_memlog_disable(void) {
+    PeakMemLogState state;
+
+    /* The mutex closes admission before a finalizer observes writer count. */
+    pthread_mutex_lock(&memlog_admission_mutex);
+    state = atomic_load_explicit(&g_memlog.state, memory_order_acquire);
+    if (state == PEAK_MEMLOG_ACTIVE) {
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED,
+                              memory_order_release);
+    }
+    pthread_mutex_unlock(&memlog_admission_mutex);
+
+    if (state == PEAK_MEMLOG_ACTIVE || state == PEAK_MEMLOG_DISABLED) {
+        while (atomic_load_explicit(&g_memlog.active_writers,
+                                    memory_order_acquire) != 0) {
+            sched_yield();
+        }
+    }
+}
+
+static size_t peak_memlog_compact_committed(void) {
+    size_t reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_acquire);
+    size_t complete = 0;
+    uint8_t* base;
+    _Atomic uint8_t* ready;
+
+    if (reserved > g_memlog.capacity_events) reserved = g_memlog.capacity_events;
+    base = (uint8_t*) g_memlog.map + g_memlog.header_bytes;
+    ready = peak_memlog_ready_flags();
+    for (size_t i = 0; i < reserved; ++i) {
+        PeakMemEvent* source = (PeakMemEvent*) (base + i * sizeof(*source));
+        if (!atomic_load_explicit(&ready[i], memory_order_acquire)) continue;
+
+        if (complete != i) {
+            PeakMemEvent* destination =
+                (PeakMemEvent*) (base + complete * sizeof(*destination));
+            destination->ts_ns = source->ts_ns;
+            destination->delta = source->delta;
+            destination->current = source->current;
+            destination->tid = source->tid;
+            destination->op = source->op;
+        }
+        ++complete;
+    }
+    return complete;
 }
 
 static void peak_memlog_open(void) {
-    if (g_memlog.initialized) return;
+    size_t capacity_events = PEAK_MEMLOG_CHUNK_EVENTS;
+    size_t header_bytes;
+    size_t event_bytes;
+    size_t ready_offset;
+    size_t ready_bytes;
+    size_t map_bytes;
+    int fd = -1;
+    void* base = MAP_FAILED;
+    const char* env_capacity;
 
-    size_t chunk_ev = PEAK_MEMLOG_CHUNK_EVENTS;
-    const char *env_chunk = getenv("PEAK_MEMLOG_CHUNK_EVENTS");
-    if (env_chunk) {
-        long long v = atoll(env_chunk);
-        if (v > 1000) chunk_ev = (size_t) v;
+    if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) !=
+        PEAK_MEMLOG_UNINITIALIZED) return;
+
+    env_capacity = getenv("PEAK_MEMLOG_CHUNK_EVENTS");
+    if (env_capacity && !parse_memlog_capacity(env_capacity, &capacity_events)) {
+        peak_log_warn("[peak] memlog: invalid PEAK_MEMLOG_CHUNK_EVENTS; disabling log\n");
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
+        return;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    {
+        size_t override = atomic_load_explicit(&g_memlog_test_capacity_override,
+                                               memory_order_acquire);
+        if (override != 0) capacity_events = override;
+    }
+#endif
+
+    if (!page_align_up(sizeof(PeakMemHeader), &header_bytes) ||
+        header_bytes > UINT32_MAX ||
+        !checked_mul_size(capacity_events, sizeof(PeakMemEvent), &event_bytes) ||
+        !checked_add_size(header_bytes, event_bytes, &ready_offset) ||
+        !checked_mul_size(capacity_events, sizeof(_Atomic uint8_t), &ready_bytes) ||
+        !checked_add_size(ready_offset, ready_bytes, &map_bytes) ||
+        !size_fits_off_t(map_bytes)) {
+        peak_log_warn("[peak] memlog: fixed storage size is invalid; disabling log\n");
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
+        return;
     }
 
     build_paths(g_memlog.tmp_path, g_memlog.csv_path, g_memlog.otf2_prefix);
-
-    int fd = open(g_memlog.tmp_path, O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0644);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (atomic_load_explicit(&g_memlog_test_failure, memory_order_acquire) ==
+        PEAK_MEMLOG_TEST_FAIL_CREATE) {
+        errno = EACCES;
+    } else
+#endif
+    {
+        fd = open(g_memlog.tmp_path, O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0644);
+    }
     if (fd < 0) {
         peak_log_warn("[peak] memlog: open(%s) failed: %s\n", g_memlog.tmp_path, strerror(errno));
-        g_memlog.initialized = 1;
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
         return;
     }
 
-    size_t header_bytes = page_align_up(sizeof(PeakMemHeader));
-    size_t init_events  = chunk_ev;
-    size_t init_bytes   = header_bytes + init_events * sizeof(PeakMemEvent);
-
-    if (ftruncate(fd, (off_t) init_bytes) != 0) {
+    if (peak_memlog_ftruncate(fd, map_bytes) != 0) {
         peak_log_warn("[peak] memlog: ftruncate init failed: %s\n", strerror(errno));
         close(fd);
-        g_memlog.initialized = 1;
+        unlink(g_memlog.tmp_path);
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
         return;
     }
 
-    void *base = mmap(NULL, init_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (atomic_load_explicit(&g_memlog_test_failure, memory_order_acquire) ==
+        PEAK_MEMLOG_TEST_FAIL_MAPPING) {
+        errno = ENOMEM;
+    } else
+#endif
+    {
+        base = mmap(NULL, map_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    }
     if (base == MAP_FAILED) {
         peak_log_warn("[peak] memlog: mmap init failed: %s\n", strerror(errno));
         close(fd);
-        g_memlog.initialized = 1;
+        unlink(g_memlog.tmp_path);
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
         return;
     }
 
-    PeakMemHeader *hdr = (PeakMemHeader *) base;
+    PeakMemHeader* hdr = (PeakMemHeader*) base;
     memset(hdr, 0, sizeof(*hdr));
     memcpy(hdr->magic, "PEAKMEM\0", 8);
     hdr->header_bytes = (uint32_t) header_bytes;
-    g_memlog.t0_ns    = nsec_now();
-    hdr->t0_ns        = g_memlog.t0_ns;
-    hdr->clock_id     = (uint64_t) CLOCK_MONOTONIC_RAW;
+    g_memlog.t0_ns = nsec_now();
+    hdr->t0_ns = g_memlog.t0_ns;
+    hdr->clock_id = (uint64_t) CLOCK_MONOTONIC_RAW;
+    {
+        int rank = -1;
+        get_mpi_rank(&rank);
+        hdr->mpi_rank = rank;
+    }
+    hdr->pid = (int32_t) getpid();
+    hdr->ppid = (int32_t) getppid();
 
-    int rank = -1;
-    get_mpi_rank(&rank);
-    hdr->mpi_rank = rank;
-    hdr->pid      = (int32_t) getpid();
-    hdr->ppid     = (int32_t) getppid();
+    g_memlog.fd = fd;
+    g_memlog.map = base;
+    g_memlog.map_bytes = map_bytes;
+    g_memlog.header_bytes = header_bytes;
+    g_memlog.capacity_events = capacity_events;
+    g_memlog.ready_offset = ready_offset;
+    atomic_store_explicit(&g_memlog.reserved, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_memlog.committed, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_memlog.dropped, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_memlog.active_writers, 0, memory_order_relaxed);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_store_explicit(&g_memlog_test_exported, 0, memory_order_relaxed);
+#endif
+    atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_ACTIVE, memory_order_release);
 
-    g_memlog.fd              = fd;
-    g_memlog.map             = base;
-    g_memlog.map_bytes       = init_bytes;
-    g_memlog.header_bytes    = header_bytes;
-    g_memlog.capacity_events = init_events;
-    g_memlog.chunk_events    = chunk_ev;
-    atomic_store(&g_memlog.index, 0);
-
-    // Initialize resize mutex on first successful open
-    pthread_mutex_init(&g_memlog.resize_mutex, NULL);
-
-    peak_log_event(nsec_now(), (int64_t) 0, (uint64_t) 0, 1);
-
-    g_memlog.initialized = 1;
+    peak_log_event(nsec_now(), 0, 0, 1);
 }
 
 /* small helper to keep CSV emit identical but clearer */
@@ -329,11 +532,42 @@ static inline void peak_csv_emit_line(int fd_csv, const PeakMemEvent *e) {
 
 /* Convert the mmapped binary buffer to a CSV file (and remove the temp backing file). */
 static void peak_memlog_finalize(void) {
-    if (!g_memlog.initialized || !g_memlog.map) return;
+    size_t events;
+    size_t event_bytes;
+    size_t used_bytes;
+    PeakMemLogState state;
 
-    size_t events = atomic_load_explicit(&g_memlog.index, memory_order_relaxed);
-    size_t used_bytes = g_memlog.header_bytes + events * sizeof(PeakMemEvent);
-    if (used_bytes > g_memlog.map_bytes) used_bytes = g_memlog.map_bytes;
+    /* Serialize finalizers; a DISABLED state can still have admitted writers. */
+    pthread_mutex_lock(&memlog_finalize_mutex);
+    state = atomic_load_explicit(&g_memlog.state, memory_order_acquire);
+    if (state == PEAK_MEMLOG_FINALIZED) {
+        pthread_mutex_unlock(&memlog_finalize_mutex);
+        return;
+    }
+    if (state == PEAK_MEMLOG_UNINITIALIZED) {
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_FINALIZED, memory_order_release);
+        pthread_mutex_unlock(&memlog_finalize_mutex);
+        return;
+    }
+
+    peak_memlog_disable();
+    if (!g_memlog.map) {
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_FINALIZED, memory_order_release);
+        pthread_mutex_unlock(&memlog_finalize_mutex);
+        return;
+    }
+
+    /* Never use committed as a prefix length: reservations can complete out of order. */
+    events = peak_memlog_compact_committed();
+    if (!checked_mul_size(events, sizeof(PeakMemEvent), &event_bytes) ||
+        !checked_add_size(g_memlog.header_bytes, event_bytes, &used_bytes)) {
+        peak_log_warn("[peak] memlog: final size overflow; exporting no events\n");
+        events = 0;
+        used_bytes = g_memlog.header_bytes;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_store_explicit(&g_memlog_test_exported, events, memory_order_release);
+#endif
 
     msync(g_memlog.map, used_bytes, MS_SYNC);
 
@@ -358,17 +592,21 @@ static void peak_memlog_finalize(void) {
         }
         close(fd_csv);
     }
-    peak_log_report("[peak] memlog CSV written: %s (events=%zu)\n", g_memlog.csv_path, events);
+    peak_log_report("[peak] memlog CSV written: %s (events=%zu dropped=%zu)\n",
+                    g_memlog.csv_path,
+                    events,
+                    atomic_load_explicit(&g_memlog.dropped, memory_order_acquire));
 
     munmap(g_memlog.map, g_memlog.map_bytes);
-    (void) ftruncate(g_memlog.fd, (off_t) used_bytes);
     close(g_memlog.fd);
     unlink(g_memlog.tmp_path);
 
     g_memlog.map = NULL;
     g_memlog.map_bytes = 0;
     g_memlog.capacity_events = 0;
-    g_memlog.initialized = 0;
+    g_memlog.fd = -1;
+    atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_FINALIZED, memory_order_release);
+    pthread_mutex_unlock(&memlog_finalize_mutex);
 }
 
 /*=========================
@@ -386,12 +624,22 @@ static void add_tracking_entry(void* ptr, size_t size, int log) {
     entry->size     = size;
 
     pthread_mutex_lock(&track_mutex);
+    if (size > G_MAXULONG - current_memory) {
+        pthread_mutex_unlock(&track_mutex);
+        internal_free(entry);
+        peak_log_warn("[peak] memory profiler accounting overflow; allocation not tracked\n");
+        return;
+    }
     gum_metal_hash_table_insert(track_table, ptr, entry);
     current_memory += size;
     max_memory = current_memory > max_memory ? current_memory : max_memory;
+    gulong current_snapshot = current_memory;
     pthread_mutex_unlock(&track_mutex);
 
-    if (log) peak_log_event(nsec_now(), (int64_t) size, (uint64_t) current_memory, 1);
+    int64_t delta;
+    if (log && size_to_event_delta(size, &delta)) {
+        peak_log_event(nsec_now(), delta, (uint64_t) current_snapshot, 1);
+    }
 }
 
 static AllocationEntry* find_tracking_entry(void* ptr) {
@@ -418,10 +666,55 @@ static void remove_tracking_entry(void* ptr) {
     }
 
     if (entry) {
-        peak_log_event(nsec_now(), -((int64_t) entry->size), (uint64_t) current_memory, 2);
+        int64_t delta;
+        if (size_to_event_delta(entry->size, &delta)) {
+            peak_log_event(nsec_now(), -delta, (uint64_t) current_memory, 2);
+        }
         internal_free(entry);
     }
     pthread_mutex_unlock(&track_mutex);
+}
+
+static int update_tracking_entry_after_realloc(void* old_ptr,
+                                               void* new_ptr,
+                                               size_t new_size,
+                                               size_t* old_size_out,
+                                               gulong* current_after_remove_out,
+                                               gulong* current_after_add_out) {
+    AllocationEntry* entry;
+
+    if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&track_mutex);
+    entry = gum_metal_hash_table_lookup(track_table, old_ptr);
+    if (!entry || entry->ptr != old_ptr) {
+        pthread_mutex_unlock(&track_mutex);
+        return 0;
+    }
+
+    *old_size_out = entry->size;
+    current_memory -= entry->size;
+    *current_after_remove_out = current_memory;
+    if (new_size > G_MAXULONG - current_memory) {
+        gum_metal_hash_table_remove(track_table, old_ptr);
+        pthread_mutex_unlock(&track_mutex);
+        internal_free(entry);
+        peak_log_warn("[peak] memory profiler accounting overflow after realloc\n");
+        return 0;
+    }
+    if (new_ptr != old_ptr) {
+        gum_metal_hash_table_remove(track_table, old_ptr);
+        gum_metal_hash_table_insert(track_table, new_ptr, entry);
+    }
+    entry->ptr = new_ptr;
+    entry->size = new_size;
+    current_memory += new_size;
+    max_memory = current_memory > max_memory ? current_memory : max_memory;
+    *current_after_add_out = current_memory;
+    pthread_mutex_unlock(&track_mutex);
+    return 1;
 }
 
 static void init_table(void) {
@@ -568,12 +861,34 @@ static void* custom_realloc(void* ptr, size_t size) {
 
     int hook_val = in_peak_alloc_hook;
     in_peak_alloc_hook = 1;
-    AllocationEntry* entry = find_tracking_entry(ptr);
-    if (entry) {
-        remove_tracking_entry(ptr);
-    }
     void* new_ptr = original_realloc(ptr, size);
-    if (new_ptr) {
+    if (!new_ptr) {
+        /* ISO C preserves ptr on realloc failure; do not touch its entry. */
+        in_peak_alloc_hook = hook_val;
+        malloc_hook_leave();
+        return NULL;
+    }
+
+    size_t old_size;
+    gulong current_after_remove;
+    gulong current_after_add;
+    if (update_tracking_entry_after_realloc(ptr,
+                                            new_ptr,
+                                            size,
+                                            &old_size,
+                                            &current_after_remove,
+                                            &current_after_add)) {
+        int64_t old_delta;
+        int64_t new_delta;
+        if (size_to_event_delta(old_size, &old_delta)) {
+            peak_log_event(nsec_now(), -old_delta,
+                           (uint64_t) current_after_remove, 2);
+        }
+        if (size_to_event_delta(size, &new_delta)) {
+            peak_log_event(nsec_now(), new_delta,
+                           (uint64_t) current_after_add, 1);
+        }
+    } else {
         int flag = peak_log_backtrace_malloc();
         add_tracking_entry(new_ptr, size, flag);
     }
@@ -703,10 +1018,196 @@ void malloc_interceptor_detach(void) {
 
     memory_usage_log_print();
     peak_memlog_finalize();
+}
 
-    // Clean up resize mutex
-    if (g_memlog.initialized) {
-        pthread_mutex_destroy(&g_memlog.resize_mutex);
-        g_memlog.initialized = 0;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+void
+peak_memlog_test_set_failure(PeakMemLogTestFailure failure)
+{
+    atomic_store_explicit(&g_memlog_test_failure, failure, memory_order_release);
+}
+
+int
+peak_memlog_test_open(size_t capacity_events)
+{
+    atomic_store_explicit(&g_memlog_test_capacity_override,
+                          capacity_events,
+                          memory_order_release);
+    peak_memlog_open();
+    return atomic_load_explicit(&g_memlog.state, memory_order_acquire) ==
+        PEAK_MEMLOG_ACTIVE;
+}
+
+void
+peak_memlog_test_log_event(uint64_t ts, int64_t delta, uint64_t current, uint8_t op)
+{
+    peak_log_event(ts, delta, current, op);
+}
+
+size_t
+peak_memlog_test_ready_records(void)
+{
+    size_t reserved;
+    size_t ready_count = 0;
+    _Atomic uint8_t* ready_flags;
+
+    if (!g_memlog.map) return 0;
+    reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_acquire);
+    if (reserved > g_memlog.capacity_events) reserved = g_memlog.capacity_events;
+    ready_flags = peak_memlog_ready_flags();
+    for (size_t i = 0; i < reserved; ++i) {
+        if (atomic_load_explicit(&ready_flags[i], memory_order_acquire)) ++ready_count;
+    }
+    return ready_count;
+}
+
+int
+peak_memlog_test_read_event(size_t index, PeakMemEvent* out)
+{
+    PeakMemEvent* event;
+    _Atomic uint8_t* ready;
+
+    if (!out || !g_memlog.map || index >= g_memlog.capacity_events) return 0;
+    ready = peak_memlog_ready_flags();
+    if (!atomic_load_explicit(&ready[index], memory_order_acquire)) return 0;
+    event = (PeakMemEvent*) ((uint8_t*) g_memlog.map + g_memlog.header_bytes +
+                             index * sizeof(*event));
+    out->ts_ns = event->ts_ns;
+    out->delta = event->delta;
+    out->current = event->current;
+    out->tid = event->tid;
+    out->op = event->op;
+    return 1;
+}
+
+void
+peak_memlog_test_snapshot(PeakMemLogTestSnapshot* out)
+{
+    if (!out) return;
+    out->state = atomic_load_explicit(&g_memlog.state, memory_order_acquire);
+    out->capacity = g_memlog.capacity_events;
+    out->reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_acquire);
+    out->committed = atomic_load_explicit(&g_memlog.committed, memory_order_acquire);
+    out->dropped = atomic_load_explicit(&g_memlog.dropped, memory_order_acquire);
+    out->active_writers = atomic_load_explicit(&g_memlog.active_writers, memory_order_acquire);
+    out->exported = atomic_load_explicit(&g_memlog_test_exported, memory_order_acquire);
+    out->mapping_live = g_memlog.map != NULL;
+}
+
+void
+peak_memlog_test_pause_before_commit(int enabled)
+{
+    atomic_store_explicit(&g_memlog_test_pause_before_commit, enabled != 0,
+                          memory_order_release);
+    if (!enabled) {
+        atomic_store_explicit(&g_memlog_test_writer_paused, 0, memory_order_release);
     }
 }
+
+int
+peak_memlog_test_writer_is_paused(void)
+{
+    return atomic_load_explicit(&g_memlog_test_writer_paused, memory_order_acquire);
+}
+
+void
+peak_memlog_test_finalize(void)
+{
+    peak_memlog_finalize();
+}
+
+int
+peak_malloc_test_failed_realloc_preserves_accounting(void)
+{
+    AllocationEntry* entry;
+    AllocationEntry* observed;
+    void* ptr;
+    void* result;
+    int preserved;
+    void* (*saved_malloc)(size_t) = original_malloc;
+    void (*saved_free)(void*) = original_free;
+    void* (*saved_realloc)(void*, size_t) = original_realloc;
+
+    if (track_table != NULL) return 0;
+    original_malloc = malloc;
+    original_free = free;
+    original_realloc = peak_memlog_test_realloc_failure;
+    ptr = original_malloc(64);
+    entry = original_malloc(sizeof(*entry));
+    if (!ptr || !entry) {
+        original_free(ptr);
+        original_free(entry);
+        original_malloc = saved_malloc;
+        original_free = saved_free;
+        original_realloc = saved_realloc;
+        return 0;
+    }
+    track_table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
+    if (!track_table) {
+        original_free(entry);
+        original_free(ptr);
+        original_malloc = saved_malloc;
+        original_free = saved_free;
+        original_realloc = saved_realloc;
+        return 0;
+    }
+    entry->ptr = ptr;
+    entry->size = 64;
+    current_memory = 64;
+    gum_metal_hash_table_insert(track_table, ptr, entry);
+
+    result = custom_realloc(ptr, SIZE_MAX);
+    pthread_mutex_lock(&track_mutex);
+    observed = gum_metal_hash_table_lookup(track_table, ptr);
+    preserved = result == NULL && observed == entry && observed->size == 64 &&
+        current_memory == 64;
+    gum_metal_hash_table_remove(track_table, ptr);
+    pthread_mutex_unlock(&track_mutex);
+    gum_metal_hash_table_unref(track_table);
+    track_table = NULL;
+    current_memory = 0;
+    original_free(entry);
+    original_free(ptr);
+    original_malloc = saved_malloc;
+    original_free = saved_free;
+    original_realloc = saved_realloc;
+    return preserved;
+}
+
+int
+peak_malloc_test_tracking_allocation_failure(void)
+{
+    void* ptr;
+    void* (*saved_malloc)(size_t) = original_malloc;
+    void (*saved_free)(void*) = original_free;
+    GumMetalHashTable* table;
+    int rejected;
+
+    if (track_table != NULL) return 0;
+    original_malloc = malloc;
+    original_free = free;
+    ptr = original_malloc(64);
+    table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
+    if (!ptr || !table) {
+        original_free(ptr);
+        if (table) gum_metal_hash_table_unref(table);
+        original_malloc = saved_malloc;
+        original_free = saved_free;
+        return 0;
+    }
+    track_table = table;
+    current_memory = 0;
+    peak_memlog_test_set_failure(PEAK_MEMLOG_TEST_FAIL_ALLOCATION);
+    add_tracking_entry(ptr, 64, 1);
+    pthread_mutex_lock(&track_mutex);
+    rejected = gum_metal_hash_table_lookup(track_table, ptr) == NULL && current_memory == 0;
+    pthread_mutex_unlock(&track_mutex);
+    gum_metal_hash_table_unref(track_table);
+    track_table = NULL;
+    current_memory = 0;
+    original_free(ptr);
+    original_malloc = saved_malloc;
+    original_free = saved_free;
+    return rejected;
+}
+#endif

--- a/src/malloc_otf2.c
+++ b/src/malloc_otf2.c
@@ -97,8 +97,9 @@ static void peak_otf2_log_err(const char* where, OTF2_ErrorCode ec) {
             desc ? desc : "");
 }
 
-/* base: pointer to first PeakMemEvent in mmap region (after header_bytes)
- * events: count from atomic_load_explicit(&g_memlog.index, ...)
+/* base: pointer to first compacted, fully committed PeakMemEvent in the mmap
+ * region (after header_bytes).  The caller filters per-slot publication flags
+ * after writer quiescence; events is never a raw reservation count.
  */
 void peak_memlog_export_otf2(char* filename, const PeakMemEvent* base, size_t events) {
     if (!base || events == 0) return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -181,7 +181,10 @@ if(BUILD_TESTING)
         COMMAND test_socket_report_transport)
     set_tests_properties(test_socket_report_transport
         PROPERTIES
-            TIMEOUT 30
+            # A test-only startup grace isolates peer launch from protocol
+            # timing. This cap includes the deterministic two-second
+            # pre-connect regression delay and failed-child cleanup.
+            TIMEOUT 60
             PASS_REGULAR_EXPRESSION "socket_report_transport_test_ok")
 
     add_executable(test_mpi_report_request_lifetime

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3060,6 +3060,16 @@ if(BUILD_TESTING)
 
     # Add test of memory allocation intercepting
     add_subdirectory(memory)
+    foreach(memlog_case create sizing mapping overflow capacity stalled stress allocation realloc)
+        add_test(NAME test_memlog_${memlog_case}
+            COMMAND test_memlog_safety ${memlog_case})
+        set_tests_properties(test_memlog_${memlog_case}
+            PROPERTIES
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                TIMEOUT 10)
+    endforeach()
+    set_tests_properties(test_memlog_sizing
+        PROPERTIES PASS_REGULAR_EXPRESSION "memlog: ftruncate init failed")
     add_test(NAME test_memory COMMAND ${PROJECT_BINARY_DIR}/test/memory/test_memory)
     set_tests_properties(test_memory
         PROPERTIES

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -4,8 +4,10 @@ import argparse
 import csv
 import os
 import re
+import secrets
 import shlex
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -86,6 +88,22 @@ STATS_FIELDS = [
     "dropped_threads",
 ]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
+SOCKET_TEST_PORT_MIN = 20000
+SOCKET_TEST_PORT_MAX = 30000
+SOCKET_TEST_PORT_ATTEMPTS = 128
+SOCKET_TRANSPORT_MODES = {
+    "finalize-clean-output-socket-bad-host",
+    "finalize-clean-output-socket-bad-host-no-fallback",
+    "finalize-clean-output-socket-release-fail",
+    "finalize-clean-output-socket-token-mismatch",
+    "finalize-clean-output-socket-token-mismatch-no-fallback",
+    "finalize-socket-post-work",
+    "finalize-defer-socket-post-work",
+}
+SOCKET_TRANSPORT_FALLBACK_MODES = {
+    "finalize-clean-output-mpi-reducer-fail",
+}
+ALLOCATED_SOCKET_TEST_PORT_BASES = set()
 
 
 def require_valid_accounting_diagnostics(name, rows):
@@ -289,6 +307,54 @@ MPI_REDUCER_SOCKET_FALLBACK_DIAGNOSTIC = (
 
 def split_flags(value):
     return [flag for flag in shlex.split(value) if flag]
+
+
+def reserve_socket_port_pair():
+    """Return a preflighted, contiguous gather/release TCP port pair.
+
+    The process cannot retain these listeners through mpiexec because the
+    root rank must bind them itself. `RESOURCE_LOCK` serializes lifecycle
+    cases. Pairs are not reused within this checker process; fresh random
+    pairs and immediate preflight make the remaining external TOCTOU window
+    small, but cannot eliminate it.
+    """
+    port_span = SOCKET_TEST_PORT_MAX - SOCKET_TEST_PORT_MIN
+
+    for _ in range(SOCKET_TEST_PORT_ATTEMPTS):
+        base_port = SOCKET_TEST_PORT_MIN + secrets.randbelow(port_span)
+        if base_port in ALLOCATED_SOCKET_TEST_PORT_BASES:
+            continue
+        listeners = []
+        try:
+            for port in (base_port, base_port + 1):
+                listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                listeners.append(listener)
+                listener.bind(("0.0.0.0", port))
+                listener.listen(1)
+            ALLOCATED_SOCKET_TEST_PORT_BASES.add(base_port)
+            return base_port
+        except OSError:
+            pass
+        finally:
+            for listener in listeners:
+                listener.close()
+
+    raise RuntimeError(
+        "could not reserve a preflighted contiguous socket test port pair"
+    )
+
+
+def configure_socket_transport_ports(env):
+    base_port = reserve_socket_port_pair()
+    env["PEAK_OUTPUT_AGGREGATION_PORT"] = str(base_port)
+    return base_port
+
+
+def configure_lifecycle_socket_ports(mode, env):
+    if (mode not in SOCKET_TRANSPORT_MODES and
+            mode not in SOCKET_TRANSPORT_FALLBACK_MODES):
+        return None
+    return configure_socket_transport_ports(env)
 
 
 def launcher_version_text(mpiexec):
@@ -1054,6 +1120,7 @@ def main():
             env["PEAK_MPI_FINALIZE_RETURN_MARKER_PREFIX"] = str(
                 Path(stats_dir) / "finalize-return"
             )
+        configure_lifecycle_socket_ports(args.mode, env)
         returncode, output, timed_out = run_mpi_command(
             command,
             env=env,

--- a/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
+++ b/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 CHECKER_PATH = Path(__file__).with_name("run_mpi_lifecycle_check.py")
@@ -131,6 +132,134 @@ class ReportInterruptionPolicyTest(unittest.TestCase):
             "all_reports_succeeded=1 all_real_finalize_allowed=1\n"
         )
         self.assertFalse(CHECKER.report_release_was_interrupted(output))
+
+
+class SocketPortIsolationTest(unittest.TestCase):
+    def test_busy_port_in_either_contiguous_pair_slot_retries(self) -> None:
+        first_base = 21000
+        second_base = 22000
+
+        for busy_port in (first_base, first_base + 1):
+            with self.subTest(busy_port=busy_port):
+                created = []
+
+                class FakeSocket:
+                    def __init__(self, *_args):
+                        self.closed = False
+                        created.append(self)
+
+                    def bind(self, address):
+                        if address == ("0.0.0.0", busy_port):
+                            raise OSError("simulated TIME_WAIT collision")
+
+                    def listen(self, _backlog):
+                        pass
+
+                    def close(self):
+                        self.closed = True
+
+                CHECKER.ALLOCATED_SOCKET_TEST_PORT_BASES.clear()
+                try:
+                    with mock.patch.object(
+                            CHECKER.secrets,
+                            "randbelow",
+                            side_effect=[
+                                first_base - CHECKER.SOCKET_TEST_PORT_MIN,
+                                second_base - CHECKER.SOCKET_TEST_PORT_MIN,
+                            ]), mock.patch.object(
+                                CHECKER.socket,
+                                "socket",
+                                side_effect=FakeSocket):
+                        self.assertEqual(
+                            CHECKER.reserve_socket_port_pair(), second_base
+                        )
+                finally:
+                    CHECKER.ALLOCATED_SOCKET_TEST_PORT_BASES.clear()
+
+                self.assertTrue(all(listener.closed for listener in created))
+
+    def test_adjacent_invocations_do_not_reuse_a_preflighted_pair(self) -> None:
+        first_base = 24000
+        second_base = 25000
+        created = []
+
+        class FakeSocket:
+            def __init__(self, *_args):
+                created.append(self)
+
+            def bind(self, _address):
+                pass
+
+            def listen(self, _backlog):
+                pass
+
+            def close(self):
+                pass
+
+        CHECKER.ALLOCATED_SOCKET_TEST_PORT_BASES.clear()
+        try:
+            with mock.patch.object(
+                    CHECKER.secrets,
+                    "randbelow",
+                    side_effect=[
+                        first_base - CHECKER.SOCKET_TEST_PORT_MIN,
+                        first_base - CHECKER.SOCKET_TEST_PORT_MIN,
+                        second_base - CHECKER.SOCKET_TEST_PORT_MIN,
+                    ]), mock.patch.object(
+                        CHECKER.socket,
+                        "socket",
+                        side_effect=FakeSocket):
+                first = CHECKER.reserve_socket_port_pair()
+                second = CHECKER.reserve_socket_port_pair()
+        finally:
+            CHECKER.ALLOCATED_SOCKET_TEST_PORT_BASES.clear()
+
+        self.assertEqual((first, second), (first_base, second_base))
+        self.assertEqual(len(created), 4)
+
+    def test_all_socket_modes_and_reducer_labels_get_port_pairs(self) -> None:
+        explicit_socket_modes = {
+            "finalize-clean-output-socket-bad-host",
+            "finalize-clean-output-socket-bad-host-no-fallback",
+            "finalize-clean-output-socket-release-fail",
+            "finalize-clean-output-socket-token-mismatch",
+            "finalize-clean-output-socket-token-mismatch-no-fallback",
+            "finalize-socket-post-work",
+            "finalize-defer-socket-post-work",
+        }
+        reducer_labels = (
+            "profile-control-ratio-tuple-doubles",
+            "profile-control-ratio-owner",
+            "profile-control-ratio-tuple-valid",
+            "profile-control-ratio-tuple-local-ranks",
+            "profile-control-ratio-tuple-counts",
+        )
+        self.assertSetEqual(
+            CHECKER.SOCKET_TRANSPORT_MODES,
+            explicit_socket_modes,
+        )
+        modes = list(explicit_socket_modes)
+        modes.extend(
+            "finalize-clean-output-mpi-reducer-fail"
+            for _ in reducer_labels
+        )
+        environments = [{} for _ in modes]
+
+        with mock.patch.object(
+                CHECKER,
+                "reserve_socket_port_pair",
+                return_value=26000) as reserve:
+            for mode, env in zip(modes, environments):
+                self.assertEqual(
+                    CHECKER.configure_lifecycle_socket_ports(mode, env),
+                    26000,
+                )
+
+        self.assertEqual(reserve.call_count, len(modes))
+        self.assertTrue(all(
+            env.get("PEAK_OUTPUT_AGGREGATION_PORT") == "26000"
+            for env in environments
+        ))
 
 
 if __name__ == "__main__":

--- a/test/memory/CMakeLists.txt
+++ b/test/memory/CMakeLists.txt
@@ -1,3 +1,8 @@
 
 add_executable(test_memory test_memory.cpp)
 target_link_libraries(test_memory PRIVATE Threads::Threads)
+
+add_executable(test_memlog_safety test_memlog_safety.c)
+target_include_directories(test_memlog_safety PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_compile_definitions(test_memlog_safety PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
+target_link_libraries(test_memlog_safety PRIVATE peak Threads::Threads)

--- a/test/memory/test_memlog_safety.c
+++ b/test/memory/test_memlog_safety.c
@@ -1,0 +1,194 @@
+#define PEAK_ENABLE_TEST_HOOKS 1
+#include "malloc_interceptor.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define STRESS_THREADS 8
+#define STRESS_EVENTS_PER_THREAD 128
+
+static int expect(int condition, const char* message)
+{
+    if (!condition) {
+        fprintf(stderr, "memlog safety test: %s\n", message);
+        return 0;
+    }
+    return 1;
+}
+
+static void* write_one_event(void* unused)
+{
+    (void) unused;
+    peak_memlog_test_log_event(2, 1, 1, 1);
+    return NULL;
+}
+
+static void* finalize_log(void* unused)
+{
+    (void) unused;
+    peak_memlog_test_finalize();
+    return NULL;
+}
+
+typedef struct {
+    unsigned int id;
+} StressWriter;
+
+static void* write_stress_events(void* data)
+{
+    StressWriter* writer = data;
+    for (unsigned int i = 0; i < STRESS_EVENTS_PER_THREAD; ++i) {
+        int64_t value = (int64_t) writer->id * STRESS_EVENTS_PER_THREAD + i + 1;
+        peak_memlog_test_log_event((uint64_t) value, value, (uint64_t) value, 1);
+    }
+    return NULL;
+}
+
+static int run_failure(PeakMemLogTestFailure failure)
+{
+    PeakMemLogTestSnapshot snapshot;
+
+    peak_memlog_test_set_failure(failure);
+    if (!expect(!peak_memlog_test_open(4), "faulted creation unexpectedly succeeded")) return 1;
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.state == PEAK_MEMLOG_DISABLED && !snapshot.mapping_live,
+                "faulted creation left a live mapping")) return 1;
+    peak_memlog_test_finalize();
+    peak_memlog_test_snapshot(&snapshot);
+    return !expect(snapshot.state == PEAK_MEMLOG_FINALIZED,
+                   "disabled log did not finalize");
+}
+
+static int run_capacity(void)
+{
+    PeakMemLogTestSnapshot snapshot;
+
+    if (!expect(peak_memlog_test_open(2), "fixed-capacity log did not open")) return 1;
+    for (unsigned int i = 0; i < 10; ++i) {
+        peak_memlog_test_log_event(10 + i, 1, i + 1, 1);
+    }
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.capacity == 2 && snapshot.reserved == 2 &&
+                snapshot.committed == 2 && snapshot.dropped == 9,
+                "capacity exhaustion did not drop without over-reserving")) return 1;
+    peak_memlog_test_finalize();
+    return 0;
+}
+
+static int run_overflow(void)
+{
+    PeakMemLogTestSnapshot snapshot;
+
+    if (!expect(!peak_memlog_test_open(SIZE_MAX),
+                "overflow-sized fixed storage unexpectedly opened")) return 1;
+    peak_memlog_test_snapshot(&snapshot);
+    return !expect(snapshot.state == PEAK_MEMLOG_DISABLED && !snapshot.mapping_live,
+                   "overflow-sized storage left a live mapping");
+}
+
+static int run_stalled_writer(void)
+{
+    PeakMemLogTestSnapshot snapshot;
+    pthread_t writer;
+    pthread_t finalizer;
+
+    if (!expect(peak_memlog_test_open(4), "stalled-writer log did not open")) return 1;
+    peak_memlog_test_pause_before_commit(1);
+    if (pthread_create(&writer, NULL, write_one_event, NULL) != 0) return 1;
+    for (unsigned int i = 0; i < 10000 && !peak_memlog_test_writer_is_paused(); ++i) usleep(100);
+    if (!expect(peak_memlog_test_writer_is_paused(), "writer did not stall before publish")) return 1;
+
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.reserved == 2 && snapshot.committed == 1 &&
+                peak_memlog_test_ready_records() == 1,
+                "ready scan accepted an uncommitted reservation")) return 1;
+
+    if (pthread_create(&finalizer, NULL, finalize_log, NULL) != 0) return 1;
+    for (unsigned int i = 0; i < 10000; ++i) {
+        peak_memlog_test_snapshot(&snapshot);
+        if (snapshot.state == PEAK_MEMLOG_DISABLED) break;
+        usleep(100);
+    }
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.state == PEAK_MEMLOG_DISABLED && snapshot.mapping_live,
+                "finalizer unmapped storage while a writer still held it")) return 1;
+
+    peak_memlog_test_pause_before_commit(0);
+    pthread_join(writer, NULL);
+    pthread_join(finalizer, NULL);
+    peak_memlog_test_snapshot(&snapshot);
+    return !expect(snapshot.state == PEAK_MEMLOG_FINALIZED && !snapshot.mapping_live,
+                   "finalizer did not complete after writer publication");
+}
+
+static int run_multithread_stress(void)
+{
+    const size_t event_count = STRESS_THREADS * STRESS_EVENTS_PER_THREAD;
+    PeakMemLogTestSnapshot snapshot;
+    pthread_t threads[STRESS_THREADS];
+    StressWriter writers[STRESS_THREADS];
+    unsigned char seen[STRESS_THREADS * STRESS_EVENTS_PER_THREAD] = {0};
+
+    if (!expect(peak_memlog_test_open(event_count + 1), "stress log did not open")) return 1;
+    for (unsigned int i = 0; i < STRESS_THREADS; ++i) {
+        writers[i].id = i;
+        if (pthread_create(&threads[i], NULL, write_stress_events, &writers[i]) != 0) return 1;
+    }
+    for (unsigned int i = 0; i < STRESS_THREADS; ++i) pthread_join(threads[i], NULL);
+
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.reserved == event_count + 1 &&
+                snapshot.committed == event_count + 1 && snapshot.dropped == 0 &&
+                peak_memlog_test_ready_records() == event_count + 1,
+                "multi-producer records were not fully committed")) return 1;
+
+    for (size_t i = 1; i <= event_count; ++i) {
+        PeakMemEvent event;
+        if (!expect(peak_memlog_test_read_event(i, &event), "committed record was unreadable")) return 1;
+        if (!expect(event.delta > 0 && (uint64_t) event.delta <= event_count &&
+                    !seen[event.delta - 1], "duplicate or corrupt concurrent record")) return 1;
+        seen[event.delta - 1] = 1;
+    }
+    for (size_t i = 0; i < event_count; ++i) {
+        if (!expect(seen[i], "a concurrent producer record was lost")) return 1;
+    }
+
+    peak_memlog_test_log_event(UINT64_MAX, 1, 1, 1);
+    peak_memlog_test_log_event(UINT64_MAX, 1, 1, 1);
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.dropped == 2 && snapshot.reserved == event_count + 1,
+                "fixed capacity did not count dropped concurrent events")) return 1;
+    peak_memlog_test_finalize();
+    peak_memlog_test_snapshot(&snapshot);
+    return !expect(snapshot.state == PEAK_MEMLOG_FINALIZED && !snapshot.mapping_live &&
+                   snapshot.exported == event_count + 1,
+                   "export did not use only the fully committed records");
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 2) return 2;
+    if (strcmp(argv[1], "create") == 0) return run_failure(PEAK_MEMLOG_TEST_FAIL_CREATE);
+    if (strcmp(argv[1], "sizing") == 0) return run_failure(PEAK_MEMLOG_TEST_FAIL_SIZING);
+    if (strcmp(argv[1], "mapping") == 0) return run_failure(PEAK_MEMLOG_TEST_FAIL_MAPPING);
+    if (strcmp(argv[1], "overflow") == 0) return run_overflow();
+    if (strcmp(argv[1], "capacity") == 0) return run_capacity();
+    if (strcmp(argv[1], "stalled") == 0) return run_stalled_writer();
+    if (strcmp(argv[1], "stress") == 0) return run_multithread_stress();
+    if (strcmp(argv[1], "realloc") == 0) {
+        gum_init_embedded();
+        int result = !peak_malloc_test_failed_realloc_preserves_accounting();
+        gum_deinit_embedded();
+        return result;
+    }
+    if (strcmp(argv[1], "allocation") == 0) {
+        gum_init_embedded();
+        int result = !peak_malloc_test_tracking_allocation_failure();
+        gum_deinit_embedded();
+        return result;
+    }
+    return 2;
+}

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -449,17 +449,18 @@ run_two_rank_case(int port,
     PeakReportSnapshot* root = fixture_snapshot(0, false);
     PeakReportSnapshot* aggregate = NULL;
     PeakSocketReportSession* session = NULL;
-    PeakSocketReportStatus root_status;
-    PeakSocketReportTestTelemetry root_telemetry;
-    PeakSocketReportStatus expected_peer =
+    PeakSocketReportStatus root_status = PEAK_SOCKET_REPORT_FAILED;
+    PeakSocketReportTestTelemetry root_telemetry = {0};
+    bool success_path =
+        !mismatched_peer_name &&
         (action == TEST_ROOT_COMMIT ||
          action == TEST_ROOT_COMMIT_AFTER_PEER_READY ||
          action == TEST_ROOT_COMMIT_DROP_ONCE ||
          action == TEST_ROOT_COMMIT_RESOLVE_AGAIN ||
          action == TEST_ROOT_COMMIT_CONFIRM_RETRY ||
          action == TEST_GATHER_PARTIAL_SUCCESS ||
-         action == TEST_GATHER_PROGRESS_SUCCESS) &&
-                !mismatched_peer_name
+         action == TEST_GATHER_PROGRESS_SUCCESS);
+    PeakSocketReportStatus expected_peer = success_path
             ? PEAK_SOCKET_REPORT_PEER_RELEASED
             : PEAK_SOCKET_REPORT_FAILED;
     bool gather_must_fail =
@@ -512,6 +513,16 @@ run_two_rank_case(int port,
          * on both sides of the refresh for a loaded hosted runner.
          */
         (void)setenv("PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS", "1000", 1);
+    }
+    if (action == TEST_GATHER_SLOW_FAILURE ||
+        action == TEST_GATHER_PROGRESS_SUCCESS) {
+        (void)unsetenv(
+            "PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS");
+    } else {
+        /* Test-only grace isolates launcher scheduling before transport I/O. */
+        (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS",
+                     "10000",
+                     1);
     }
     (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS",
                  action == TEST_GATHER_PROGRESS_SUCCESS
@@ -609,18 +620,22 @@ run_two_rank_case(int port,
         (void)unsetenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DELAY_RANK");
     }
-    if (action == TEST_GATHER_PROGRESS_SUCCESS) {
+    if (action == TEST_GATHER_PROGRESS_SUCCESS ||
+        action == TEST_ROOT_COMMIT_CONFIRM_RETRY) {
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS",
-            "600",
+            action == TEST_GATHER_PROGRESS_SUCCESS ? "600" : "2000",
             1);
+    } else {
+        (void)unsetenv(
+            "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS");
+    }
+    if (action == TEST_GATHER_PROGRESS_SUCCESS) {
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER",
             "1",
             1);
     } else {
-        (void)unsetenv(
-            "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS");
         (void)unsetenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER");
     }
@@ -876,6 +891,8 @@ run_two_rank_case(int port,
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DELAY_RANK");
     (void)unsetenv(
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS");
+    (void)unsetenv(
+        "PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS");
     (void)unsetenv(
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER");
     (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS",


### PR DESCRIPTION
Closes #64

## Root cause

The experimental memory profiler reserved event indices independently from mapping growth. Concurrent `mremap(..., MREMAP_MAYMOVE)` could invalidate addresses still used by writers, failed growth could leave the raw reservation count beyond mapped capacity, and partial initialization did not have an explicit lifecycle. `realloc` tracking was also removed before the underlying operation succeeded.

## Summary

- replace the moving/growing memlog with one checked, fixed-capacity mapping
- keep per-slot publication flags in a sidecar so the packed event format remains unchanged
- separate reserved, committed, and dropped counts; export only fully published records
- close writer admission and wait for active writers before finalization/unmap
- add explicit `UNINITIALIZED / ACTIVE / DISABLED / FINALIZED` lifecycle handling
- preserve allocation tracking when `realloc` fails
- report capacity drops and document the fixed-capacity experimental behavior
- add deterministic failure injection, stalled-writer, capacity, overflow, realloc, and multithreaded publication tests
- make socket scheduling tests deterministic without changing production behavior
- isolate MPI lifecycle test port pairs so independent CI jobs cannot collide with stale sockets

## Review and state-machine invariant

- implementation completed by GPT-5.6 Terra High
- accepted by the primary review
- final exact-head review accepted by an independent GPT-5.6 Sol High reviewer with no P0-P3 findings
- exact reviewed head: `c55f278d0b428ea8bae8aecef8f2e260af09c555`
- `src/detach_controller.c`, `src/pthread_listener.c`, their public headers, and `src/general_listener.c` have identical base/head blobs
- detach lifecycle invariant test passes; detach/reattach FSM and state transitions are unchanged
- exact `BUILD_TESTING=OFF` production DSO exports no memlog or socket test hooks
- base/head production socket transport objects have identical machine instructions

## Local and sanitizer validation

- fresh Clang Release focused suite: 14/14
- memlog stalled-writer and 8x128 producer stress: 200/200 each
- Clang ASan + UBSan + LeakSanitizer: 9/9 memlog tests
- isolated Clang TSan: 16 writers + 4 finalizers and stalled writer + 4 finalizers, 10/10 each with no reports
- actual CSV and OTF2 exports: exactly 1,025 complete records (1 initial + 1,024 unique concurrent records)
- Clang analyzer clean
- changed C source and tests compile cleanly with GCC/Clang `-Wall -Wextra -Werror`
- socket transport focused test and 14/14 lifecycle policy tests pass
- `git diff --check`

## GitHub CI

- exact-head GitHub CI: 12/12 successful
- GCC and Clang Release builds
- MPICH, OpenMPI, and Intel MPI jobs
- detach benchmarks
- pthread slot registry TSan job

## Vista and Frontera high-thread stress

The stress jobs exercised the same production source tree as the final head. The only later exact-head changes were two MPI test-runner Python files.

- Vista job `876185`: 64 threads, `below_events=668784`, `below_dropped=0`, fixed-capacity arm `events=1024`, `dropped=668168`
- Frontera job `7881062`: 56 threads, `below_events=669389`, `below_dropped=0`, fixed-capacity arm `events=1024`, `dropped=664309`
- both jobs emitted `PR69_MEMORY_STRESS_PASS`
- both used a normal `BUILD_TESTING=OFF` production DSO with no test-hook symbols
- no partial `.tmp` output or leak warning was observed

## 1024-node MILC certification

- Frontera job `7881097`: `COMPLETED`, exit `0:0`, elapsed `00:23:59`
- `large` partition, 1024 nodes, 4096 ranks, 12 OpenMP threads per rank
- immutable exact-head artifact and provenance hashes matched before launch
- backend-repeat arms `B0/A1/S1/A2/S2/A3/S3/Bend`: 8/8 `validation=pass`, `launcher_rc=0`
- matrix summary: `failures=0`, `run_complete=1`
- `B0` and `Bend` baselines contain no PEAK output or PEAK CSV
- every PEAK arm produced exactly one CSV and exactly one PEAK completion marker
- every MILC arm contained exactly one `RUNNING COMPLETED`
- every PEAK arm reported `failed control windows: windows=0 snapshot_valid=1`
- lifecycle coverage for every PEAK arm: `detached_targets=28 reattached_targets=27 revisited_targets=20`
- no fatal, hang, unsafe-state, or timeout marker was detected

## Residual tool limitation

The full Frida-linked binary starts with a pre-main SIGSEGV under Clang TSan in this environment and emits no TSan diagnostic. The memlog concurrency protocol was therefore validated with the original `malloc_interceptor.c` in an isolated TSan harness that stubs only logging/MPI/OTF2 and garbage-collects unrelated Gum paths.
