### PR TITLE
Bound CUDA profiler state and use stable kernel identity APIs

### DIFF
--- a/include/cuda_interceptor.h
+++ b/include/cuda_interceptor.h
@@ -28,10 +28,6 @@
 #include <mutex>
 #endif
 
-#ifdef HAVE_MPI
-#include <mpi.h>
-#endif
-
 #define max(a,b)             \
 ({                           \
     __typeof__ (a) _a = (a); \
@@ -56,8 +52,8 @@ extern "C" {
 /**
  * @brief Installs the available CUDA launch replacements.
  *
- * The implementation initializes the module-owned result maps and per-target
- * CUDA events, then attempts each supported Runtime and Driver replacement in
+ * The implementation initializes the module-owned result maps and bounded
+ * CUDA event pool, then attempts each supported Runtime and Driver replacement in
  * one Gum transaction.  Missing entry points are skipped.  If one replacement
  * fails, already successful replacements remain installed; the function does
  * not roll them back.
@@ -75,10 +71,12 @@ int cuda_interceptor_attach();
  * New event admission is stopped before the Gum replacements are reverted.
  * If Gum cannot flush, the function logs the failure and deliberately retains
  * the interceptor, CUDA events, and result maps so live trampoline users do
- * not observe freed state.  After a successful flush it drains pending CUDA
- * events and releases the module-owned maps and event arrays.  The Gum
- * interceptor reference itself remains pinned to cover wrappers that may
- * already have entered before in-flight accounting began.
+ * not observe freed state.  A successful flush still retains the bounded CUDA
+ * state when an in-flight wrapper is observed; a later detach retry drains
+ * pending events and releases the module-owned maps and event pool only once
+ * no wrappers remain.  The Gum interceptor reference itself remains pinned to
+ * cover wrappers that may already have entered before in-flight accounting
+ * began.
  *
  * The function is a no-op when no interceptor has been obtained.
  */
@@ -90,19 +88,33 @@ void cuda_interceptor_dettach();
  * @{ */
 
 /**
+ * @brief Compatibility CUDA report entry point.
+ *
+ * Retains the historical boolean interface: nonzero selects MPI aggregation;
+ * zero selects rank-local output. It never selects socket aggregation.
+ *
+ * @param[in] is_MPI Nonzero for MPI aggregation, zero for rank-local output.
+ */
+void cuda_interceptor_print(int is_MPI);
+
+/**
  * @brief Synchronizes pending CUDA work and reports collected launch data.
  *
  * Calling this function permanently stops admission of new events for the
  * current attachment, synchronizes the CUDA device, and drains kernel and
- * graph event records.  When PEAK is built with MPI and @p is_MPI is nonzero,
- * results are reduced through the MPI reporting path; otherwise they are
- * printed locally.  The function is a no-op if the result maps were not
+ * graph event records. Kernel rows use a separate, bounded report snapshot
+ * through the established aggregation transport; rank-local graph rows are
+ * printed here. The function is a no-op if the result maps were not
  * initialized.
  *
- * @param[in] is_MPI Nonzero to request MPI reduction in an MPI-enabled build;
- *                   zero to emit the local report.
+ * @param[in] aggregation_mode A `PeakOutputAggregationMode` numeric value.
+ * @param[in] active_mpi_job Nonzero when this process belongs to an active MPI
+ *            job.  CUDA socket aggregation then obtains rank metadata only
+ *            from launcher environment, so it never touches MPI while the
+ *            CPU reducer is failed-closed or MPI teardown is in progress.
  */
-void cuda_interceptor_print(int is_MPI);
+void cuda_interceptor_print_with_mpi_job_policy(int aggregation_mode,
+                                                int active_mpi_job);
 
 /** @} */
 

--- a/include/cuda_interceptor.h
+++ b/include/cuda_interceptor.h
@@ -28,20 +28,6 @@
 #include <mutex>
 #endif
 
-#define max(a,b)             \
-({                           \
-    __typeof__ (a) _a = (a); \
-    __typeof__ (b) _b = (b); \
-    _a > _b ? _a : _b;       \
-})
-
-#define min(a,b)             \
-({                           \
-    __typeof__ (a) _a = (a); \
-    __typeof__ (b) _b = (b); \
-    _a < _b ? _a : _b;       \
-})
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/general_listener.h
+++ b/include/general_listener.h
@@ -321,13 +321,7 @@ gboolean peak_general_listener_support_attach_target_is_supported(
  * processes. The PEAK-patched Frida Gum devkit validates Gum's online ELF
  * memory fallback before Gum parses a memory source as an ELF object.
  */
-#ifdef __cplusplus
-extern "C" {
-#endif
 gpointer peak_general_listener_find_function(const char* symbol);
-#ifdef __cplusplus
-}
-#endif
 
 /**
  * @brief Returns whether unresolved requested targets require dlopen rescans.

--- a/include/general_listener.h
+++ b/include/general_listener.h
@@ -321,7 +321,13 @@ gboolean peak_general_listener_support_attach_target_is_supported(
  * processes. The PEAK-patched Frida Gum devkit validates Gum's online ELF
  * memory fallback before Gum parses a memory source as an ELF object.
  */
+#ifdef __cplusplus
+extern "C" {
+#endif
 gpointer peak_general_listener_find_function(const char* symbol);
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @brief Returns whether unresolved requested targets require dlopen rescans.

--- a/include/internal/cuda_profiler_state.h
+++ b/include/internal/cuda_profiler_state.h
@@ -1,0 +1,89 @@
+#ifndef PEAK_CUDA_PROFILER_STATE_H
+#define PEAK_CUDA_PROFILER_STATE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/** CUDA-free admission and identity state used by the CUDA interceptor. */
+struct PeakCudaProfilerCounters {
+    std::size_t capacity;
+    std::size_t identity_capacity;
+    std::size_t cached_identities;
+    std::size_t active_slots;
+    std::size_t high_water_slots;
+    std::uint64_t dropped_pool_full;
+    std::uint64_t dropped_identity_full;
+    std::uint64_t dropped_event_create;
+    std::uint64_t dropped_timing_error;
+};
+
+struct PeakCudaKernelIdentity {
+    std::string name;
+    bool target_match;
+};
+
+struct PeakCudaIdentityKey {
+    std::uintptr_t value;
+    bool driver_function;
+
+    bool operator==(const PeakCudaIdentityKey& other) const
+    {
+        return value == other.value && driver_function == other.driver_function;
+    }
+};
+
+struct PeakCudaIdentityKeyHash {
+    std::size_t operator()(const PeakCudaIdentityKey& key) const
+    {
+        return std::hash<std::uintptr_t>()(key.value) ^
+               (std::hash<bool>()(key.driver_function) << 1);
+    }
+};
+
+class PeakCudaProfilerState {
+public:
+    explicit PeakCudaProfilerState(std::size_t capacity = 256);
+
+    void reset(std::size_t capacity, std::size_t identity_capacity = 0);
+
+    PeakCudaKernelIdentity identify(
+        std::uintptr_t identity,
+        bool driver_function,
+        const char* display_name,
+        const char* target_name,
+        bool monitor_all,
+        const std::vector<std::string>& targets);
+
+    bool cached_identity(std::uintptr_t identity,
+                         bool driver_function,
+                         PeakCudaKernelIdentity* result) const;
+
+    bool acquire_slot();
+    void release_slot();
+    void record_event_create_failure();
+    void record_timing_error();
+    PeakCudaProfilerCounters counters() const;
+
+private:
+    static bool target_matches(const std::string& name,
+                               const std::vector<std::string>& targets);
+
+    mutable std::mutex mutex_;
+    std::unordered_map<PeakCudaIdentityKey, PeakCudaKernelIdentity,
+                       PeakCudaIdentityKeyHash> identities_;
+    std::size_t capacity_;
+    std::size_t identity_capacity_;
+    std::size_t active_slots_;
+    std::size_t high_water_slots_;
+    std::uint64_t dropped_pool_full_;
+    std::uint64_t dropped_identity_full_;
+    std::uint64_t dropped_event_create_;
+    std::uint64_t dropped_timing_error_;
+};
+
+#endif /* PEAK_CUDA_PROFILER_STATE_H */

--- a/include/internal/general_listener/mpi_report_transport.h
+++ b/include/internal/general_listener/mpi_report_transport.h
@@ -11,6 +11,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Outcome of one MPI final-report aggregation attempt. */
 typedef enum {
     /** Rank zero owns the aggregate returned through the output parameter. */
@@ -58,6 +62,10 @@ void peak_mpi_report_transport_reset_failed_closed(void);
 #ifdef PEAK_ENABLE_TEST_HOOKS
 /** Returns the number of active requests retained for process lifetime. */
 size_t peak_mpi_report_transport_quarantined_request_count(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* PEAK_MPI_REPORT_TRANSPORT_H */

--- a/include/internal/general_listener/report_maxima.h
+++ b/include/internal/general_listener/report_maxima.h
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Metrics for which the final report retains a per-rank maximum. */
 typedef enum {
     PEAK_REPORT_METRIC_COMBINED = 0,
@@ -97,5 +101,9 @@ bool peak_report_maxima_assign(
     const PeakReportMaxima* maxima,
     PeakReportRankTuple tuples[PEAK_REPORT_METRIC_COUNT],
     int owner_ranks[PEAK_REPORT_METRIC_COUNT]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PEAK_REPORT_MAXIMA_H */

--- a/include/internal/general_listener/report_model.h
+++ b/include/internal/general_listener/report_model.h
@@ -12,6 +12,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Final overhead data consumed by local and aggregated report renderers. */
 typedef struct {
     bool valid;
@@ -58,5 +62,9 @@ PeakReportRankTuple peak_report_overhead_rank_tuple(
 
 /** Validates a tuple received from an aggregation transport. */
 bool peak_report_rank_tuple_is_valid(const PeakReportRankTuple* tuple);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PEAK_REPORT_MODEL_H */

--- a/include/internal/general_listener/report_snapshot.h
+++ b/include/internal/general_listener/report_snapshot.h
@@ -76,6 +76,12 @@ uint64_t peak_report_snapshot_slot_identity_hash(
 bool peak_report_snapshot_has_duplicate_names(
     const PeakReportSnapshot* snapshot);
 
+/** Stores the latest real local transport context for optional report domains. */
+void peak_report_snapshot_set_transport_overhead(const PeakReportOverhead* overhead);
+
+/** Returns the stored context, or a deterministic invalid zero context. */
+PeakReportOverhead peak_report_snapshot_get_transport_overhead(void);
+
 /** Releases the snapshot and all memory it owns. */
 void peak_report_snapshot_destroy(PeakReportSnapshot* snapshot);
 

--- a/include/internal/general_listener/report_snapshot.h
+++ b/include/internal/general_listener/report_snapshot.h
@@ -12,6 +12,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Owned final-report data captured from the live listener.
  *
@@ -84,5 +88,9 @@ PeakReportOverhead peak_report_snapshot_get_transport_overhead(void);
 
 /** Releases the snapshot and all memory it owns. */
 void peak_report_snapshot_destroy(PeakReportSnapshot* snapshot);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PEAK_REPORT_SNAPSHOT_H */

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -134,6 +134,7 @@ typedef struct {
     uint32_t root_release_target_count;
     uint32_t root_release_confirmed_count;
     uint8_t root_release_decision;
+    bool root_receipt_failure_injected;
     bool peer_receipt_received;
     bool peer_confirmation_sent;
     bool peer_release_started;
@@ -148,6 +149,10 @@ void peak_socket_report_test_telemetry_reset(void);
 /** Copies test-only socket gather observations to @p telemetry_out. */
 void peak_socket_report_test_telemetry_get(
     PeakSocketReportTestTelemetry* telemetry_out);
+
+/** Configures a one-shot test-only barrier around root receipt transmission. */
+void peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,
+                                                 int root_signal_fd);
 
 /**
  * Returns the default socket aggregation port for the current shared

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -22,6 +22,12 @@ typedef enum {
     PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED,
 } PeakSocketReportRankSource;
 
+/** Independent port domains for sequential report transports. */
+typedef enum {
+    PEAK_SOCKET_REPORT_CHANNEL_CPU = 0,
+    PEAK_SOCKET_REPORT_CHANNEL_CUDA = 1,
+} PeakSocketReportChannel;
+
 /** Outcome of the blocking first phase of socket report aggregation. */
 typedef enum {
     /** Aggregation failed; the caller may choose rank-local output. */
@@ -81,6 +87,18 @@ PeakSocketReportStatus peak_socket_report_transport_begin(
     PeakReportSnapshot** aggregate_out);
 
 /**
+ * Same protocol as `peak_socket_report_transport_begin`, in an explicit
+ * channel. CPU uses channel zero (base/base+1); CUDA uses channel one
+ * (base+2/base+3), preventing sequential TIME_WAIT and port collisions.
+ */
+PeakSocketReportStatus peak_socket_report_transport_begin_channel(
+    const PeakReportSnapshot* local,
+    PeakSocketReportRankSource rank_source,
+    PeakSocketReportChannel channel,
+    PeakSocketReportSession** session_out,
+    PeakReportSnapshot** aggregate_out);
+
+/**
  * Sends the final ACK decision to every registered peer, waits for each peer's
  * confirmation, and consumes @p session.
  *
@@ -132,6 +150,9 @@ void peak_socket_report_test_telemetry_get(
  * launcher identity.
  */
 int peak_socket_report_test_default_port(void);
+
+/** Returns the gather port selected for a test channel, or -1 when invalid. */
+int peak_socket_report_test_channel_port(PeakSocketReportChannel channel);
 
 /** Computes a test-only rolling deadline from an injected clock value. */
 int64_t peak_socket_report_test_progress_deadline_us(

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -12,6 +12,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Sources from which socket aggregation may obtain the process rank. */
 typedef enum {
     /** Use active MPI first, then fall back to launcher metadata. */
@@ -184,6 +188,10 @@ unsigned int peak_socket_report_test_latest_admission_ms(
 int peak_general_listener_test_first_slurm_host(const char* nodelist,
                                                 char* out,
                                                 size_t out_size);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* PEAK_SOCKET_REPORT_TRANSPORT_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
 endif()
 
 if (CUDA_FOUND OR CUDAToolkit_FOUND)
-    add_library(cuda_interceptor_obj OBJECT cuda_interceptor.cpp)
+    add_library(cuda_interceptor_obj OBJECT
+        cuda_interceptor.cpp
+        cuda_profiler_state.cpp)
 endif()
 
 # Preserve the original source order while expressing optional modules once.

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -1,5 +1,14 @@
 #include "cuda_interceptor.h"
+#include "general_listener.h"
+#include "internal/cuda_profiler_state.h"
+#include "internal/general_listener/report_snapshot.h"
+#include "internal/general_listener/socket_report_transport.h"
+#ifdef HAVE_MPI
+#include "internal/general_listener/mpi_report_transport.h"
+#endif
 #include "logging.h"
+
+#include <algorithm>
 
 #define PEAK_CUDA_WRAPPER_EXPORT extern "C" __attribute__((visibility("default")))
 
@@ -20,8 +29,6 @@ static gpointer* hook_cu_launch_cooperative_multiple_device;
 static gpointer* hook_cu_launch_ex;
 static gpointer* hook_cuda_graph_launch;
 static gpointer* hook_cu_graph_launch;
-static cudaEvent_t* peak_gpu_cuda_start_event_array;
-static cudaEvent_t* peak_gpu_cuda_end_event_array;
 extern size_t peak_gpu_hook_address_count;
 extern char** peak_gpu_hook_strings;
 extern gboolean peak_gpu_monitor_all;
@@ -68,6 +75,42 @@ static cudaError_t (*original_cuda_graph_launch)(
 static CUresult (*original_cu_graph_launch)(
     CUgraphExec hGraphExec, CUstream hStream);
 
+/* cuFuncGetName was added after this project's minimum CUDA 11.2 support. */
+typedef CUresult (*PeakCudaFuncGetNameFn)(const char** name,
+                                          CUfunction function);
+static PeakCudaFuncGetNameFn peak_cuda_func_get_name;
+static std::once_flag peak_cuda_func_get_name_once;
+static PeakCudaProfilerState peak_cuda_profiler_state;
+
+struct PeakCudaEventSlot {
+    cudaEvent_t start;
+    cudaEvent_t end;
+    gboolean initialized;
+    gboolean leased;
+};
+
+static std::vector<PeakCudaEventSlot> peak_cuda_event_pool;
+static std::vector<size_t> peak_cuda_free_event_slots;
+static std::mutex peak_cuda_event_pool_mutex;
+static size_t peak_cuda_event_pool_capacity = 256;
+
+static gchar*
+peak_cuda_driver_kernel_name(CUfunction function)
+{
+    const char* name = NULL;
+
+    std::call_once(peak_cuda_func_get_name_once, []() {
+        peak_cuda_func_get_name = reinterpret_cast<PeakCudaFuncGetNameFn>(
+            peak_general_listener_find_function("cuFuncGetName"));
+    });
+    if (peak_cuda_func_get_name == NULL ||
+        peak_cuda_func_get_name(&name, function) != CUDA_SUCCESS ||
+        name == NULL || name[0] == '\0') {
+        return NULL;
+    }
+    return g_strdup(name);
+}
+
 typedef struct {
     gulong total_gpu_threads;
     gulong max_gpu_threads;
@@ -99,10 +142,6 @@ typedef struct {
 struct KernelLaunchSeries{
     std::vector<KernelLaunchInfo> launches;
     std::mutex mtx;
-
-    KernelLaunchSeries() {
-        launches.reserve(100);  // Preallocate space for 100 launches to avoid lock performance
-    }
 };
 
 typedef struct {
@@ -124,10 +163,6 @@ typedef struct {
 struct GraphLaunchSeries{
     std::vector<GraphLaunchInfo> launches;
     std::mutex mtx;
-
-    GraphLaunchSeries() {
-        launches.reserve(10);
-    }
 };
 
 static std::unordered_map<std::string, KernelLaunchSeries> peak_kernel_event_map;
@@ -156,19 +191,51 @@ gboolean str_equal_function(gconstpointer a, gconstpointer b) {
     return g_strcmp0((const gchar *)a, (const gchar *)b) == 0;
 }
 
-char* cu_demangle(char* mangled_name) {
-    int status;
-    size_t size = sizeof(char) * 1000;
-    // Fixme: size might be wrong
-    char* demangled_name = (char*)malloc(size);
+char* cu_demangle(char* mangled_name);
 
-    __cu_demangle(mangled_name, demangled_name, &size, &status);
-    if (status == 0) {
-        return demangled_name;
+static PeakCudaKernelIdentity
+peak_cuda_identify_kernel(gpointer identity, gboolean driver_function)
+{
+    PeakCudaKernelIdentity cached;
+    std::vector<std::string> targets;
+    gchar* resolved_name = NULL;
+    char* demangled_name = NULL;
+    char* target_name = NULL;
+
+    if (peak_cuda_profiler_state.cached_identity(
+            reinterpret_cast<std::uintptr_t>(identity), driver_function, &cached)) {
+        return cached;
     }
-
+    for (size_t index = 0; index < peak_gpu_hook_address_count; ++index) {
+        if (peak_gpu_hook_strings[index] != NULL) {
+            targets.emplace_back(peak_gpu_hook_strings[index]);
+        }
+    }
+    if (driver_function) {
+        resolved_name = peak_cuda_driver_kernel_name(
+            reinterpret_cast<CUfunction>(identity));
+    } else {
+        resolved_name = gum_symbol_name_from_address(identity);
+    }
+    if (resolved_name != NULL) {
+        demangled_name = cu_demangle(resolved_name);
+        target_name = extract_function_name(demangled_name);
+    }
+    PeakCudaKernelIdentity result = peak_cuda_profiler_state.identify(
+        reinterpret_cast<std::uintptr_t>(identity),
+        driver_function,
+        demangled_name,
+        target_name,
+        peak_gpu_monitor_all,
+        targets);
+    g_free(resolved_name);
     free(demangled_name);
-    return strdup(mangled_name);
+    free(target_name);
+    return result;
+}
+
+char* cu_demangle(char* mangled_name) {
+    return mangled_name != NULL ? cxa_demangle(mangled_name) : NULL;
 }
 
 static void update_kernel_map_info(const gchar* kernel_name, gulong total_threads, gulong grid_size, gulong block_size, gdouble elapsed_sec)
@@ -212,29 +279,10 @@ static void update_kernel_map_info(const gchar* kernel_name, gulong total_thread
 
 void insert_cuda_mapping_record(gchar* kernel_name, gulong total_threads, gulong grid_size, gulong block_size, gdouble elapsed_sec)
 {
-    if (peak_gpu_monitor_all) {
-        gchar* demangled = cu_demangle(kernel_name);
-        gchar* extract_kernel_name = extract_function_name(demangled);
-        g_mutex_lock(&cuda_kernel_local_dim_mapping_mutex);
-        update_kernel_map_info(demangled, total_threads, grid_size, block_size, elapsed_sec);
-        g_mutex_unlock(&cuda_kernel_local_dim_mapping_mutex);
-        free(demangled);
-        free(extract_kernel_name);
-    } else {
-        // FIXME: should we use a hash table to do the compare rather than for loop look up each time?
-        for (size_t i = 0; i < peak_gpu_hook_address_count; i++) {
-            gchar* demangled = cu_demangle(kernel_name);
-            gchar* extract_kernel_name = extract_function_name(demangled);
-            if (g_strcmp0(peak_gpu_hook_strings[i], extract_kernel_name) == 0) {
-                g_mutex_lock(&cuda_kernel_local_dim_mapping_mutex);
-                update_kernel_map_info(demangled, total_threads, grid_size, block_size, elapsed_sec);
-                g_mutex_unlock(&cuda_kernel_local_dim_mapping_mutex);
-                break;
-            }
-            free(demangled);
-            free(extract_kernel_name);
-        }
-    }
+    g_mutex_lock(&cuda_kernel_local_dim_mapping_mutex);
+    update_kernel_map_info(kernel_name != NULL ? kernel_name : "<unknown>",
+                           total_threads, grid_size, block_size, elapsed_sec);
+    g_mutex_unlock(&cuda_kernel_local_dim_mapping_mutex);
 }
 
 void insert_cuda_graph_record(CUgraphExec_st* graph, gdouble elapsed_sec)
@@ -257,40 +305,110 @@ void insert_cuda_graph_record(CUgraphExec_st* graph, gdouble elapsed_sec)
     g_mutex_unlock(&cuda_graph_local_mapping_mutex);
 }
 
-static cudaEvent_t* peak_cuda_new_event_slot()
+static size_t
+peak_cuda_parse_event_pool_capacity()
 {
-    cudaEvent_t* event = (cudaEvent_t*) calloc(1, sizeof(cudaEvent_t));
-    if (event == NULL) {
-        return NULL;
+    const gchar* value = g_getenv("PEAK_CUDA_EVENT_POOL_CAPACITY");
+    gchar* end = NULL;
+    guint64 parsed;
+
+    if (value == NULL || value[0] == '\0') {
+        return 256;
     }
-    if (cudaEventCreate(event) != cudaSuccess) {
-        free(event);
-        return NULL;
+    parsed = g_ascii_strtoull(value, &end, 10);
+    if (end == value || *end != '\0' || parsed == 0 || parsed > 65536) {
+        peak_log_warn("[peak] invalid PEAK_CUDA_EVENT_POOL_CAPACITY=%s; using 256\n",
+                      value);
+        return 256;
     }
-    return event;
+    return (size_t)parsed;
 }
 
-static void peak_cuda_record_event(cudaEvent_t* event, cudaStream_t stream)
+static void
+peak_cuda_destroy_event_pool()
 {
-    if (event != NULL && *event != NULL) {
-        cudaEventRecord(*event, stream);
+    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
+    for (PeakCudaEventSlot& slot : peak_cuda_event_pool) {
+        if (slot.start != NULL) {
+            cudaEventDestroy(slot.start);
+        }
+        if (slot.end != NULL) {
+            cudaEventDestroy(slot.end);
+        }
     }
+    peak_cuda_event_pool.clear();
+    peak_cuda_free_event_slots.clear();
 }
 
-static void peak_cuda_release_event_pair(cudaEvent_t* start_event,
-                                         cudaEvent_t* end_event)
+static gboolean
+peak_cuda_acquire_event_pair(cudaEvent_t** start_event, cudaEvent_t** end_event)
 {
-    if (start_event != NULL) {
-        if (*start_event != NULL) {
-            cudaEventDestroy(*start_event);
-        }
-        free(start_event);
+    if (start_event == NULL || end_event == NULL ||
+        !peak_cuda_accepting_events.load(std::memory_order_acquire) ||
+        !peak_cuda_profiler_state.acquire_slot()) {
+        return FALSE;
     }
-    if (end_event != NULL) {
-        if (*end_event != NULL) {
-            cudaEventDestroy(*end_event);
+
+    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
+    if (peak_cuda_free_event_slots.empty()) {
+        peak_cuda_profiler_state.release_slot();
+        return FALSE;
+    }
+    PeakCudaEventSlot& slot =
+        peak_cuda_event_pool[peak_cuda_free_event_slots.back()];
+    peak_cuda_free_event_slots.pop_back();
+    if (!slot.initialized) {
+        if (cudaEventCreate(&slot.start) != cudaSuccess ||
+            cudaEventCreate(&slot.end) != cudaSuccess) {
+            if (slot.start != NULL) {
+                cudaEventDestroy(slot.start);
+                slot.start = NULL;
+            }
+            if (slot.end != NULL) {
+                cudaEventDestroy(slot.end);
+                slot.end = NULL;
+            }
+            peak_cuda_free_event_slots.push_back(
+                (size_t)(&slot - peak_cuda_event_pool.data()));
+            peak_cuda_profiler_state.record_event_create_failure();
+            peak_cuda_profiler_state.release_slot();
+            return FALSE;
         }
-        free(end_event);
+        slot.initialized = TRUE;
+    }
+    slot.leased = TRUE;
+    *start_event = &slot.start;
+    *end_event = &slot.end;
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_record_event(cudaEvent_t* event, cudaStream_t stream)
+{
+    if (event == NULL || *event == NULL ||
+        cudaEventRecord(*event, stream) != cudaSuccess) {
+        peak_cuda_profiler_state.record_timing_error();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static void
+peak_cuda_release_event_pair(cudaEvent_t* start_event, cudaEvent_t* end_event)
+{
+    (void)end_event;
+    if (start_event == NULL) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
+    for (size_t index = 0; index < peak_cuda_event_pool.size(); ++index) {
+        PeakCudaEventSlot& slot = peak_cuda_event_pool[index];
+        if (&slot.start == start_event && slot.leased) {
+            slot.leased = FALSE;
+            peak_cuda_free_event_slots.push_back(index);
+            peak_cuda_profiler_state.release_slot();
+            return;
+        }
     }
 }
 
@@ -307,8 +425,10 @@ static void peak_cuda_release_kernel_launch(KernelLaunchInfo* launch,
         *(launch->start_event) != NULL &&
         *(launch->end_event) != NULL) {
         float ms = 0.0f;
-        cudaEventElapsedTime(&ms, *(launch->start_event), *(launch->end_event));
-        if (launch->result == cudaSuccess) {
+        if (cudaEventElapsedTime(&ms, *(launch->start_event),
+                                 *(launch->end_event)) != cudaSuccess) {
+            peak_cuda_profiler_state.record_timing_error();
+        } else if (launch->result == cudaSuccess) {
             insert_cuda_mapping_record(
                 launch->kernel_name,
                 launch->total_threads,
@@ -339,8 +459,10 @@ static void peak_cuda_release_graph_launch(GraphLaunchInfo* launch,
         *(launch->start_event) != NULL &&
         *(launch->end_event) != NULL) {
         float ms = 0.0f;
-        cudaEventElapsedTime(&ms, *(launch->start_event), *(launch->end_event));
-        if (launch->result == cudaSuccess) {
+        if (cudaEventElapsedTime(&ms, *(launch->start_event),
+                                 *(launch->end_event)) != cudaSuccess) {
+            peak_cuda_profiler_state.record_timing_error();
+        } else if (launch->result == cudaSuccess) {
             insert_cuda_graph_record(launch->graph, ms / 1000.0);
         }
     }
@@ -436,17 +558,33 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel(
     void** args, size_t sharedMem, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
-    gchar* kernel_name = gum_symbol_name_from_address((gpointer)func);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, FALSE);
+    if (!identity.target_match) {
+        return original_cuda_launch_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
     gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
     gulong block_size = blockDim.x * blockDim.y * blockDim.z;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, stream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cuda_launch_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    if (!peak_cuda_record_event(start, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cuda_launch_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
     cudaError_t result = original_cuda_launch_kernel(func, gridDim, blockDim, args, sharedMem, stream);
-    peak_cuda_record_event(end, stream);
+    if (!peak_cuda_record_event(end, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -458,8 +596,6 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    g_free(kernel_name);
-
     return result;
 }
 
@@ -468,17 +604,33 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel(
     void** args, size_t sharedMem, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
-    gchar* kernel_name = gum_symbol_name_from_address((gpointer)func);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, FALSE);
+    if (!identity.target_match) {
+        return original_cuda_launch_cooperative_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
     gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
     gulong block_size = blockDim.x * blockDim.y * blockDim.z;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, stream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cuda_launch_cooperative_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    if (!peak_cuda_record_event(start, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cuda_launch_cooperative_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
     cudaError_t result = original_cuda_launch_cooperative_kernel(func, gridDim, blockDim, args, sharedMem, stream);
-    peak_cuda_record_event(end, stream);
+    if (!peak_cuda_record_event(end, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -490,8 +642,6 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    g_free(kernel_name);
-
     return result;
 }
 
@@ -504,17 +654,33 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel_multipl
     dim3 blockDim = launchParamsList->blockDim;
     cudaStream_t stream = launchParamsList->stream;
 
-    gchar* kernel_name = gum_symbol_name_from_address((gpointer)func);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, FALSE);
+    if (!identity.target_match) {
+        return original_cuda_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
     gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
     gulong block_size = blockDim.x * blockDim.y * blockDim.z;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, stream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cuda_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
+    if (!peak_cuda_record_event(start, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cuda_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
     cudaError_t result = original_cuda_launch_cooperative_kernel_multiple_device(launchParamsList, numDevices, flags);
-    peak_cuda_record_event(end, stream);
+    if (!peak_cuda_record_event(end, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -526,8 +692,6 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel_multipl
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    g_free(kernel_name);
-
     return result;
 }
 
@@ -540,19 +704,32 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel_exc(
     dim3 blockDim = config->blockDim;
     cudaStream_t stream = config->stream;
 
-    gchar* kernel_name = gum_symbol_name_from_address((gpointer)func);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, FALSE);
+    if (!identity.target_match) {
+        return original_cuda_launch_kernel_exc(config, func, args);
+    }
+    const gchar* kernel_label = identity.name.c_str();
 
 
     gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
     gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
     gulong block_size = blockDim.x * blockDim.y * blockDim.z;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, stream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cuda_launch_kernel_exc(config, func, args);
+    }
+    if (!peak_cuda_record_event(start, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cuda_launch_kernel_exc(config, func, args);
+    }
     cudaError_t result = original_cuda_launch_kernel_exc(config, func, args);
-    peak_cuda_record_event(end, stream);
+    if (!peak_cuda_record_event(end, stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -564,8 +741,6 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel_exc(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    g_free(kernel_name);
-
     return result;
 }
 
@@ -576,21 +751,39 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel(
     unsigned int sharedMemBytes, CUstream hStream, void** kernelParams, void** extra)
 {
     PeakCudaInflightGuard in_flight;
-    // Kernel Name Address Source
-    // https://forums.developer.nvidia.com/t/how-to-get-a-kernel-functions-name-through-its-pointer/37427/2
-    gchar* kernel_name = *(char**)((size_t)func + 8);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, TRUE);
+    if (!identity.target_match) {
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams, extra);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
     gulong grid_size = gridDimX * gridDimY * gridDimZ;
     gulong block_size = blockDimX * blockDimY * blockDimZ;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)hStream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
+            blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
+            blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
+    }
     CUresult result = original_cu_launch_kernel(func, gridDimX, gridDimY, gridDimZ,
                                                 blockDimX, blockDimY, blockDimZ,
                                                 sharedMemBytes, hStream, kernelParams, extra);
-    peak_cuda_record_event(end, (cudaStream_t)hStream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -602,7 +795,6 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-
     return result;
 }
 
@@ -613,21 +805,41 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel(
     unsigned int sharedMemBytes, CUstream hStream, void** kernelParams)
 {
     PeakCudaInflightGuard in_flight;
-    gchar* kernel_name = *(char**)((size_t)func + 8);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, TRUE);
+    if (!identity.target_match) {
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
     gulong grid_size = gridDimX * gridDimY * gridDimZ;
     gulong block_size = blockDimX * blockDimY * blockDimZ;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)hStream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
+            blockDimZ, sharedMemBytes, hStream, kernelParams);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
+            blockDimZ, sharedMemBytes, hStream, kernelParams);
+    }
     CUresult result = original_cu_launch_cooperative_kernel(
                                                 func, gridDimX, gridDimY, gridDimZ,
                                                 blockDimX, blockDimY, blockDimZ,
                                                 sharedMemBytes, hStream, kernelParams);
 
-    peak_cuda_record_event(end, (cudaStream_t)hStream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -639,7 +851,6 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-
     return result;
 }
 
@@ -657,18 +868,34 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel_multiple_dev
     unsigned int blockDimZ = launchParamsList->blockDimZ;
     CUstream hStream = launchParamsList->hStream;
 
-    gchar* kernel_name = *(char**)((size_t)func + 8);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, TRUE);
+    if (!identity.target_match) {
+        return original_cu_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
     gulong grid_size = gridDimX * gridDimY * gridDimZ;
     gulong block_size = blockDimX * blockDimY * blockDimZ;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)hStream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cu_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cu_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
     CUresult result = original_cu_launch_cooperative_kernel_multiple_device(
                                     launchParamsList, numDevices, flags);
-    peak_cuda_record_event(end, (cudaStream_t)hStream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -680,7 +907,6 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel_multiple_dev
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-
     return result;
 }
 
@@ -697,17 +923,30 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel_ex(
     unsigned int blockDimZ = config->blockDimZ;
     CUstream hStream = config->hStream;
 
-    gchar* kernel_name = *(char**)((size_t)func + 8);
-    const gchar* kernel_label = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
+    PeakCudaKernelIdentity identity =
+        peak_cuda_identify_kernel((gpointer)func, TRUE);
+    if (!identity.target_match) {
+        return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
+    }
+    const gchar* kernel_label = identity.name.c_str();
     gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
     gulong grid_size = gridDimX * gridDimY * gridDimZ;
     gulong block_size = blockDimX * blockDimY * blockDimZ;
 
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)hStream);
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
+    }
     CUresult result = original_cu_launch_kernel_ex(config, func, kernelParams, extra);
-    peak_cuda_record_event(end, (cudaStream_t)hStream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     KernelLaunchInfo info = {
         .kernel_name = g_strdup(kernel_label),
@@ -719,7 +958,6 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel_ex(
         .result = (cudaError_t)result
     };
     peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-
     return result;
 }
 
@@ -727,11 +965,21 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_graph_launch(
     cudaGraphExec_t graphExec, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)stream);
+    /* Graph executable handles are rank-local; profile them locally only. */
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cuda_graph_launch(graphExec, stream);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cuda_graph_launch(graphExec, stream);
+    }
     cudaError_t result = original_cuda_graph_launch(graphExec, stream);
-    peak_cuda_record_event(end, (cudaStream_t)stream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)stream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     GraphLaunchInfo info = {
         .graph = graphExec,
@@ -748,11 +996,21 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_graph_launch(
     CUgraphExec hGraphExec, CUstream hStream)
 {
     PeakCudaInflightGuard in_flight;
-    cudaEvent_t* start = peak_cuda_new_event_slot();
-    cudaEvent_t* end = peak_cuda_new_event_slot();
-    peak_cuda_record_event(start, (cudaStream_t)hStream);
+    /* Graph executable handles are rank-local; profile them locally only. */
+    cudaEvent_t* start = NULL;
+    cudaEvent_t* end = NULL;
+    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
+    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
     CUresult result = original_cu_graph_launch(hGraphExec, hStream);
-    peak_cuda_record_event(end, (cudaStream_t)hStream);
+    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
+        peak_cuda_release_event_pair(start, end);
+        return result;
+    }
 
     GraphLaunchInfo info = {
         .graph = hGraphExec,
@@ -784,15 +1042,17 @@ extern "C" int cuda_interceptor_attach()
 
     gum_interceptor_begin_transaction(cuda_interceptor);
 
-    // Initialize cudaEvent_t array
-    peak_gpu_cuda_start_event_array = g_new0(cudaEvent_t, peak_gpu_hook_address_count);
-    peak_gpu_cuda_end_event_array = g_new0(cudaEvent_t, peak_gpu_hook_address_count);
-    for (size_t i = 0; i < peak_gpu_hook_address_count; i++) {
-        if (cudaEventCreate(&peak_gpu_cuda_start_event_array[i]) != cudaSuccess) {
-            peak_gpu_cuda_start_event_array[i] = NULL;
-        }
-        if (cudaEventCreate(&peak_gpu_cuda_end_event_array[i]) != cudaSuccess) {
-            peak_gpu_cuda_end_event_array[i] = NULL;
+    peak_cuda_destroy_event_pool();
+    peak_cuda_event_pool_capacity = peak_cuda_parse_event_pool_capacity();
+    peak_cuda_profiler_state.reset(peak_cuda_event_pool_capacity,
+                                   peak_cuda_event_pool_capacity * 4);
+    {
+        std::lock_guard<std::mutex> event_lock(peak_cuda_event_pool_mutex);
+        peak_cuda_event_pool.reserve(peak_cuda_event_pool_capacity);
+        peak_cuda_free_event_slots.reserve(peak_cuda_event_pool_capacity);
+        for (size_t i = 0; i < peak_cuda_event_pool_capacity; ++i) {
+            peak_cuda_event_pool.push_back({NULL, NULL, FALSE, FALSE});
+            peak_cuda_free_event_slots.push_back(i);
         }
     }
 
@@ -1015,27 +1275,20 @@ extern "C" void cuda_interceptor_dettach()
 
     unsigned int active_cuda_wrappers = peak_cuda_in_flight.load(std::memory_order_acquire);
     if (active_cuda_wrappers != 0) {
-        peak_log_warn("[peak] CUDA interceptor teardown observed %u active wrapper(s); keeping Gum trampoline state alive\n",
+        peak_log_warn("[peak] CUDA interceptor teardown observed %u active wrapper(s); keeping all CUDA state alive for cleanup retry\n",
                    active_cuda_wrappers);
+        /*
+         * A wrapper may still hold addresses into peak_cuda_event_pool before
+         * its in-flight guard became observable. Do not drain maps, destroy
+         * events, or clear identity state until a later detach observes zero.
+         */
+        return;
     }
 
     peak_cuda_drain_kernel_event_map(FALSE);
     peak_cuda_drain_graph_event_map(FALSE);
 
-    for (size_t i = 0; i < peak_gpu_hook_address_count; i++) {
-        if (peak_gpu_cuda_start_event_array != NULL &&
-            peak_gpu_cuda_start_event_array[i] != NULL) {
-            cudaEventDestroy(peak_gpu_cuda_start_event_array[i]);
-        }
-        if (peak_gpu_cuda_end_event_array != NULL &&
-            peak_gpu_cuda_end_event_array[i] != NULL) {
-            cudaEventDestroy(peak_gpu_cuda_end_event_array[i]);
-        }
-    }
-    g_free(peak_gpu_cuda_start_event_array);
-    g_free(peak_gpu_cuda_end_event_array);
-    peak_gpu_cuda_start_event_array = NULL;
-    peak_gpu_cuda_end_event_array = NULL;
+    peak_cuda_destroy_event_pool();
 
     if (cuda_kernel_local_dim_mapping != NULL) {
         g_hash_table_destroy(cuda_kernel_local_dim_mapping);
@@ -1050,126 +1303,9 @@ extern "C" void cuda_interceptor_dettach()
     /*
      * Keep cuda_interceptor referenced after physical detach. A target thread may
      * already be at a wrapper entry before PeakCudaInflightGuard executes, and
-     * that wrapper can still need Gum's original trampoline. Retaining this
-     * bounded state avoids a teardown race without delaying physical detach.
+     * that wrapper can still need Gum's original trampoline. State is retained
+     * unchanged on an active-wrapper observation and can be cleaned on retry.
      */
-}
-
-static void cuda_interceptor_print_kernel_result(GHashTable* hashTable)
-{
-    gboolean have_output = FALSE;
-    GHashTableIter iter;
-    gpointer key, value;
-
-    g_hash_table_iter_init(&iter, hashTable);
-    while (g_hash_table_iter_next(&iter, &key, &value)) {
-        KernelDimInfo* dim_info = (KernelDimInfo*) value;
-        if (dim_info->total_kernel_call_cnt > 0) {
-            have_output = TRUE;
-            break;
-        }
-    }
-
-    if (have_output) {
-        const guint row_width = 100;
-        const guint max_function_width = 40;
-        const guint max_col_width = 9;
-
-        char* space_separator = (char *) malloc(row_width + 1);
-        char* row_separator = (char *)  malloc(row_width + 1);
-        memset(space_separator, ' ', row_width);
-        memset(row_separator, '-', row_width);
-        space_separator[row_width] = '\0';
-        row_separator[row_width] = '\0';
-
-        peak_log_report("\n%s\n", row_separator);
-        peak_log_report("%*sGPU STATISTICS (Kernel)%*s\n",
-            (row_width - 15) / 2, "",
-            (row_width - 15 + 1) / 2, "");
-        peak_log_report("%s\n", row_separator);
-
-        // Section: Kernel call count & time
-        peak_log_report("\n%s\n", row_separator);
-        peak_log_report("%*sKERNEL STATISTICS (GPU)%*s\n",
-            (row_width - 26) / 2, "",
-            (row_width - 26 + 1) / 2, "");
-        peak_log_report("%s\n", row_separator);
-        peak_log_report("| %-*s | %*s | %*s | %*s | %*s |\n",
-            max_function_width, "Kernel",
-            max_col_width, "Calls",
-            max_col_width, "Total(s)",
-            max_col_width, "Max(s)",
-            max_col_width, "Min(s)");
-        peak_log_report("%s\n", row_separator);
-
-        g_hash_table_iter_init(&iter, hashTable);
-        while (g_hash_table_iter_next(&iter, &key, &value)) {
-            KernelDimInfo* dim_info = (KernelDimInfo*) value;
-            char* truncated_name = truncate_string((const char *)key, max_function_width);
-            peak_log_report("| %-*s | %*lu | %*.6f | %*.6f | %*.6f |\n",
-                max_function_width, truncated_name,
-                max_col_width, dim_info->total_kernel_call_cnt,
-                max_col_width, dim_info->total_time,
-                max_col_width, dim_info->max_time,
-                max_col_width, dim_info->min_time);
-            free(truncated_name);
-        }
-        peak_log_report("%s\n", row_separator);
-
-        // Section: Kernel block & thread size
-        peak_log_report("\n%s\n", row_separator);
-        peak_log_report("%*sKERNEL BLOCK SIZE%*s\n",
-            (row_width - 20) / 2, "",
-            (row_width - 20 + 1) / 2, "");
-        peak_log_report("%s\n", row_separator);
-        peak_log_report("| %-*s | %*s | %*s | %*s |\n",
-            max_function_width, "Kernel",
-            max_col_width, "AvgBlk",
-            max_col_width, "MaxBlk",
-            max_col_width, "MinBlk");
-        peak_log_report("%s\n", row_separator);
-
-        g_hash_table_iter_init(&iter, hashTable);
-        while (g_hash_table_iter_next(&iter, &key, &value)) {
-            KernelDimInfo* dim_info = (KernelDimInfo*) value;
-            char* truncated_name = truncate_string((const char *)key, max_function_width);
-            peak_log_report("| %-*s | %*.2f | %*lu | %*lu |\n",
-                max_function_width, truncated_name,
-                max_col_width, (double)dim_info->total_block_size / dim_info->total_kernel_call_cnt,
-                max_col_width, dim_info->max_block_size,
-                max_col_width, dim_info->min_block_size);
-            free(truncated_name);
-        }
-        peak_log_report("%s\n", row_separator);
-
-        peak_log_report("\n%s\n", row_separator);
-        peak_log_report("%*sKERNEL GRID SIZE%*s\n",
-            (row_width - 21) / 2, "",
-            (row_width - 21 + 1) / 2, "");
-        peak_log_report("%s\n", row_separator);
-        peak_log_report("| %-*s | %*s | %*s | %*s |\n",
-            max_function_width, "Kernel",
-            max_col_width, "AvgGrid",
-            max_col_width, "MaxGrid",
-            max_col_width, "MinGrid");
-        peak_log_report("%s\n", row_separator);
-
-        g_hash_table_iter_init(&iter, hashTable);
-        while (g_hash_table_iter_next(&iter, &key, &value)) {
-            KernelDimInfo* dim_info = (KernelDimInfo*) value;
-            char* truncated_name = truncate_string((const char *)key, max_function_width);
-            peak_log_report("| %-*s | %*.2f | %*lu | %*lu |\n",
-                max_function_width, truncated_name,
-                max_col_width, (double)dim_info->total_grid_size / dim_info->total_kernel_call_cnt,
-                max_col_width, dim_info->max_grid_size,
-                max_col_width, dim_info->min_grid_size);
-            free(truncated_name);
-        }
-        peak_log_report("%s\n", row_separator);
-
-        free(space_separator);
-        free(row_separator);
-    }
 }
 
 static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
@@ -1235,325 +1371,153 @@ static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
     }
 }
 
-static void cuda_interceptor_print_graph_mpi_result(const gint* ranks,
-                                                    CUgraphExec_st** graphs,
-                                                    const GraphRecordInfo* values,
-                                                    gint count)
-{
-    gboolean have_output = FALSE;
-    for (gint i = 0; i < count; i++) {
-        if (values[i].total_graph_call_cnt > 0) {
-            have_output = TRUE;
-            break;
-        }
-    }
-
-    if (have_output) {
-        const guint row_width = 112;
-        const guint max_col_width = 9;
-
-        char* row_separator = (char *) malloc(row_width + 1);
-        memset(row_separator, '-', row_width);
-        row_separator[row_width] = '\0';
-
-        peak_log_report("\n%s\n", row_separator);
-        peak_log_report("%*sGRAPH STATISTICS (GPU, MPI)%*s\n",
-            (row_width - 27) / 2, "",
-            (row_width - 27 + 1) / 2, "");
-        peak_log_report("%s\n", row_separator);
-        peak_log_report("| %*s | %*s | %*s | %*s | %*s | %*s |\n",
-            max_col_width, "Rank",
-            18, "Graph",
-            max_col_width, "Calls",
-            max_col_width, "Total(s)",
-            max_col_width, "Max(s)",
-            max_col_width, "Min(s)");
-        peak_log_report("%s\n", row_separator);
-
-        for (gint i = 0; i < count; i++) {
-            if (values[i].total_graph_call_cnt == 0) {
-                continue;
-            }
-            peak_log_report("| %*d | %18p | %*lu | %*.6f | %*.6f | %*.6f |\n",
-                max_col_width, ranks[i],
-                graphs[i],
-                max_col_width, values[i].total_graph_call_cnt,
-                max_col_width, values[i].total_time,
-                max_col_width, values[i].max_time,
-                max_col_width, values[i].min_time);
-        }
-        peak_log_report("%s\n", row_separator);
-
-        free(row_separator);
-    }
-}
-
-#ifdef HAVE_MPI
-static void
-cuda_interceptor_reduce_kernel_result()
-{
-    int world_rank, world_size;
-    int init_flag;
-    MPI_Initialized(&init_flag);
-    if (!init_flag) {
-        MPI_Init(NULL, NULL);
-    }
-    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
-
-    GHashTable* cuda_kernel_global_dim_mapping = NULL;
-    if (world_rank == 0) {
-        cuda_kernel_global_dim_mapping = g_hash_table_new_full(g_str_hash, str_equal_function, NULL, g_free);
-    }
-
-    gint local_kernel_count = g_hash_table_size(cuda_kernel_local_dim_mapping);
-    gint local_values_size = local_kernel_count * sizeof(KernelDimInfo);
-    gchar** local_keys = g_new(gchar*, local_kernel_count);
-    KernelDimInfo* values = g_new(KernelDimInfo, local_kernel_count);
-
-    GHashTableIter iter;
-    gpointer key, value;
-    guint index = 0;
-    gint local_keys_buffer_size = 0;
-    g_hash_table_iter_init(&iter, cuda_kernel_local_dim_mapping);
-    while (g_hash_table_iter_next(&iter, &key, &value)) {
-        local_keys_buffer_size += strlen((char*) key) + 1;
-        local_keys[index] = g_strdup((char*) key);
-        values[index] = *(KernelDimInfo*) value;
-        index++;
-    }
-
-    gchar* local_keys_buffer = g_new(gchar, local_keys_buffer_size);
-    guint offset = 0;
-    for (guint i = 0; i < local_kernel_count; i++) {
-        strcpy(&local_keys_buffer[offset], local_keys[i]);
-        offset += strlen(local_keys[i]) + 1;
-    }
-
-    gulong global_kernel_count = 0;
-    gulong global_keys_length_sum;
-    gulong* kernel_count_array = NULL;
-    gint* keys_buffer_array = NULL;
-    gint* values_buffer_array = NULL;
-    if (world_rank == 0) {
-        global_kernel_count = 0;
-        global_keys_length_sum = world_size; // initialize for each rank plus one for space or \0 after words
-        kernel_count_array = g_new(gulong, world_size);
-        keys_buffer_array = g_new(gint, world_size);
-        values_buffer_array = g_new(gint, world_size);
-    }
-    MPI_Reduce(&local_kernel_count, &global_kernel_count, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Reduce(&local_keys_buffer_size, &global_keys_length_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_kernel_count, 1, MPI_INT, kernel_count_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_keys_buffer_size, 1, MPI_INT, keys_buffer_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_values_size, 1, MPI_INT, values_buffer_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-    gchar *global_keys_string = NULL;
-    gint *keys_offset_array = NULL;
-    gint *values_offset_array = NULL;
-    gchar **global_keys_array = NULL;
-    KernelDimInfo* global_values_array = NULL;
-
-    if (world_rank == 0) {
-        // Key
-        keys_offset_array = g_new(gint, world_size);
-        keys_offset_array[0] = 0;
-        for (guint i = 1; i < world_size; i++) {
-            keys_offset_array[i] = keys_offset_array[i-1] + keys_buffer_array[i-1];
-        }
-        global_keys_string = g_new(gchar, global_keys_length_sum == 0 ? 1 : global_keys_length_sum);
-        if (global_keys_length_sum > 0) {
-            memset(global_keys_string, '\0', global_keys_length_sum - 1); // allocate string, pre-fill with \0
-            global_keys_string[global_keys_length_sum - 1] = '\0';
-        } else {
-            global_keys_string[0] = '\0';
-        }
-
-        // Value
-        global_values_array = (global_kernel_count > 0) ? g_new(KernelDimInfo, global_kernel_count) : NULL;
-        values_offset_array = g_new(gint, world_size);
-        values_offset_array[0] = 0;
-        for (guint i = 1; i < world_size; i++) {
-            values_offset_array[i] = values_offset_array[i-1] + values_buffer_array[i-1];
-        }
-    }
-
-    MPI_Gatherv(local_keys_buffer, local_keys_buffer_size, MPI_CHAR, global_keys_string, keys_buffer_array, keys_offset_array, MPI_CHAR, 0, MPI_COMM_WORLD);
-    MPI_Gatherv(values, local_kernel_count * sizeof(KernelDimInfo), MPI_BYTE, global_values_array, values_buffer_array, values_offset_array, MPI_BYTE, 0, MPI_COMM_WORLD);
-
-    if (world_rank == 0) {
-        if (global_kernel_count > 0) {
-            // Spilt global key strings into global key array
-            global_keys_array = g_new(gchar*, global_kernel_count);
-            guint index = 0;
-            for (guint i = 0; i < global_kernel_count; i++) {
-                guint len = strlen(global_keys_string + index);
-                global_keys_array[i] = g_new(gchar, len+1);
-                strcpy(global_keys_array[i], global_keys_string + index);
-                index += len + 1;
-            }
-
-            // aggregate value
-            for (guint i = 0; i < global_kernel_count; i++) {
-                KernelDimInfo* existing = (KernelDimInfo*) g_hash_table_lookup(cuda_kernel_global_dim_mapping, g_strdup(global_keys_array[i]));
-                if (existing) {
-                    existing->total_kernel_call_cnt += global_values_array[i].total_kernel_call_cnt;
-                    existing->total_gpu_threads += global_values_array[i].total_gpu_threads;
-                    existing->max_gpu_threads = max(existing->max_gpu_threads, global_values_array[i].max_gpu_threads);
-                    existing->min_gpu_threads = min(existing->min_gpu_threads, global_values_array[i].min_gpu_threads);
-                    existing->total_block_size += global_values_array[i].total_block_size;
-                    existing->max_block_size = max(existing->max_block_size, global_values_array[i].max_block_size);
-                    existing->min_block_size = min(existing->min_block_size, global_values_array[i].min_block_size);
-                    existing->total_grid_size += global_values_array[i].total_grid_size;
-                    existing->max_grid_size = max(existing->max_grid_size, global_values_array[i].max_grid_size);
-                    existing->min_grid_size = min(existing->min_grid_size, global_values_array[i].min_grid_size);
-                    existing->total_time += global_values_array[i].total_time;
-                    existing->max_time = max(existing->max_time, global_values_array[i].max_time);
-                    existing->min_time = min(existing->min_time, global_values_array[i].min_time);
-                } else {
-                    g_hash_table_insert(cuda_kernel_global_dim_mapping, g_strdup(global_keys_array[i]), g_memdup2(&global_values_array[i], sizeof(KernelDimInfo)));
-                }
-            }
-
-            cuda_interceptor_print_kernel_result(cuda_kernel_global_dim_mapping);
-
-            for (guint i = 0; i < global_kernel_count; i++) {
-                g_free(global_keys_array[i]);
-            }
-        }
-
-        g_free(global_keys_string);
-        g_free(keys_offset_array);
-        g_free(values_offset_array);
-        g_free(global_keys_array);
-        g_free(global_values_array);
-    }
-
-    for (guint i = 0; i < local_kernel_count; i++) {
-        g_free(local_keys[i]);
-    }
-    g_free(local_keys);
-    g_free(values);
-    g_free(local_keys_buffer);
-    if (world_rank == 0) {
-        g_hash_table_destroy(cuda_kernel_global_dim_mapping);
-        g_free(kernel_count_array);
-        g_free(keys_buffer_array);
-        g_free(values_buffer_array);
-    }
-}
-
-static void
-cuda_interceptor_reduce_graph_result()
-{
-    // FIXME: consider not using CUgraphExec_st* to determine unique graph, as it may not work across MPI ranks
-
-    int world_rank, world_size;
-    int init_flag;
-    MPI_Initialized(&init_flag);
-    if (!init_flag) {
-        MPI_Init(NULL, NULL);
-    }
-    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
-
-    gint local_graph_count = g_hash_table_size(cuda_graph_local_mapping);
-    gint local_key_size = local_graph_count * sizeof(CUgraphExec_st*);
-    gint local_values_size = local_graph_count * sizeof(GraphRecordInfo);
-    CUgraphExec_st** keys = g_new(CUgraphExec_st*, local_graph_count);
-    GraphRecordInfo* values = g_new(GraphRecordInfo, local_graph_count);
-
-    GHashTableIter iter;
-    gpointer key, value;
-    guint index = 0;
-    g_hash_table_iter_init(&iter, cuda_graph_local_mapping);
-    while (g_hash_table_iter_next(&iter, &key, &value)) {
-        keys[index] = (CUgraphExec_st*) key;
-        values[index] = *(GraphRecordInfo*) value;
-        index++;
-    }
-
-    gint global_graph_count = 0;
-    gint* graph_count_array = NULL;
-    gint* keys_buffer_array = NULL;
-    gint* values_buffer_array = NULL;
-    if (world_rank == 0) {
-        global_graph_count = 0;
-        graph_count_array = g_new(gint, world_size);
-        keys_buffer_array = g_new(gint, world_size);
-        values_buffer_array = g_new(gint, world_size);
-    }
-    MPI_Reduce(&local_graph_count, &global_graph_count, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_graph_count, 1, MPI_INT, graph_count_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_key_size, 1, MPI_INT, keys_buffer_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    MPI_Gather(&local_values_size, 1, MPI_INT, values_buffer_array, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-    gint *keys_offset_array = NULL;
-    gint *values_offset_array = NULL;
-    CUgraphExec_st** global_keys_array = NULL;
-    GraphRecordInfo* global_values_array = NULL;
-    gint* global_rank_array = NULL;
-
-    if (world_rank == 0) {
-        // Key
-        global_keys_array = g_new(CUgraphExec_st*, global_graph_count);
-        global_rank_array = g_new(gint, global_graph_count);
-        keys_offset_array = g_new(gint, world_size);
-        keys_offset_array[0] = 0;
-        gint graph_offset = 0;
-        for (guint i = 0; i < (guint) graph_count_array[0]; i++) {
-            global_rank_array[graph_offset++] = 0;
-        }
-        for (guint i = 1; i < world_size; i++) {
-            keys_offset_array[i] = keys_offset_array[i-1] + keys_buffer_array[i-1];
-            for (guint j = 0; j < (guint) graph_count_array[i]; j++) {
-                global_rank_array[graph_offset++] = i;
-            }
-        }
-
-        // Value
-        global_values_array = g_new(GraphRecordInfo, global_graph_count);
-        values_offset_array = g_new(gint, world_size);
-        values_offset_array[0] = 0;
-        for (guint i = 1; i < world_size; i++) {
-            values_offset_array[i] = values_offset_array[i-1] + values_buffer_array[i-1];
-        }
-    }
-    MPI_Gatherv(keys, local_graph_count * sizeof(CUgraphExec_st*), MPI_BYTE, global_keys_array, keys_buffer_array, keys_offset_array, MPI_BYTE, 0, MPI_COMM_WORLD);
-    MPI_Gatherv(values, local_graph_count * sizeof(GraphRecordInfo), MPI_BYTE, global_values_array, values_buffer_array, values_offset_array, MPI_BYTE, 0, MPI_COMM_WORLD);
-
-    if (world_rank == 0) {
-        if (global_graph_count > 0) {
-            cuda_interceptor_print_graph_mpi_result(global_rank_array,
-                                                    global_keys_array,
-                                                    global_values_array,
-                                                    global_graph_count);
-        }
-
-        g_free(keys_offset_array);
-        g_free(values_offset_array);
-        g_free(global_rank_array);
-        g_free(global_keys_array);
-        g_free(global_values_array);
-    }
-
-    g_free(keys);
-    g_free(values);
-    if (world_rank == 0) {
-        g_free(graph_count_array);
-        g_free(keys_buffer_array);
-        g_free(values_buffer_array);
-    }
-}
-#endif
-
 static void cuda_sync_kernel_event() {
     cudaDeviceSynchronize();
     peak_cuda_drain_kernel_event_map(TRUE);
     peak_cuda_drain_graph_event_map(TRUE);
 }
 
-extern "C" void cuda_interceptor_print(int is_MPI) {
+static PeakReportSnapshot*
+peak_cuda_build_report_snapshot()
+{
+    std::vector<std::pair<std::string, KernelDimInfo>> kernels;
+    PeakReportSnapshot* snapshot;
+    size_t index = 0;
+
+    g_mutex_lock(&cuda_kernel_local_dim_mapping_mutex);
+    GHashTableIter iter;
+    gpointer key;
+    gpointer value;
+    g_hash_table_iter_init(&iter, cuda_kernel_local_dim_mapping);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
+        kernels.emplace_back((const gchar*)key, *(KernelDimInfo*)value);
+    }
+    g_mutex_unlock(&cuda_kernel_local_dim_mapping_mutex);
+    std::sort(kernels.begin(), kernels.end(),
+              [](const auto& left, const auto& right) {
+                  return left.first < right.first;
+              });
+    if (kernels.size() > (SIZE_MAX - 4) / 4) {
+        return NULL;
+    }
+    snapshot = peak_report_snapshot_create(kernels.size() * 4 + 4);
+    if (snapshot == NULL || !peak_report_snapshot_set_program(snapshot, "CUDA")) {
+        peak_report_snapshot_destroy(snapshot);
+        return NULL;
+    }
+    snapshot->overhead = peak_report_snapshot_get_transport_overhead();
+    snapshot->rank_count = 1;
+    for (const auto& entry : kernels) {
+        const KernelDimInfo& info = entry.second;
+        const gchar* suffixes[] = {" [time]", " [threads]", " [block]", " [grid]"};
+        for (const gchar* suffix : suffixes) {
+            gchar* name = g_strdup_printf("CUDA kernel: %s%s",
+                                          entry.first.c_str(), suffix);
+            gboolean named = name != NULL &&
+                peak_report_snapshot_set_name(snapshot, index, name);
+            g_free(name);
+            if (!named) {
+                peak_report_snapshot_destroy(snapshot);
+                return NULL;
+            }
+            snapshot->instrumented[index++] = 1;
+        }
+        index -= 4;
+        snapshot->num_calls[index] = info.total_kernel_call_cnt;
+        snapshot->total_time[index] = info.total_time;
+        snapshot->max_total_time[index] = info.max_time;
+        snapshot->min_total_time[index++] = info.min_time;
+        snapshot->num_calls[index] = info.total_gpu_threads;
+        snapshot->max_total_time[index] = (double)info.max_gpu_threads;
+        snapshot->min_total_time[index++] = (double)info.min_gpu_threads;
+        snapshot->num_calls[index] = info.total_block_size;
+        snapshot->max_total_time[index] = (double)info.max_block_size;
+        snapshot->min_total_time[index++] = (double)info.min_block_size;
+        snapshot->num_calls[index] = info.total_grid_size;
+        snapshot->max_total_time[index] = (double)info.max_grid_size;
+        snapshot->min_total_time[index++] = (double)info.min_grid_size;
+    }
+    PeakCudaProfilerCounters counters = peak_cuda_profiler_state.counters();
+    const gchar* drops[] = {"CUDA profiler drops [pool_full]",
+                            "CUDA profiler drops [identity_full]",
+                            "CUDA profiler drops [event_create]",
+                            "CUDA profiler drops [timing_error]"};
+    const guint64 values[] = {counters.dropped_pool_full,
+                              counters.dropped_identity_full,
+                              counters.dropped_event_create,
+                              counters.dropped_timing_error};
+    for (size_t drop = 0; drop < G_N_ELEMENTS(drops); ++drop) {
+        if (!peak_report_snapshot_set_name(snapshot, index, drops[drop])) {
+            peak_report_snapshot_destroy(snapshot);
+            return NULL;
+        }
+        snapshot->instrumented[index] = 1;
+        snapshot->num_calls[index++] = (gulong)values[drop];
+    }
+    return snapshot;
+}
+
+static gboolean
+peak_cuda_render_report_snapshot(const PeakReportSnapshot* snapshot)
+{
+    const size_t prefix_length = strlen("CUDA kernel: ");
+    const size_t suffix_length = strlen(" [time]");
+    gboolean have_output = FALSE;
+    guint64 drops[4] = {0, 0, 0, 0};
+
+    if (snapshot == NULL) {
+        return FALSE;
+    }
+    for (size_t i = 0; i + 3 < snapshot->hook_count; ++i) {
+        const gchar* name = snapshot->names[i];
+        size_t length;
+        if (name == NULL || !g_str_has_prefix(name, "CUDA kernel: ")) {
+            continue;
+        }
+        length = strlen(name);
+        if (length < prefix_length + suffix_length ||
+            strcmp(name + length - suffix_length, " [time]") != 0) {
+            continue;
+        }
+        if (!have_output) {
+            peak_log_report("\nGPU STATISTICS (Kernel)\n");
+            peak_log_report("| Kernel | Calls | Total(s) | Max(s) | Min(s) | AvgThr | MaxThr | MinThr | AvgBlk | MaxBlk | MinBlk | AvgGrid | MaxGrid | MinGrid |\n");
+            have_output = TRUE;
+        }
+        std::string label(name + prefix_length, length - prefix_length - suffix_length);
+        const double calls = (double)snapshot->num_calls[i];
+        peak_log_report("| %s | %lu | %.6f | %.6f | %.6f | %.2f | %.0f | %.0f | %.2f | %.0f | %.0f | %.2f | %.0f | %.0f |\n",
+                        label.c_str(), snapshot->num_calls[i], snapshot->total_time[i],
+                        snapshot->max_total_time[i], snapshot->min_total_time[i],
+                        calls != 0.0 ? (double)snapshot->num_calls[i + 1] / calls : 0.0,
+                        snapshot->max_total_time[i + 1], snapshot->min_total_time[i + 1],
+                        calls != 0.0 ? (double)snapshot->num_calls[i + 2] / calls : 0.0,
+                        snapshot->max_total_time[i + 2], snapshot->min_total_time[i + 2],
+                        calls != 0.0 ? (double)snapshot->num_calls[i + 3] / calls : 0.0,
+                        snapshot->max_total_time[i + 3], snapshot->min_total_time[i + 3]);
+    }
+    for (size_t i = 0; i < snapshot->hook_count; ++i) {
+        const gchar* name = snapshot->names[i];
+        if (name == NULL) continue;
+        for (size_t drop = 0; drop < G_N_ELEMENTS(drops); ++drop) {
+            const gchar* suffixes[] = {"[pool_full]", "[identity_full]",
+                                       "[event_create]", "[timing_error]"};
+            if (g_str_has_suffix(name, suffixes[drop])) {
+                drops[drop] = snapshot->num_calls[i];
+            }
+        }
+    }
+    if (drops[0] != 0 || drops[1] != 0 || drops[2] != 0 || drops[3] != 0) {
+        peak_log_report("[peak] CUDA profiler drops: pool_full=%" G_GUINT64_FORMAT
+                        " identity_full=%" G_GUINT64_FORMAT " event_create=%"
+                        G_GUINT64_FORMAT " timing_error=%" G_GUINT64_FORMAT "\n",
+                        drops[0], drops[1], drops[2], drops[3]);
+    }
+    return TRUE;
+}
+
+extern "C" void cuda_interceptor_print_with_mpi_job_policy(
+    int aggregation_mode, int active_mpi_job) {
     std::lock_guard<std::mutex> lifecycle_lock(peak_cuda_lifecycle_mutex);
     if (cuda_kernel_local_dim_mapping == NULL ||
         cuda_graph_local_mapping == NULL) {
@@ -1561,16 +1525,56 @@ extern "C" void cuda_interceptor_print(int is_MPI) {
     }
     peak_cuda_accepting_events.store(false, std::memory_order_release);
     cuda_sync_kernel_event();
-    #ifdef HAVE_MPI
-        if (is_MPI) {
-            cuda_interceptor_reduce_kernel_result();
-            cuda_interceptor_reduce_graph_result();
+    PeakReportSnapshot* local = peak_cuda_build_report_snapshot();
+    if (local != NULL) {
+#ifdef HAVE_MPI
+        if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI) {
+            PeakReportSnapshot* aggregate = NULL;
+            PeakMpiReportTransportResult result =
+                peak_mpi_report_transport_reduce(local, &aggregate);
+            if (result == PEAK_MPI_REPORT_TRANSPORT_ROOT_READY) {
+                (void)peak_cuda_render_report_snapshot(aggregate);
+            } else if (result != PEAK_MPI_REPORT_TRANSPORT_PEER_COMPLETE) {
+                (void)peak_cuda_render_report_snapshot(local);
+            }
+            peak_report_snapshot_destroy(aggregate);
+        } else
+#endif
+        if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_SOCKET) {
+            PeakSocketReportSession* session = NULL;
+            PeakReportSnapshot* aggregate = NULL;
+            PeakSocketReportRankSource socket_rank_source = active_mpi_job
+                ? PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED
+                : PEAK_SOCKET_REPORT_RANK_MPI_OR_ENV;
+            PeakSocketReportStatus status = peak_socket_report_transport_begin_channel(
+                local, socket_rank_source,
+                PEAK_SOCKET_REPORT_CHANNEL_CUDA, &session, &aggregate);
+            if (status == PEAK_SOCKET_REPORT_SINGLE_READY) {
+                (void)peak_cuda_render_report_snapshot(aggregate);
+            } else if (status == PEAK_SOCKET_REPORT_ROOT_PREPARED) {
+                if (peak_cuda_render_report_snapshot(aggregate)) {
+                    (void)peak_socket_report_transport_commit(session);
+                } else {
+                    peak_socket_report_transport_abort(session);
+                    (void)peak_cuda_render_report_snapshot(local);
+                }
+            } else if (status != PEAK_SOCKET_REPORT_PEER_RELEASED) {
+                peak_socket_report_transport_abort(session);
+                (void)peak_cuda_render_report_snapshot(local);
+            }
+            peak_report_snapshot_destroy(aggregate);
         } else {
-            cuda_interceptor_print_kernel_result(cuda_kernel_local_dim_mapping);
-            cuda_interceptor_print_graph_result(cuda_graph_local_mapping);
+            (void)peak_cuda_render_report_snapshot(local);
         }
-    #else
-        cuda_interceptor_print_kernel_result(cuda_kernel_local_dim_mapping);
-        cuda_interceptor_print_graph_result(cuda_graph_local_mapping);
-    #endif
+        peak_report_snapshot_destroy(local);
+    }
+    cuda_interceptor_print_graph_result(cuda_graph_local_mapping);
+}
+
+extern "C" void
+cuda_interceptor_print(int is_MPI)
+{
+    cuda_interceptor_print_with_mpi_job_policy(
+        is_MPI ? PEAK_OUTPUT_AGGREGATION_MPI : PEAK_OUTPUT_AGGREGATION_LOCAL,
+        FALSE);
 }

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "cuda_interceptor.h"
 #include "general_listener.h"
 #include "internal/cuda_profiler_state.h"
@@ -8,11 +10,7 @@
 #endif
 #include "logging.h"
 
-#include <algorithm>
-
 #define PEAK_CUDA_WRAPPER_EXPORT extern "C" __attribute__((visibility("default")))
-
-extern "C" gpointer peak_general_listener_find_function(const char* symbol);
 
 static GHashTable* cuda_kernel_local_dim_mapping;
 static GHashTable* cuda_graph_local_mapping;
@@ -266,14 +264,14 @@ static void update_kernel_map_info(const gchar* kernel_name, gulong total_thread
         dim_info->total_block_size += block_size;
         dim_info->total_grid_size += grid_size;
         dim_info->total_time += elapsed_sec;
-        dim_info->max_gpu_threads = max(dim_info->max_gpu_threads, total_threads);
-        dim_info->min_gpu_threads = min(dim_info->min_gpu_threads, total_threads);
-        dim_info->max_block_size = max(dim_info->max_block_size, block_size);
-        dim_info->min_block_size = min(dim_info->min_block_size, block_size);
-        dim_info->max_grid_size = max(dim_info->max_grid_size, grid_size);
-        dim_info->min_grid_size = min(dim_info->min_grid_size, grid_size);
-        dim_info->max_time = max(dim_info->max_time, elapsed_sec);
-        dim_info->min_time = min(dim_info->min_time, elapsed_sec);
+        dim_info->max_gpu_threads = std::max(dim_info->max_gpu_threads, total_threads);
+        dim_info->min_gpu_threads = std::min(dim_info->min_gpu_threads, total_threads);
+        dim_info->max_block_size = std::max(dim_info->max_block_size, block_size);
+        dim_info->min_block_size = std::min(dim_info->min_block_size, block_size);
+        dim_info->max_grid_size = std::max(dim_info->max_grid_size, grid_size);
+        dim_info->min_grid_size = std::min(dim_info->min_grid_size, grid_size);
+        dim_info->max_time = std::max(dim_info->max_time, elapsed_sec);
+        dim_info->min_time = std::min(dim_info->min_time, elapsed_sec);
     }
 }
 
@@ -299,8 +297,8 @@ void insert_cuda_graph_record(CUgraphExec_st* graph, gdouble elapsed_sec)
     } else {
         graph_info->total_graph_call_cnt++;
         graph_info->total_time += elapsed_sec;
-        graph_info->max_time = max(graph_info->max_time, elapsed_sec);
-        graph_info->min_time = min(graph_info->min_time, elapsed_sec);
+        graph_info->max_time = std::max(graph_info->max_time, elapsed_sec);
+        graph_info->min_time = std::min(graph_info->min_time, elapsed_sec);
     }
     g_mutex_unlock(&cuda_graph_local_mapping_mutex);
 }

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 
 #include "cuda_interceptor.h"
-#include "general_listener.h"
 #include "internal/cuda_profiler_state.h"
 #include "internal/general_listener/report_snapshot.h"
 #include "internal/general_listener/socket_report_transport.h"
@@ -11,6 +10,14 @@
 #include "logging.h"
 
 #define PEAK_CUDA_WRAPPER_EXPORT extern "C" __attribute__((visibility("default")))
+
+extern "C" gpointer peak_general_listener_find_function(const char* symbol);
+
+enum PeakCudaOutputAggregationMode {
+    PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0,
+    PEAK_CUDA_OUTPUT_AGGREGATION_MPI = 1,
+    PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2,
+};
 
 static GHashTable* cuda_kernel_local_dim_mapping;
 static GHashTable* cuda_graph_local_mapping;
@@ -1526,7 +1533,7 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
     PeakReportSnapshot* local = peak_cuda_build_report_snapshot();
     if (local != NULL) {
 #ifdef HAVE_MPI
-        if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI) {
+        if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_MPI) {
             PeakReportSnapshot* aggregate = NULL;
             PeakMpiReportTransportResult result =
                 peak_mpi_report_transport_reduce(local, &aggregate);
@@ -1538,7 +1545,7 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
             peak_report_snapshot_destroy(aggregate);
         } else
 #endif
-        if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_SOCKET) {
+        if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET) {
             PeakSocketReportSession* session = NULL;
             PeakReportSnapshot* aggregate = NULL;
             PeakSocketReportRankSource socket_rank_source = active_mpi_job
@@ -1573,6 +1580,7 @@ extern "C" void
 cuda_interceptor_print(int is_MPI)
 {
     cuda_interceptor_print_with_mpi_job_policy(
-        is_MPI ? PEAK_OUTPUT_AGGREGATION_MPI : PEAK_OUTPUT_AGGREGATION_LOCAL,
+        is_MPI ? PEAK_CUDA_OUTPUT_AGGREGATION_MPI :
+                 PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL,
         FALSE);
 }

--- a/src/cuda_profiler_state.cpp
+++ b/src/cuda_profiler_state.cpp
@@ -1,0 +1,156 @@
+#include "internal/cuda_profiler_state.h"
+
+#include <algorithm>
+
+namespace {
+constexpr const char* kUnknownKernelName = "<unknown>";
+constexpr std::size_t kMaximumKernelNameLength = 255;
+}
+
+PeakCudaProfilerState::PeakCudaProfilerState(std::size_t capacity)
+    : capacity_(capacity),
+      identity_capacity_(capacity),
+      active_slots_(0),
+      high_water_slots_(0),
+      dropped_pool_full_(0),
+      dropped_identity_full_(0),
+      dropped_event_create_(0),
+      dropped_timing_error_(0)
+{
+}
+
+void
+PeakCudaProfilerState::reset(std::size_t capacity,
+                             std::size_t identity_capacity)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    identities_.clear();
+    capacity_ = capacity;
+    identity_capacity_ = identity_capacity == 0 ? capacity : identity_capacity;
+    active_slots_ = 0;
+    high_water_slots_ = 0;
+    dropped_pool_full_ = 0;
+    dropped_identity_full_ = 0;
+    dropped_event_create_ = 0;
+    dropped_timing_error_ = 0;
+}
+
+PeakCudaKernelIdentity
+PeakCudaProfilerState::identify(
+    std::uintptr_t identity,
+    bool driver_function,
+    const char* display_name,
+    const char* target_name,
+    bool monitor_all,
+    const std::vector<std::string>& targets)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    const PeakCudaIdentityKey key = {identity, driver_function};
+    const auto existing = identities_.find(key);
+
+    if (existing != identities_.end()) {
+        return existing->second;
+    }
+
+    if (identities_.size() >= identity_capacity_) {
+        ++dropped_identity_full_;
+        return {kUnknownKernelName, monitor_all};
+    }
+
+    PeakCudaKernelIdentity result = {
+        display_name != nullptr && display_name[0] != '\0'
+            ? display_name
+            : kUnknownKernelName,
+        false,
+    };
+    if (result.name.size() > kMaximumKernelNameLength) {
+        result.name.resize(kMaximumKernelNameLength);
+    }
+    result.target_match = monitor_all ||
+                          (target_name != nullptr && target_name[0] != '\0' &&
+                           target_matches(target_name, targets));
+    identities_.emplace(key, result);
+    return result;
+}
+
+bool
+PeakCudaProfilerState::cached_identity(
+    std::uintptr_t identity,
+    bool driver_function,
+    PeakCudaKernelIdentity* result) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = identities_.find({identity, driver_function});
+
+    if (existing == identities_.end()) {
+        return false;
+    }
+    if (result != nullptr) {
+        *result = existing->second;
+    }
+    return true;
+}
+
+bool
+PeakCudaProfilerState::acquire_slot()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (active_slots_ >= capacity_) {
+        ++dropped_pool_full_;
+        return false;
+    }
+    ++active_slots_;
+    high_water_slots_ = std::max(high_water_slots_, active_slots_);
+    return true;
+}
+
+void
+PeakCudaProfilerState::release_slot()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (active_slots_ != 0) {
+        --active_slots_;
+    }
+}
+
+void
+PeakCudaProfilerState::record_event_create_failure()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++dropped_event_create_;
+}
+
+void
+PeakCudaProfilerState::record_timing_error()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++dropped_timing_error_;
+}
+
+PeakCudaProfilerCounters
+PeakCudaProfilerState::counters() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    return {
+        capacity_,
+        identity_capacity_,
+        identities_.size(),
+        active_slots_,
+        high_water_slots_,
+        dropped_pool_full_,
+        dropped_identity_full_,
+        dropped_event_create_,
+        dropped_timing_error_,
+    };
+}
+
+bool
+PeakCudaProfilerState::target_matches(const std::string& name,
+                                      const std::vector<std::string>& targets)
+{
+    return std::find(targets.begin(), targets.end(), name) != targets.end();
+}

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -8415,6 +8415,7 @@ peak_general_listener_print_with_mpi_job_policy(
 
     PeakReportOverhead local_report =
         peak_general_listener_local_report_overhead(sum_num_calls);
+    peak_report_snapshot_set_transport_overhead(&local_report);
     local_snapshot = peak_general_listener_build_report_snapshot(
         sum_num_calls,
         sum_total_time,

--- a/src/general_listener/report_snapshot.c
+++ b/src/general_listener/report_snapshot.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+static PeakReportOverhead peak_report_snapshot_transport_overhead;
+
 static char*
 peak_report_snapshot_duplicate_string(const char* source)
 {
@@ -218,6 +220,19 @@ peak_report_snapshot_has_duplicate_names(
         }
     }
     return false;
+}
+
+void
+peak_report_snapshot_set_transport_overhead(const PeakReportOverhead* overhead)
+{
+    peak_report_snapshot_transport_overhead =
+        overhead != NULL ? *overhead : (PeakReportOverhead){0};
+}
+
+PeakReportOverhead
+peak_report_snapshot_get_transport_overhead(void)
+{
+    return peak_report_snapshot_transport_overhead;
 }
 
 void

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -175,6 +175,12 @@ typedef enum {
     PEAK_SOCKET_RELEASE_FALLBACK,
 } PeakSocketReleaseResult;
 
+static bool peak_socket_reduce_channel_ports(PeakSocketReportChannel channel,
+                                             int* gather_port,
+                                             int* release_port);
+static _Thread_local PeakSocketReportChannel peak_socket_report_channel =
+    PEAK_SOCKET_REPORT_CHANNEL_CPU;
+
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static PeakSocketReportTestTelemetry peak_socket_test_telemetry = {
     .wire_version = PEAK_SOCKET_REDUCE_VERSION,
@@ -450,6 +456,16 @@ int
 peak_socket_report_test_default_port(void)
 {
     return peak_socket_reduce_default_port();
+}
+
+int
+peak_socket_report_test_channel_port(PeakSocketReportChannel channel)
+{
+    int gather_port = -1;
+    int release_port = -1;
+
+    return peak_socket_reduce_channel_ports(channel, &gather_port,
+                                            &release_port) ? gather_port : -1;
 }
 #endif
 
@@ -1481,6 +1497,33 @@ static int
 peak_socket_reduce_release_port(int port)
 {
     return port < 65535 ? port + 1 : port - 1;
+}
+
+static bool
+peak_socket_reduce_channel_ports(PeakSocketReportChannel channel,
+                                 int* gather_port,
+                                 int* release_port)
+{
+    int base = peak_socket_reduce_port();
+
+    if (gather_port == NULL || release_port == NULL ||
+        (channel != PEAK_SOCKET_REPORT_CHANNEL_CPU &&
+         channel != PEAK_SOCKET_REPORT_CHANNEL_CUDA)) {
+        return false;
+    }
+    if (channel == PEAK_SOCKET_REPORT_CHANNEL_CPU) {
+        *gather_port = base;
+        *release_port = peak_socket_reduce_release_port(base);
+        return true;
+    }
+    if (base > 65532) {
+        peak_log_warn("[peak] socket CUDA channel requires base port <= 65532; refusing %d\n",
+                      base);
+        return false;
+    }
+    *gather_port = base + 2;
+    *release_port = base + 3;
+    return true;
 }
 
 static PeakSocketReleaseResult
@@ -2956,8 +2999,10 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
         return PEAK_SOCKET_REPORT_FAILED;
     }
 
-    port = peak_socket_reduce_port();
-    release_port = peak_socket_reduce_release_port(port);
+    if (!peak_socket_reduce_channel_ports(peak_socket_report_channel,
+                                          &port, &release_port)) {
+        return PEAK_SOCKET_REPORT_FAILED;
+    }
     session_token = peak_socket_reduce_session_token();
 
     if (!peak_socket_reduce_rank_size(&rank, &size, rank_source)) {
@@ -3228,6 +3273,24 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     *session_out = session;
     *aggregate_out = aggregate;
     return PEAK_SOCKET_REPORT_ROOT_PREPARED;
+}
+
+PeakSocketReportStatus
+peak_socket_report_transport_begin_channel(
+    const PeakReportSnapshot* local,
+    PeakSocketReportRankSource rank_source,
+    PeakSocketReportChannel channel,
+    PeakSocketReportSession** session_out,
+    PeakReportSnapshot** aggregate_out)
+{
+    PeakSocketReportChannel previous = peak_socket_report_channel;
+    PeakSocketReportStatus result;
+
+    peak_socket_report_channel = channel;
+    result = peak_socket_report_transport_begin(local, rank_source,
+                                                session_out, aggregate_out);
+    peak_socket_report_channel = previous;
+    return result;
 }
 
 bool

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -185,6 +185,18 @@ static _Thread_local PeakSocketReportChannel peak_socket_report_channel =
 static PeakSocketReportTestTelemetry peak_socket_test_telemetry = {
     .wire_version = PEAK_SOCKET_REDUCE_VERSION,
 };
+static int peak_socket_test_receipt_barrier_peer_wait_fd = -1;
+static int peak_socket_test_receipt_barrier_root_signal_fd = -1;
+static bool peak_socket_test_receipt_failure_injected;
+
+static void
+peak_socket_test_receipt_barrier_close(int* fd)
+{
+    if (fd != NULL && *fd >= 0) {
+        close(*fd);
+        *fd = -1;
+    }
+}
 
 void
 peak_socket_report_test_telemetry_reset(void)
@@ -203,6 +215,55 @@ peak_socket_report_test_telemetry_get(
     if (telemetry_out != NULL) {
         *telemetry_out = peak_socket_test_telemetry;
     }
+}
+
+void
+peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,
+                                            int root_signal_fd)
+{
+    peak_socket_test_receipt_barrier_close(
+        &peak_socket_test_receipt_barrier_peer_wait_fd);
+    peak_socket_test_receipt_barrier_close(
+        &peak_socket_test_receipt_barrier_root_signal_fd);
+    peak_socket_test_receipt_barrier_peer_wait_fd = peer_wait_fd;
+    peak_socket_test_receipt_barrier_root_signal_fd = root_signal_fd;
+    peak_socket_test_receipt_failure_injected = false;
+}
+
+static bool
+peak_socket_test_receipt_barrier_wait_for_root(void)
+{
+    unsigned char signal = 0;
+    int fd = peak_socket_test_receipt_barrier_peer_wait_fd;
+    ssize_t received;
+
+    if (fd < 0) {
+        return true;
+    }
+    peak_socket_test_receipt_barrier_peer_wait_fd = -1;
+    do {
+        received = recv(fd, &signal, sizeof(signal), 0);
+    } while (received < 0 && errno == EINTR);
+    close(fd);
+    return received == (ssize_t)sizeof(signal) && signal == 0x72U;
+}
+
+static bool
+peak_socket_test_receipt_barrier_signal_root(void)
+{
+    const unsigned char signal = 0x72U;
+    int fd = peak_socket_test_receipt_barrier_root_signal_fd;
+    ssize_t written;
+
+    if (fd < 0) {
+        return true;
+    }
+    peak_socket_test_receipt_barrier_root_signal_fd = -1;
+    do {
+        written = send(fd, &signal, sizeof(signal), MSG_NOSIGNAL);
+    } while (written < 0 && errno == EINTR);
+    close(fd);
+    return written == (ssize_t)sizeof(signal);
 }
 #endif
 
@@ -2166,6 +2227,11 @@ peak_socket_gather_prepare_receipt(
         PEAK_SOCKET_REDUCE_GATHER_REGISTERED;
     connection->receipt_bytes = 0;
     connection->phase = PEAK_SOCKET_GATHER_SENDING_RECEIPT;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (!peak_socket_test_receipt_barrier_signal_root()) {
+        return false;
+    }
+#endif
     return true;
 }
 
@@ -2385,16 +2451,12 @@ peak_socket_gather_write_ready(PeakSocketGatherConnection* connection,
     }
     *complete_out = false;
 #ifdef PEAK_ENABLE_TEST_HOOKS
-    {
-        static bool injected_receipt_failure = false;
-
-        if (!injected_receipt_failure &&
-            peak_general_listener_env_value_truthy(
-                getenv(
-                    PEAK_TEST_OUTPUT_AGGREGATION_RECEIPT_FAIL_ONCE_ENV))) {
-            injected_receipt_failure = true;
-            return false;
-        }
+    if (!peak_socket_test_receipt_failure_injected &&
+        peak_general_listener_env_value_truthy(
+            getenv(PEAK_TEST_OUTPUT_AGGREGATION_RECEIPT_FAIL_ONCE_ENV))) {
+        peak_socket_test_receipt_failure_injected = true;
+        peak_socket_test_telemetry.root_receipt_failure_injected = true;
+        return false;
     }
 #endif
 
@@ -2892,6 +2954,9 @@ peak_socket_report_peer_begin(const PeakReportSnapshot* local,
                                               &gather_written,
                                               header->rank,
                                               deadline_us);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    sent = sent && peak_socket_test_receipt_barrier_wait_for_root();
+#endif
     memset(&receipt, 0, sizeof(receipt));
     receipt_received =
         sent &&

--- a/src/peak.c
+++ b/src/peak.c
@@ -1119,9 +1119,22 @@ peak_fini_impl(void)
         }
     }
     #ifdef HAVE_CUDA
-        cuda_interceptor_print(use_mpi_collective_output &&
-                               used_mpi_aggregation &&
-                               !mpi_reducer_failed_closed);
+        cuda_interceptor_print_with_mpi_job_policy(
+            (mpi_reducer_failed_closed ||
+             (output_mode == PEAK_OUTPUT_AGGREGATION_MPI &&
+              !used_mpi_aggregation)) ?
+                PEAK_OUTPUT_AGGREGATION_LOCAL : output_mode,
+            found_MPI ? TRUE : FALSE);
+        mpi_reducer_failed_closed = found_MPI &&
+            peak_general_listener_mpi_reducer_failed_closed();
+        if (mpi_reducer_failed_closed) {
+            peak_mpi_teardown_collectives_mark_failed_closed();
+            allow_real_mpi_finalize = 0;
+            use_mpi_collective_output = 0;
+            if (mpi_log_rank) {
+                g_printerr("[peak] CUDA MPI reducer failed or timed out; skipping real PMPI_Finalize\n");
+            }
+        }
         errno = 0;
         if (fflush(stderr) != 0 || ferror(stderr)) {
             report_write_succeeded = FALSE;
@@ -1248,7 +1261,8 @@ peak_fini_impl(void)
 #else
     (void)peak_general_listener_print(0, NULL);
     #ifdef HAVE_CUDA
-    cuda_interceptor_print(0);
+    cuda_interceptor_print_with_mpi_job_policy(
+        PEAK_OUTPUT_AGGREGATION_LOCAL, FALSE);
     cuda_interceptor_dettach();
     #endif
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,16 @@ if(BUILD_TESTING)
         PROPERTIES
             PASS_REGULAR_EXPRESSION "mpi_lifecycle_synthetic_stats_diagnostics_ok")
 
+    add_executable(test_cuda_profiler_state
+        cuda_profiler_state_test.cpp
+        ${PROJECT_SOURCE_DIR}/src/cuda_profiler_state.cpp)
+    target_include_directories(test_cuda_profiler_state PRIVATE
+        ${PROJECT_SOURCE_DIR}/include)
+    target_link_libraries(test_cuda_profiler_state PRIVATE Threads::Threads)
+    add_test(NAME test_cuda_profiler_state COMMAND test_cuda_profiler_state)
+    set_tests_properties(test_cuda_profiler_state
+        PROPERTIES PASS_REGULAR_EXPRESSION "cuda_profiler_state_test_ok")
+
     if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_READELF)
         add_test(NAME test_peak_shared_unwinder
             COMMAND ${Python3_EXECUTABLE}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,6 +152,19 @@ if(BUILD_TESTING)
         PROPERTIES
             PASS_REGULAR_EXPRESSION "report_snapshot_test_ok")
 
+    add_executable(test_report_snapshot_cxx_link
+        report/test_report_snapshot_cxx_link.cpp
+        ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/report_maxima.c)
+    target_include_directories(test_report_snapshot_cxx_link PRIVATE
+        ${PROJECT_SOURCE_DIR}/include)
+    add_test(NAME test_report_snapshot_cxx_link
+        COMMAND test_report_snapshot_cxx_link)
+    set_tests_properties(test_report_snapshot_cxx_link
+        PROPERTIES
+            PASS_REGULAR_EXPRESSION "report_snapshot_cxx_link_test_ok")
+
     add_executable(test_report_formatter
         report/test_report_formatter.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_formatter.c

--- a/test/cuda_profiler_state_test.cpp
+++ b/test/cuda_profiler_state_test.cpp
@@ -1,0 +1,157 @@
+#include "internal/cuda_profiler_state.h"
+
+#include <atomic>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <vector>
+
+static int
+test_identity_cache_and_non_target_fast_path()
+{
+    PeakCudaProfilerState state(2);
+    const std::vector<std::string> targets = {"wanted"};
+    PeakCudaKernelIdentity first =
+        state.identify(0x1000, false, "unwanted", "unwanted", false, targets);
+    PeakCudaKernelIdentity cached =
+        state.identify(0x1000, false, "wanted", "wanted", false, targets);
+    PeakCudaKernelIdentity driver =
+        state.identify(0x1000, true, "wanted", "wanted", false, targets);
+    PeakCudaKernelIdentity lookup;
+
+    if (first.target_match || cached.target_match ||
+        cached.name != "unwanted" || !driver.target_match ||
+        !state.cached_identity(0x1000, false, &lookup) ||
+        lookup.name != "unwanted" || state.counters().active_slots != 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_bounded_pool_and_drop_accounting()
+{
+    PeakCudaProfilerState state(2);
+
+    if (!state.acquire_slot() || !state.acquire_slot() ||
+        state.acquire_slot()) {
+        return 1;
+    }
+    PeakCudaProfilerCounters counters = state.counters();
+    if (counters.active_slots != 2 || counters.high_water_slots != 2 ||
+        counters.dropped_pool_full != 1) {
+        return 1;
+    }
+    state.release_slot();
+    state.release_slot();
+    state.record_event_create_failure();
+    state.record_timing_error();
+    counters = state.counters();
+    return counters.active_slots != 0 ||
+           counters.dropped_event_create != 1 ||
+           counters.dropped_timing_error != 1;
+}
+
+static int
+test_identity_cache_is_bounded()
+{
+    PeakCudaProfilerState state(4);
+    const std::vector<std::string> targets = {"wanted"};
+
+    state.reset(4, 1);
+    (void)state.identify(0x1, false, "wanted", "wanted", false, targets);
+    PeakCudaKernelIdentity overflow =
+        state.identify(0x2, false, "another", "another", true, targets);
+    PeakCudaProfilerCounters counters = state.counters();
+    return overflow.name != "<unknown>" || !overflow.target_match ||
+           counters.cached_identities != 1 ||
+           counters.dropped_identity_full != 1;
+}
+
+static int
+test_concurrent_stress_remains_bounded()
+{
+    PeakCudaProfilerState state(8);
+    std::atomic<bool> start(false);
+    std::vector<std::thread> workers;
+
+    for (int worker = 0; worker < 8; ++worker) {
+        workers.emplace_back([&state, &start]() {
+            while (!start.load(std::memory_order_acquire)) {
+            }
+            for (int iteration = 0; iteration < 10000; ++iteration) {
+                if (state.acquire_slot()) {
+                    state.release_slot();
+                }
+            }
+        });
+    }
+    start.store(true, std::memory_order_release);
+    for (std::thread& worker : workers) {
+        worker.join();
+    }
+    PeakCudaProfilerCounters counters = state.counters();
+    return counters.active_slots != 0 || counters.high_water_slots > 8;
+}
+
+static int
+fake_launch_with_admission(PeakCudaProfilerState* state,
+                           bool event_create_succeeds,
+                           int* original_calls,
+                           int* event_records)
+{
+    if (!state->acquire_slot()) {
+        ++*original_calls;
+        return 7;
+    }
+    if (!event_create_succeeds) {
+        state->record_event_create_failure();
+        state->release_slot();
+        ++*original_calls;
+        return 7;
+    }
+    ++*event_records;
+    ++*original_calls;
+    ++*event_records;
+    state->release_slot();
+    return 7;
+}
+
+static int
+test_admission_failure_executes_original_once_without_events()
+{
+    PeakCudaProfilerState state(1);
+    int original_calls = 0;
+    int event_records = 0;
+
+    if (!state.acquire_slot() ||
+        fake_launch_with_admission(&state, true, &original_calls,
+                                   &event_records) != 7 ||
+        original_calls != 1 || event_records != 0) {
+        return 1;
+    }
+    state.release_slot();
+    original_calls = 0;
+    event_records = 0;
+    if (fake_launch_with_admission(&state, false, &original_calls,
+                                   &event_records) != 7 ||
+        original_calls != 1 || event_records != 0 ||
+        state.counters().dropped_event_create != 1) {
+        return 1;
+    }
+    return 0;
+}
+
+int
+main()
+{
+    if (test_identity_cache_and_non_target_fast_path() != 0 ||
+        test_bounded_pool_and_drop_accounting() != 0 ||
+        test_identity_cache_is_bounded() != 0 ||
+        test_concurrent_stress_remains_bounded() != 0 ||
+        test_admission_failure_executes_original_once_without_events() != 0) {
+        return 1;
+    }
+    std::puts("cuda_profiler_state_test_ok");
+    return 0;
+}

--- a/test/dlopen_controller/test_gum_module_sync_lifecycle.c
+++ b/test/dlopen_controller/test_gum_module_sync_lifecycle.c
@@ -241,11 +241,16 @@ main(void)
             atomic_store_explicit(&failed, 1, memory_order_release);
         }
         atomic_store_explicit(&quiesce_gate_enabled, 0, memory_order_release);
-        gum_deinit_embedded();
+
+        /*
+         * Process-final Gum teardown may remove the RTLD interceptor.  No
+         * loader may still be executing its trampoline at that point.
+         */
         atomic_store_explicit(&stop, 1, memory_order_release);
         for (int i = 0; i < THREADS; i++) {
             pthread_join(threads[i], NULL);
         }
+        gum_deinit_embedded();
 
         if (atomic_load_explicit(&failed, memory_order_acquire) != 0) {
             fprintf(stderr, "loader failed in lifecycle cycle %d\n", cycle);

--- a/test/report/test_report_snapshot.c
+++ b/test/report/test_report_snapshot.c
@@ -25,6 +25,9 @@ int main(void)
     snapshot->overhead_per_call = 0.25;
     snapshot->dropped_calls = 7;
     snapshot->dropped_threads = 3;
+    peak_report_snapshot_set_transport_overhead(&snapshot->overhead);
+    PeakReportOverhead transport = peak_report_snapshot_get_transport_overhead();
+    assert(transport.valid && transport.elapsed_seconds == 4.0);
 
     assert(!peak_report_snapshot_has_duplicate_names(snapshot));
     assert(peak_report_snapshot_slot_identity_hash(snapshot, 0) != 0);

--- a/test/report/test_report_snapshot_cxx_link.cpp
+++ b/test/report/test_report_snapshot_cxx_link.cpp
@@ -1,0 +1,20 @@
+#include "internal/general_listener/report_snapshot.h"
+
+#include <cassert>
+#include <cstdio>
+
+int
+main()
+{
+    PeakReportSnapshot* snapshot = peak_report_snapshot_create(1);
+    PeakReportMaxima maxima;
+
+    assert(snapshot != nullptr);
+    assert(peak_report_snapshot_set_program(snapshot, "cxx-link"));
+    assert(peak_report_snapshot_set_name(snapshot, 0, "slot"));
+    peak_report_maxima_reset(&maxima);
+    assert(peak_report_calls_per_active_thread(9, 2) == 5);
+    peak_report_snapshot_destroy(snapshot);
+    std::puts("report_snapshot_cxx_link_test_ok");
+    return 0;
+}

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -471,6 +471,14 @@ run_two_rank_case(int port,
         action == TEST_GATHER_PAYLOAD_DROP_FAILURE ||
         action == TEST_GATHER_RECEIPT_FAILURE ||
         action == TEST_GATHER_CONFIRM_DROP_FAILURE;
+    /*
+     * These injected peers can connect, send their configured early bytes,
+     * and close from the TCP backlog before a delayed root reaches accept().
+     * That valid failure path has no userland active connection to observe.
+     */
+    bool early_drop_may_skip_accept =
+        action == TEST_GATHER_DROP_FAILURE ||
+        action == TEST_GATHER_PAYLOAD_DROP_FAILURE;
     bool peer_registration_expected =
         !gather_must_fail ||
         action == TEST_GATHER_CONFIRM_DROP_FAILURE;
@@ -747,7 +755,10 @@ run_two_rank_case(int port,
     memset(&root_telemetry, 0, sizeof(root_telemetry));
     peak_socket_report_test_telemetry_get(&root_telemetry);
     if (root_telemetry.wire_version != 12U ||
-        root_telemetry.root_max_active != 1U ||
+        (!early_drop_may_skip_accept &&
+         root_telemetry.root_max_active != 1U) ||
+        (early_drop_may_skip_accept &&
+         root_telemetry.root_max_active > 1U) ||
         (gather_must_fail &&
          (root_telemetry.root_payload_count !=
               ((action == TEST_GATHER_RECEIPT_FAILURE ||

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -933,6 +933,252 @@ run_dropped_counter_saturation_case(int port)
     return result;
 }
 
+/*
+ * Exercises the production sequence used when both CPU and CUDA reporting are
+ * enabled.  The same two processes complete CPU first, then use CUDA's
+ * independent port pair.  Keeping the child alive across both phases catches
+ * accidental channel state leakage as well as TIME_WAIT port reuse bugs.
+ */
+static int
+run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
+{
+    PeakReportSnapshot* root_cpu = fixture_snapshot(0, false);
+    PeakReportSnapshot* root_cuda = fixture_snapshot(0, false);
+    PeakReportSnapshot* aggregate = NULL;
+    PeakSocketReportSession* session = NULL;
+    PeakSocketReportTestTelemetry telemetry;
+    PeakSocketReportStatus cpu_status = PEAK_SOCKET_REPORT_FAILED;
+    PeakSocketReportStatus cuda_status = PEAK_SOCKET_REPORT_FAILED;
+    char port_text[16];
+    char token_text[64];
+    pid_t child;
+    int child_status = -1;
+    int result = 0;
+
+    if (root_cpu == NULL || root_cuda == NULL) {
+        peak_report_snapshot_destroy(root_cpu);
+        peak_report_snapshot_destroy(root_cuda);
+        return 1;
+    }
+    snprintf(port_text, sizeof(port_text), "%d", port);
+    snprintf(token_text,
+             sizeof(token_text),
+             "socket-sequential-channels-%ld-%d",
+             (long)getpid(),
+             port);
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_HOST", "127.0.0.1", 1);
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_PORT", port_text, 1);
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS", "1500", 1);
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS", "3000", 1);
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_TOKEN", token_text, 1);
+    (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS",
+                 "10000",
+                 1);
+    (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS", "10", 1);
+
+    child = fork();
+    if (child < 0) {
+        peak_report_snapshot_destroy(root_cpu);
+        peak_report_snapshot_destroy(root_cuda);
+        return 1;
+    }
+    if (child == 0) {
+        PeakReportSnapshot* peer_cpu = fixture_snapshot(1, false);
+        PeakReportSnapshot* peer_cuda =
+            fixture_snapshot(1, cuda_schema_mismatch);
+        PeakReportSnapshot* peer_aggregate = NULL;
+        PeakSocketReportSession* peer_session = NULL;
+        PeakSocketReportStatus peer_cpu_status;
+        PeakSocketReportStatus peer_cuda_status;
+
+        set_test_rank(1, 2);
+        if (peer_cpu == NULL || peer_cuda == NULL) {
+            peak_report_snapshot_destroy(peer_cpu);
+            peak_report_snapshot_destroy(peer_cuda);
+            _exit(99);
+        }
+        peer_cpu_status = peak_socket_report_transport_begin_channel(
+            peer_cpu,
+            PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
+            PEAK_SOCKET_REPORT_CHANNEL_CPU,
+            &peer_session,
+            &peer_aggregate);
+        memset(&telemetry, 0, sizeof(telemetry));
+        peak_socket_report_test_telemetry_get(&telemetry);
+        peak_socket_report_transport_abort(peer_session);
+        peak_report_snapshot_destroy(peer_aggregate);
+        if (peer_cpu_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
+            telemetry.wire_version != 12U ||
+            !telemetry.peer_receipt_received ||
+            !telemetry.peer_confirmation_sent ||
+            !telemetry.peer_release_started ||
+            !telemetry.peer_release_decision_received ||
+            !telemetry.peer_release_confirmation_sent ||
+            telemetry.peer_release_decision != TEST_RELEASE_ACK) {
+            peak_report_snapshot_destroy(peer_cpu);
+            peak_report_snapshot_destroy(peer_cuda);
+            _exit(99);
+        }
+        peak_report_snapshot_destroy(peer_cpu);
+
+        peer_aggregate = NULL;
+        peer_session = NULL;
+        peer_cuda_status = peak_socket_report_transport_begin_channel(
+            peer_cuda,
+            PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
+            PEAK_SOCKET_REPORT_CHANNEL_CUDA,
+            &peer_session,
+            &peer_aggregate);
+        memset(&telemetry, 0, sizeof(telemetry));
+        peak_socket_report_test_telemetry_get(&telemetry);
+        peak_socket_report_transport_abort(peer_session);
+        peak_report_snapshot_destroy(peer_aggregate);
+        peak_report_snapshot_destroy(peer_cuda);
+        if ((!cuda_schema_mismatch &&
+             (peer_cuda_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
+              telemetry.wire_version != 12U ||
+              !telemetry.peer_receipt_received ||
+              !telemetry.peer_confirmation_sent ||
+              !telemetry.peer_release_started ||
+              !telemetry.peer_release_decision_received ||
+              !telemetry.peer_release_confirmation_sent ||
+              telemetry.peer_release_decision != TEST_RELEASE_ACK)) ||
+            (cuda_schema_mismatch &&
+             (peer_cuda_status != PEAK_SOCKET_REPORT_FAILED ||
+              telemetry.peer_release_decision == TEST_RELEASE_ACK))) {
+            _exit(99);
+        }
+        _exit(0);
+    }
+
+    set_test_rank(0, 2);
+    cpu_status = peak_socket_report_transport_begin_channel(
+        root_cpu,
+        PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
+        PEAK_SOCKET_REPORT_CHANNEL_CPU,
+        &session,
+        &aggregate);
+    memset(&telemetry, 0, sizeof(telemetry));
+    peak_socket_report_test_telemetry_get(&telemetry);
+    if (cpu_status != PEAK_SOCKET_REPORT_ROOT_PREPARED || session == NULL ||
+        !aggregate_matches(aggregate) || telemetry.wire_version != 12U ||
+        telemetry.root_payload_count != 1U ||
+        telemetry.root_receipt_count != 1U ||
+        telemetry.root_confirmation_count != 1U ||
+        telemetry.root_release_target_count != 1U) {
+        result = 1;
+        peak_socket_report_transport_abort(session);
+        session = NULL;
+    } else if (!peak_socket_report_transport_commit(session)) {
+        result = 1;
+        session = NULL;
+    } else {
+        session = NULL;
+        memset(&telemetry, 0, sizeof(telemetry));
+        peak_socket_report_test_telemetry_get(&telemetry);
+        if (telemetry.root_release_decision != TEST_RELEASE_ACK ||
+            telemetry.root_release_confirmed_count != 1U) {
+            result = 1;
+        }
+    }
+    peak_report_snapshot_destroy(aggregate);
+    aggregate = NULL;
+    if (session == NULL) {
+        int gather_fd = bind_test_tcp_port(port, true);
+        int release_fd = bind_test_tcp_port(port + 1, true);
+
+        if (gather_fd < 0 || release_fd < 0) {
+            result = 1;
+        }
+        if (gather_fd >= 0) {
+            close(gather_fd);
+        }
+        if (release_fd >= 0) {
+            close(release_fd);
+        }
+    }
+
+    if (cpu_status == PEAK_SOCKET_REPORT_ROOT_PREPARED && result == 0) {
+        cuda_status = peak_socket_report_transport_begin_channel(
+            root_cuda,
+            PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
+            PEAK_SOCKET_REPORT_CHANNEL_CUDA,
+            &session,
+            &aggregate);
+        memset(&telemetry, 0, sizeof(telemetry));
+        peak_socket_report_test_telemetry_get(&telemetry);
+        if (cuda_schema_mismatch) {
+            if (cuda_status != PEAK_SOCKET_REPORT_FAILED || session != NULL ||
+                aggregate != NULL || telemetry.root_release_decision ==
+                    TEST_RELEASE_ACK) {
+                result = 1;
+                peak_socket_report_transport_abort(session);
+                session = NULL;
+            }
+        } else if (cuda_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
+                   session == NULL || !aggregate_matches(aggregate) ||
+                   telemetry.wire_version != 12U ||
+                   telemetry.root_payload_count != 1U ||
+                   telemetry.root_receipt_count != 1U ||
+                   telemetry.root_confirmation_count != 1U ||
+                   telemetry.root_release_target_count != 1U) {
+            result = 1;
+            peak_socket_report_transport_abort(session);
+            session = NULL;
+        } else if (!peak_socket_report_transport_commit(session)) {
+            result = 1;
+            session = NULL;
+        } else {
+            session = NULL;
+            memset(&telemetry, 0, sizeof(telemetry));
+            peak_socket_report_test_telemetry_get(&telemetry);
+            if (telemetry.root_release_decision != TEST_RELEASE_ACK ||
+                telemetry.root_release_confirmed_count != 1U) {
+                result = 1;
+            }
+        }
+        peak_report_snapshot_destroy(aggregate);
+        aggregate = NULL;
+        if (session == NULL) {
+            int gather_fd = bind_test_tcp_port(port + 2, true);
+            int release_fd = bind_test_tcp_port(port + 3, true);
+
+            if (gather_fd < 0 || release_fd < 0) {
+                result = 1;
+            }
+            if (gather_fd >= 0) {
+                close(gather_fd);
+            }
+            if (release_fd >= 0) {
+                close(release_fd);
+            }
+        }
+    }
+
+    if (waitpid(child, &child_status, 0) != child ||
+        !WIFEXITED(child_status) || WEXITSTATUS(child_status) != 0) {
+        result = 1;
+    }
+    peak_socket_report_transport_abort(session);
+    peak_report_snapshot_destroy(aggregate);
+    peak_report_snapshot_destroy(root_cpu);
+    peak_report_snapshot_destroy(root_cuda);
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS");
+    (void)unsetenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS");
+    return result;
+}
+
+static int
+run_two_rank_sequential_channels_repeatedly(int port)
+{
+    for (int iteration = 0; iteration < 20; iteration++) {
+        if (run_two_rank_sequential_channels(port, false) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int
 check_release_port_reservation_fails_before_gather(int port)
 {
@@ -1067,6 +1313,23 @@ check_default_port_derivation(void)
     clear_socket_identity_environment();
     clear_rank_environment();
     return failed;
+}
+
+static int
+check_sequential_channel_ports(void)
+{
+    int result;
+
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_PORT", "45100", 1);
+    result = peak_socket_report_test_channel_port(
+                 PEAK_SOCKET_REPORT_CHANNEL_CPU) != 45100 ||
+             peak_socket_report_test_channel_port(
+                 PEAK_SOCKET_REPORT_CHANNEL_CUDA) != 45102;
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_PORT", "65534", 1);
+    result |= peak_socket_report_test_channel_port(
+                  PEAK_SOCKET_REPORT_CHANNEL_CUDA) != -1;
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_PORT");
+    return result;
 }
 
 static int
@@ -1522,7 +1785,7 @@ main(void)
 {
     /*
      * Hold the UDP endpoint paired with a 64-port TCP slot. The test currently
-     * consumes base..base+45, and the kernel lock prevents parallel CTest
+     * consumes base..base+53, and the kernel lock prevents parallel CTest
      * processes, including different UIDs, from choosing the same range.
      */
     int port_lock_fd = -1;
@@ -1549,6 +1812,8 @@ main(void)
                       check_progress_deadline_hard_cap());
     CHECK_SOCKET_CASE("default-port-derivation",
                       check_default_port_derivation());
+    CHECK_SOCKET_CASE("sequential-channel-ports",
+                      check_sequential_channel_ports());
     CHECK_SOCKET_CASE("gather-admission-waves",
                       check_gather_admission_waves());
     CHECK_SOCKET_CASE("single-process", check_single_process_clone());
@@ -1559,6 +1824,12 @@ main(void)
         "release-port-pre-reservation",
         check_release_port_reservation_fails_before_gather(
             base_port + 38));
+    CHECK_SOCKET_CASE(
+        "sequential-cpu-cuda-20x",
+        run_two_rank_sequential_channels_repeatedly(base_port + 46));
+    CHECK_SOCKET_CASE(
+        "sequential-cpu-success-cuda-schema-fallback",
+        run_two_rank_sequential_channels(base_port + 50, true));
     CHECK_SOCKET_CASE(
         "commit",
         run_two_rank_case(base_port, TEST_ROOT_COMMIT, false));

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -484,8 +484,11 @@ run_two_rank_case(int port,
         action == TEST_GATHER_CONFIRM_DROP_FAILURE;
     bool session_allocation_must_fail =
         action == TEST_ROOT_SESSION_ALLOC_FAILURE;
+    bool receipt_failure_barrier =
+        action == TEST_GATHER_RECEIPT_FAILURE;
     char port_text[16];
     char token_text[64];
+    int receipt_barrier_fds[2] = {-1, -1};
     pid_t child;
     int64_t case_started_ms;
     int peer_wait_status = -1;
@@ -689,9 +692,22 @@ run_two_rank_case(int port,
             "PEAK_TEST_OUTPUT_AGGREGATION_CONFIRM_DROP_RANK");
     }
 
+    peak_socket_report_test_receipt_barrier_set(-1, -1);
+    if (receipt_failure_barrier &&
+        socketpair(AF_UNIX, SOCK_STREAM, 0, receipt_barrier_fds) != 0) {
+        peak_report_snapshot_destroy(root);
+        return 1;
+    }
+
     case_started_ms = test_monotonic_ms();
     child = fork();
     if (child < 0) {
+        if (receipt_barrier_fds[0] >= 0) {
+            close(receipt_barrier_fds[0]);
+        }
+        if (receipt_barrier_fds[1] >= 0) {
+            close(receipt_barrier_fds[1]);
+        }
         peak_report_snapshot_destroy(root);
         return 1;
     }
@@ -702,6 +718,13 @@ run_two_rank_case(int port,
         PeakSocketReportStatus peer_status;
         PeakSocketReportTestTelemetry telemetry;
 
+        if (receipt_failure_barrier) {
+            close(receipt_barrier_fds[1]);
+            receipt_barrier_fds[1] = -1;
+            peak_socket_report_test_receipt_barrier_set(
+                receipt_barrier_fds[0], -1);
+            receipt_barrier_fds[0] = -1;
+        }
         set_test_rank(1, 2);
         if (peer == NULL) {
             _exit(99);
@@ -746,6 +769,13 @@ run_two_rank_case(int port,
         _exit((int)peer_status);
     }
 
+    if (receipt_failure_barrier) {
+        close(receipt_barrier_fds[0]);
+        receipt_barrier_fds[0] = -1;
+        peak_socket_report_test_receipt_barrier_set(
+            -1, receipt_barrier_fds[1]);
+        receipt_barrier_fds[1] = -1;
+    }
     set_test_rank(0, 2);
     root_status = peak_socket_report_transport_begin(
         root,
@@ -754,6 +784,10 @@ run_two_rank_case(int port,
         &aggregate);
     memset(&root_telemetry, 0, sizeof(root_telemetry));
     peak_socket_report_test_telemetry_get(&root_telemetry);
+    if (receipt_failure_barrier) {
+        /* Also releases the peer if root failed before receipt preparation. */
+        peak_socket_report_test_receipt_barrier_set(-1, -1);
+    }
     if (root_telemetry.wire_version != 12U ||
         (!early_drop_may_skip_accept &&
          root_telemetry.root_max_active != 1U) ||
@@ -774,6 +808,16 @@ run_two_rank_case(int port,
           root_telemetry.root_confirmation_count != 1U)) ||
         root_telemetry.root_release_target_count !=
             root_telemetry.root_receipt_count) {
+        result = 1;
+    }
+    if (action == TEST_GATHER_RECEIPT_FAILURE &&
+        (!root_telemetry.root_receipt_failure_injected ||
+         root_telemetry.root_max_active != 1U ||
+         root_telemetry.root_payload_count != 1U ||
+         root_telemetry.root_receipt_count != 0U ||
+         root_telemetry.root_confirmation_count != 0U ||
+         root_status != PEAK_SOCKET_REPORT_FAILED || session != NULL ||
+         aggregate != NULL)) {
         result = 1;
     }
     if (gather_must_fail || session_allocation_must_fail) {

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -179,6 +179,16 @@ def main():
     require("test_report_snapshot_cxx_link" in cxx_link_test and
             "test_report_snapshot_cxx_link.cpp" in cxx_link_test,
             "C++ report-snapshot linkage must remain a compiled regression test")
+    socket_test = (repo_root / "test" / "report" /
+                   "test_socket_report_transport.c").read_text(encoding="utf-8")
+    require("bool early_drop_may_skip_accept =" in socket_test and
+            "action == TEST_GATHER_DROP_FAILURE ||" in socket_test and
+            "action == TEST_GATHER_PAYLOAD_DROP_FAILURE;" in socket_test and
+            "(!early_drop_may_skip_accept &&" in socket_test and
+            "root_telemetry.root_max_active != 1U" in socket_test and
+            "(early_drop_may_skip_accept &&" in socket_test and
+            "root_telemetry.root_max_active > 1U" in socket_test,
+            "only immediate gather-drop injections may skip root accept telemetry")
     require("PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_MPI = 1" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2" in cuda,

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -110,8 +110,6 @@ def main():
     cuda = (repo_root / "src" / "cuda_interceptor.cpp").read_text(
         encoding="utf-8")
     general = read_general_listener_source(repo_root)
-    general_header = (repo_root / "include" / "general_listener.h").read_text(
-        encoding="utf-8")
     cuda_header = (repo_root / "include" / "cuda_interceptor.h").read_text(
         encoding="utf-8")
     support_sources = {
@@ -158,12 +156,14 @@ def main():
             "CUDA support hooks must use the Frida-native lookup helper")
     require('gum_find_function("' not in general,
             "general listener special cases must use the Frida-native lookup helper")
-    require("extern \"C\" gpointer peak_general_listener_find_function" not in cuda,
-            "CUDA must not redeclare the general-listener lookup with conflicting linkage")
-    require(re.search(r'#ifdef __cplusplus\s+extern "C" \{\s+#endif\s+'
-                      r'gpointer peak_general_listener_find_function',
-                      general_header) is not None,
-            "general-listener lookup must retain C linkage for CUDA C++ callers")
+    require('#include "general_listener.h"' not in cuda and
+            'extern "C" gpointer peak_general_listener_find_function('
+            'const char* symbol);' in cuda,
+            "CUDA must avoid C-only general-listener declarations and keep its C lookup ABI")
+    require("PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0" in cuda and
+            "PEAK_CUDA_OUTPUT_AGGREGATION_MPI = 1" in cuda and
+            "PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2" in cuda,
+            "CUDA transport mode values must match PeakOutputAggregationMode")
 
     for hook in CUDA_HOOKS:
         require(f'peak_general_listener_find_function("{hook}")' in cuda,
@@ -339,7 +339,7 @@ def main():
             "active-MPI CUDA socket output must require launcher rank metadata")
     mpi_transport = printer.find("peak_mpi_report_transport_reduce(local, &aggregate)")
     mpi_guard = printer.rfind(
-        "if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI)", 0,
+        "if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_MPI)", 0,
         mpi_transport)
     require(mpi_transport != -1 and mpi_guard != -1 and
             mpi_guard < mpi_transport,
@@ -351,9 +351,9 @@ def main():
     require(re.search(r"cuda_interceptor_print\s*\(\s*int is_MPI\s*\)",
                       cuda) is not None and
             "cuda_interceptor_print_with_mpi_job_policy(" in legacy_printer and
-            "is_MPI ? PEAK_OUTPUT_AGGREGATION_MPI : "
-            "PEAK_OUTPUT_AGGREGATION_LOCAL" in legacy_printer and
-            "PEAK_OUTPUT_AGGREGATION_SOCKET" not in legacy_printer,
+            "is_MPI ? PEAK_CUDA_OUTPUT_AGGREGATION_MPI :" in legacy_printer and
+            "PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL" in legacy_printer and
+            "PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET" not in legacy_printer,
             "legacy CUDA reporting ABI must retain boolean MPI/local semantics")
 
     attach = function_body(cuda, "cuda_interceptor_attach")

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -110,6 +110,10 @@ def main():
     cuda = (repo_root / "src" / "cuda_interceptor.cpp").read_text(
         encoding="utf-8")
     general = read_general_listener_source(repo_root)
+    general_header = (repo_root / "include" / "general_listener.h").read_text(
+        encoding="utf-8")
+    cuda_header = (repo_root / "include" / "cuda_interceptor.h").read_text(
+        encoding="utf-8")
     support_sources = {
         "src/dlopen_interceptor.c": ["dlopen"],
         "src/mpi_interceptor.c": ["PMPI_Finalize"],
@@ -154,6 +158,12 @@ def main():
             "CUDA support hooks must use the Frida-native lookup helper")
     require('gum_find_function("' not in general,
             "general listener special cases must use the Frida-native lookup helper")
+    require("extern \"C\" gpointer peak_general_listener_find_function" not in cuda,
+            "CUDA must not redeclare the general-listener lookup with conflicting linkage")
+    require(re.search(r'#ifdef __cplusplus\s+extern "C" \{\s+#endif\s+'
+                      r'gpointer peak_general_listener_find_function',
+                      general_header) is not None,
+            "general-listener lookup must retain C linkage for CUDA C++ callers")
 
     for hook in CUDA_HOOKS:
         require(f'peak_general_listener_find_function("{hook}")' in cuda,
@@ -188,6 +198,14 @@ def main():
             "each wrapper must handle both start and end event-record failures")
     require("launches.reserve(" not in cuda,
             "per-key launch vectors must not reserve beyond the shared pool budget")
+    require(re.search(r'^\s*#\s*define\s+(?:min|max)\s*\(', cuda_header,
+                      re.MULTILINE) is None,
+            "CUDA public header must not poison C++ standard min/max names")
+    require(cuda.find("#include <algorithm>") != -1 and
+            cuda.find("#include <algorithm>") <
+            cuda.find("#include \"cuda_interceptor.h\"") and
+            cuda.count("std::max(") == 5 and cuda.count("std::min(") == 5,
+            "CUDA launch statistics must use standard min/max without macro pollution")
     require("cudaEventRecord(*event, stream) != cudaSuccess" in cuda and
             "cudaEventElapsedTime(&ms" in cuda and
             "!= cudaSuccess" in cuda,

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -112,6 +112,13 @@ def main():
     general = read_general_listener_source(repo_root)
     cuda_header = (repo_root / "include" / "cuda_interceptor.h").read_text(
         encoding="utf-8")
+    c_api_headers = [
+        "include/internal/general_listener/report_maxima.h",
+        "include/internal/general_listener/report_model.h",
+        "include/internal/general_listener/report_snapshot.h",
+        "include/internal/general_listener/socket_report_transport.h",
+        "include/internal/general_listener/mpi_report_transport.h",
+    ]
     support_sources = {
         "src/dlopen_interceptor.c": ["dlopen"],
         "src/mpi_interceptor.c": ["PMPI_Finalize"],
@@ -160,6 +167,18 @@ def main():
             'extern "C" gpointer peak_general_listener_find_function('
             'const char* symbol);' in cuda,
             "CUDA must avoid C-only general-listener declarations and keep its C lookup ABI")
+    for relpath in c_api_headers:
+        header = (repo_root / relpath).read_text(encoding="utf-8")
+        require(re.search(r'#ifdef __cplusplus\s+extern "C" \{\s+#endif',
+                          header) is not None and
+                re.search(r'#ifdef __cplusplus\s+}\s+#endif\s*\n\s*#endif',
+                          header) is not None,
+                f"{relpath} must preserve C linkage for CUDA C++ callers")
+    cxx_link_test = (repo_root / "test" / "CMakeLists.txt").read_text(
+        encoding="utf-8")
+    require("test_report_snapshot_cxx_link" in cxx_link_test and
+            "test_report_snapshot_cxx_link.cpp" in cxx_link_test,
+            "C++ report-snapshot linkage must remain a compiled regression test")
     require("PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_MPI = 1" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2" in cuda,

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -189,6 +189,36 @@ def main():
             "(early_drop_may_skip_accept &&" in socket_test and
             "root_telemetry.root_max_active > 1U" in socket_test,
             "only immediate gather-drop injections may skip root accept telemetry")
+    require("socketpair(AF_UNIX, SOCK_STREAM, 0, receipt_barrier_fds)" in
+            socket_test and
+            "peak_socket_report_test_receipt_barrier_set(" in socket_test and
+            "root_telemetry.root_receipt_failure_injected" in socket_test,
+            "receipt-failure test must synchronize the precise injected phase")
+    socket_transport = (
+        repo_root / "src" / "general_listener" /
+        "socket_report_transport.c").read_text(encoding="utf-8")
+    socket_header = (
+        repo_root / "include" / "internal" / "general_listener" /
+        "socket_report_transport.h").read_text(encoding="utf-8")
+    socket_test_hook_section = socket_header.split(
+        "#ifdef PEAK_ENABLE_TEST_HOOKS", 1)[1].split("#endif", 1)[0]
+    require("root_receipt_failure_injected" in socket_test_hook_section and
+            "peak_socket_report_test_receipt_barrier_set" in
+            socket_test_hook_section,
+            "receipt barrier telemetry and API must remain test-hook-only")
+    receipt_prepare = function_body(socket_transport,
+                                    "peak_socket_gather_prepare_receipt")
+    receipt_write = function_body(socket_transport,
+                                  "peak_socket_gather_write_ready")
+    receipt_peer = function_body(socket_transport,
+                                 "peak_socket_report_peer_begin")
+    require_order(receipt_prepare,
+                  "connection->phase = PEAK_SOCKET_GATHER_SENDING_RECEIPT;",
+                  "peak_socket_test_receipt_barrier_signal_root()")
+    require("peak_socket_test_telemetry.root_receipt_failure_injected = true;"
+            in receipt_write and
+            "peak_socket_test_receipt_barrier_wait_for_root()" in receipt_peer,
+            "receipt failure must be injected only after the test barrier")
     require("PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_MPI = 1" in cuda and
             "PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2" in cuda,

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -182,13 +182,63 @@ def main():
 
     require(cuda.count("PeakCudaInflightGuard in_flight;") == 10,
             "each known CUDA wrapper must use in-flight accounting")
-    require(cuda.count("= peak_cuda_new_event_slot();") == 20,
-            "each known CUDA wrapper must allocate start/end events through the safe helper")
-    require("malloc(sizeof(cudaEvent_t))" not in cuda,
-            "per-launch CUDA events must not use raw malloc")
-    require("cudaEventCreate(start)" not in cuda and
-            "cudaEventCreate(end)" not in cuda,
-            "per-launch CUDA events must use peak_cuda_new_event_slot")
+    require(cuda.count("peak_cuda_acquire_event_pair(&start, &end)") == 10,
+            "each known CUDA wrapper must admit one bounded event-pool lease")
+    require(cuda.count("if (!peak_cuda_record_event(") == 20,
+            "each wrapper must handle both start and end event-record failures")
+    require("launches.reserve(" not in cuda,
+            "per-key launch vectors must not reserve beyond the shared pool budget")
+    require("cudaEventRecord(*event, stream) != cudaSuccess" in cuda and
+            "cudaEventElapsedTime(&ms" in cuda and
+            "!= cudaSuccess" in cuda,
+            "CUDA event record/elapsed failures must be checked")
+    require("record_timing_error" in cuda and
+            "CUDA profiler drops [timing_error]" in cuda,
+            "timing failures must be counted and transported")
+    require("peak_cuda_new_event_slot" not in cuda,
+            "per-launch CUDA event allocation must not bypass the bounded pool")
+    require("PEAK_CUDA_EVENT_POOL_CAPACITY" in cuda and
+            "peak_cuda_event_pool_capacity" in cuda,
+            "CUDA event-pool capacity must be configurable and bounded")
+    require("PeakCudaProfilerState" in cuda and
+            "peak_cuda_profiler_state.acquire_slot()" in cuda,
+            "CUDA wrappers must share bounded identity/admission state")
+    require("*(char**)((size_t)func" not in cuda and
+            "(size_t)func + 8" not in cuda,
+            "Driver CUfunction handles must not be read through private layouts")
+    require('peak_general_listener_find_function("cuFuncGetName")' in cuda,
+            "Driver names must use dynamically-resolved cuFuncGetName")
+    for forbidden_mpi_call in ("MPI_Init(", "MPI_Reduce(", "MPI_Gather(",
+                               "MPI_Gatherv("):
+        require(forbidden_mpi_call not in cuda,
+                f"CUDA interceptor must not own {forbidden_mpi_call} transport")
+
+    kernel_wrappers = CUDA_WRAPPERS[:8]
+    for wrapper in kernel_wrappers:
+        body = function_body(cuda, wrapper)
+        require("peak_cuda_identify_kernel" in body and
+                "if (!identity.target_match)" in body,
+                f"{wrapper} must filter a cached kernel identity")
+        require_order(body, "if (!identity.target_match)",
+                      "peak_cuda_acquire_event_pair(&start, &end)")
+    for wrapper in CUDA_WRAPPERS[8:]:
+        require("peak_cuda_acquire_event_pair(&start, &end)" in
+                function_body(cuda, wrapper),
+                f"{wrapper} must use the shared bounded graph-event pool")
+    for wrapper in CUDA_WRAPPERS:
+        body = function_body(cuda, wrapper)
+        first_guard = body.find("if (!peak_cuda_record_event(")
+        second_guard = body.find("if (!peak_cuda_record_event(", first_guard + 1)
+        require(first_guard != -1 and second_guard != -1,
+                f"{wrapper} must check start and end event records")
+        start_block = body[first_guard:second_guard]
+        end_block = body[second_guard:]
+        require("peak_cuda_release_event_pair(start, end);" in start_block and
+                "return original_" in start_block,
+                f"{wrapper} start-record failure must release and call original once")
+        require("peak_cuda_release_event_pair(start, end);" in end_block and
+                "return result;" in end_block,
+                f"{wrapper} end-record failure must release without rerunning original")
 
     require("std::mutex peak_kernel_event_map_mutex" in cuda,
             "missing kernel event-map mutex")
@@ -204,12 +254,89 @@ def main():
             "CUDA graph maps must use pointer equality")
     require("g_int_equal" not in cuda,
             "CUDA graph pointer maps must not use g_int_equal")
-    require("keys[index] = (CUgraphExec_st*) key;" in cuda,
-            "MPI graph reduction must not dereference direct pointer keys")
-    require("cuda_graph_global_mapping" not in cuda,
-            "MPI graph reduction must not aggregate process-local graph pointers globally")
-    require("cuda_interceptor_print_graph_mpi_result" in cuda,
-            "MPI graph reduction must print rank-qualified graph records")
+    require("Graph executable handles are rank-local" in cuda,
+            "graph records must document their rank-local policy")
+    require("peak_cuda_build_report_snapshot" in cuda and
+            "peak_cuda_render_report_snapshot" in cuda,
+            "CUDA must own an isolated transport snapshot and renderer")
+    cuda_snapshot = function_body(cuda, "peak_cuda_build_report_snapshot")
+    require("snapshot->overhead = peak_report_snapshot_get_transport_overhead();"
+            in cuda_snapshot,
+            "CUDA snapshots must copy the CPU transport-overhead context")
+    require("snapshot->rank_count = 1;" in cuda_snapshot,
+            "CUDA local snapshots must begin with a single local rank")
+    require("peak_socket_report_transport_begin_channel" in cuda and
+            "PEAK_SOCKET_REPORT_CHANNEL_CUDA" in cuda,
+            "CUDA socket output must use its own port channel")
+    require("cuda_interceptor_print_kernel_result" not in cuda,
+            "only the snapshot-based CUDA kernel renderer may remain")
+    general_source = (repo_root / "src/general_listener.c").read_text(
+        encoding="utf-8")
+    source_cmake = (repo_root / "src/CMakeLists.txt").read_text(
+        encoding="utf-8")
+    require("cuda_interceptor_prepare_report_snapshot" not in general_source and
+            "auxiliary" not in general_source,
+            "CPU report snapshots must not depend on CUDA rows")
+    require("if (CUDA_FOUND OR CUDAToolkit_FOUND)" in source_cmake and
+            "cuda_profiler_state.cpp" in source_cmake,
+            "CUDA profiling state must remain an optional CUDA-only object")
+    cpu_capture = function_body(
+        general_source, "peak_general_listener_print_with_mpi_job_policy")
+    require_order(cpu_capture,
+                  "PeakReportOverhead local_report =",
+                  "peak_general_listener_local_report_overhead(sum_num_calls)",
+                  "peak_report_snapshot_set_transport_overhead(&local_report)",
+                  "peak_general_listener_build_report_snapshot(")
+
+    cuda_mpi_gate = peak.find(
+        "cuda_interceptor_print_with_mpi_job_policy(\n"
+        "            (mpi_reducer_failed_closed ||")
+    cuda_failed_closed_recheck = peak.find(
+        "mpi_reducer_failed_closed = found_MPI &&\n"
+        "            peak_general_listener_mpi_reducer_failed_closed();",
+        cuda_mpi_gate + 1)
+    report_release_gate = peak.find(
+        "if (report_release_gate_allowed && !mpi_reducer_failed_closed)",
+        cuda_failed_closed_recheck + 1)
+    require(cuda_mpi_gate != -1 and
+            "output_mode == PEAK_OUTPUT_AGGREGATION_MPI" in
+            peak[cuda_mpi_gate:cuda_failed_closed_recheck] and
+            "!used_mpi_aggregation" in
+            peak[cuda_mpi_gate:cuda_failed_closed_recheck],
+            "CUDA MPI output must be gated on CPU MPI aggregation success")
+    require(cuda_failed_closed_recheck > cuda_mpi_gate and
+            report_release_gate > cuda_failed_closed_recheck,
+            "CUDA MPI failed-closed state must be rechecked before report release")
+
+    printer = function_body(cuda, "cuda_interceptor_print_with_mpi_job_policy")
+    require(re.search(
+                r"cuda_interceptor_print_with_mpi_job_policy\s*\(\s*"
+                r"int aggregation_mode,\s*int active_mpi_job\s*\)", cuda)
+            is not None,
+            "CUDA policy reporting must receive explicit active-MPI context")
+    require("PeakSocketReportRankSource socket_rank_source = active_mpi_job\n"
+            "                ? PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED\n"
+            "                : PEAK_SOCKET_REPORT_RANK_MPI_OR_ENV;" in printer and
+            "local, socket_rank_source," in printer,
+            "active-MPI CUDA socket output must require launcher rank metadata")
+    mpi_transport = printer.find("peak_mpi_report_transport_reduce(local, &aggregate)")
+    mpi_guard = printer.rfind(
+        "if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI)", 0,
+        mpi_transport)
+    require(mpi_transport != -1 and mpi_guard != -1 and
+            mpi_guard < mpi_transport,
+            "CUDA local or failed-closed output must not enter MPI transport")
+    require("found_MPI ? TRUE : FALSE" in
+            peak[cuda_mpi_gate:cuda_failed_closed_recheck],
+            "CUDA output must receive the active-MPI policy from peak.c")
+    legacy_printer = function_body(cuda, "cuda_interceptor_print")
+    require(re.search(r"cuda_interceptor_print\s*\(\s*int is_MPI\s*\)",
+                      cuda) is not None and
+            "cuda_interceptor_print_with_mpi_job_policy(" in legacy_printer and
+            "is_MPI ? PEAK_OUTPUT_AGGREGATION_MPI : "
+            "PEAK_OUTPUT_AGGREGATION_LOCAL" in legacy_printer and
+            "PEAK_OUTPUT_AGGREGATION_SOCKET" not in legacy_printer,
+            "legacy CUDA reporting ABI must retain boolean MPI/local semantics")
 
     attach = function_body(cuda, "cuda_interceptor_attach")
     require(attach.count("hook_replace_check != GUM_REPLACE_OK") == 10,
@@ -240,6 +367,11 @@ def main():
             "CUDA physical detach must retain Gum trampoline state")
     require("cuda_interceptor = NULL" not in detach,
             "CUDA physical detach must keep interceptor state referenced")
+    active_guard = detach.find("if (active_cuda_wrappers != 0)")
+    drain = detach.find("peak_cuda_drain_kernel_event_map(FALSE)")
+    require(active_guard != -1 and drain != -1 and active_guard < drain and
+            "return;" in detach[active_guard:drain],
+            "active CUDA wrappers must retain pool/maps for a safe cleanup retry")
 
     clear_hooks = function_body(cuda, "peak_cuda_clear_hook_pointers")
     for hook in [
@@ -267,13 +399,14 @@ def main():
     require("free(launch.start_event)" not in sync,
             "sync must drain through ownership helpers, not free inline")
 
-    printer = function_body(cuda, "cuda_interceptor_print")
     require_order(
         printer,
         "std::lock_guard<std::mutex> lifecycle_lock",
         "peak_cuda_accepting_events.store(false",
         "cuda_sync_kernel_event()",
     )
+    require("cuda_interceptor_print_kernel_result" not in printer,
+            "kernel output must flow through the shared snapshot transport")
 
     print("cuda_interceptor_consistency_ok")
     return 0

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1016,7 +1016,8 @@ def check_final_report_snapshot_order(repo_root):
         early_report_position + 1,
     )
     report_position = early_report_position
-    cuda_position = fini.find("cuda_interceptor_print(", report_position)
+    cuda_position = fini.find(
+        "cuda_interceptor_print_with_mpi_job_policy(", report_position)
     finalize_permission_position = fini.find(
         "mpi_interceptor_set_real_finalize_allowed(", report_position
     )


### PR DESCRIPTION
Closes #65

## Summary

- cache CUDA Runtime and Driver kernel identity using supported APIs, with a bounded identity table and `<unknown>` fallback
- reject cached non-target kernels before CUDA event admission
- replace per-launch CUDA event allocation with a fixed-capacity shared pool and explicit drop counters
- check event creation, record, and elapsed-time failures without invoking the original launch twice
- carry CUDA kernel snapshots through isolated local, MPI, and socket report transports
- keep CPU report schemas stable when CUDA kernel sets differ across ranks
- reserve a separate socket port pair for the sequential CUDA report channel
- retain bounded CUDA state when detach observes an active wrapper
- keep the CUDA C++ translation unit free of public `min`/`max` macros and
  C-only `<stdatomic.h>` declarations, as required by NVHPC and GCC/CUDA builds
- give report model/snapshot/socket/MPI C APIs explicit C++ linkage guards and
  compile a mixed C/C++ regression so CUDA cannot retain mangled unresolved
  `peak_report_*` symbols
- make the socket early-drop telemetry test scheduler-correct and add a
  test-only phase barrier that proves receipt-failure injection occurs only
  after the full payload is merged, without changing production transport
  behavior or fail-closed protocol assertions
- fix a main-existing Gum lifecycle test teardown race by stopping and joining
  synthetic loader threads before the test-only Gum library deinitialization;
  production Gum and detach/reattach behavior are unchanged
- track CUPTI Activity API migration separately in #70

## Review and detach/reattach redline

- implementation completed by GPT-5.6 Terra High
- accepted by the primary review
- independent GPT-5.6 Sol High exact-head review: ACCEPT, no P0-P3 findings
- exact candidate head: `6eb1dcfc54379b33a9f71afba2d3f9278c391235`
- `src/detach_controller.c`, `src/pthread_listener.c`, `include/detach_controller.h`, and `include/general_listener.h` are byte-identical to `origin/main`
- detach lifecycle invariant test passes; the detach/reattach FSM and its transitions are unchanged

## Local validation

- focused CTest suite: 8/8
- mixed C/C++ report-link regression and symbol audit: PASS (unmangled C
  references; no unresolved `peak_report_*` symbols)
- real forked two-rank socket sequence: CPU aggregate/commit/release followed by CUDA aggregate/commit/release, repeated 20 times
- CUDA-only schema mismatch regression: CPU aggregation remains successful; only the CUDA channel falls back
- Clang ASan/UBSan/LeakSanitizer for bounded state, report context, and the full forked socket transport
- Clang TSan bounded-state stress
- socket transport repeated 20/20 across implementation, primary, and
  independent review runs; the receipt-failure case strictly proves
  `injected=true`, payload=1, receipt=0, confirmation=0, root/peer failure,
  null session/aggregate, and port rebind
- test-hook-disabled preprocessing is byte-identical to the previous
  production transport, and the production object exports no barrier or
  telemetry symbols
- Gum lifecycle teardown regression: fresh Clang Release and ASan/UBSan;
  implementation Release serial 1000/1000, Release 16-way x1000, and
  ASan/UBSan 16-way x200; primary Release 16-way x1000 and ASan/UBSan
  16-way x200; independent Sol High Release 2000 and ASan/UBSan 600, all
  zero failures
- strict Clang `-Wall -Wextra -Werror`
- non-CUDA production DSO builds and `ldd -r` reports no unresolved symbols
- `git diff --check`

## GitHub CI

- exact-head GitHub CI: 12/12 successful
- GCC and Clang Release builds
- MPICH, OpenMPI, and Intel MPI jobs
- detach benchmarks
- pthread slot registry TSan job

## Vista and Frontera stress

- Vista CPU/FSM job `878938`: `COMPLETED 0:0`, 144 threads; slot reuse
  50/50, six lifecycle/FSM regressions 6/6, helper/signal/stale stress 8/8
  each; exact-head pass marker
- Frontera CPU/FSM job `7882637`: `COMPLETED 0:0`, 56 threads; the same
  slot-reuse, lifecycle/FSM, helper/signal/stale gates all pass; exact-head
  pass marker
- Vista GPU job `878939`: 144 threads, 7,200 calls, five launch paths,
  bounded-pool drops (`pool_full=7136`), target filtering, ABI linkage, and
  `timing_error=0`; exact-head pass marker
- Frontera GPU job `7882640`: 64 threads, 3,200 calls, the same functional,
  bounded-pool, target-filter, and ABI gates; `pool_full=3136`,
  `timing_error=0`; exact-head pass marker
- exact-head Intel MPI artifact job `7882643`: `COMPLETED 0:0`;
  source/lib/helper/provenance hashes locked for final MILC

## 1024-node MILC certification

- Frontera job `7882675`: `COMPLETED 0:0`, elapsed `00:24:01`
- `large` partition, 1024 nodes, 4096 ranks, 12 OpenMP threads per rank
- immutable exact-head artifact and source/lib/helper/provenance hashes matched
  before launch
- backend-repeat arms `B0/A1/S1/A2/S2/A3/S3/Bend`: 8/8
  `launcher_rc=0`, `validation=pass`
- matrix summary: `failures=0`, `run_complete=1`
- B0 and Bend baselines contain no PEAK output and no PEAK CSV
- every PEAK arm produced exactly one CSV, exactly one PEAK completion marker,
  and exactly one MILC `RUNNING COMPLETED`
- every PEAK arm reported
  `failed control windows: windows=0 snapshot_valid=1`
- lifecycle coverage for every PEAK arm:
  `detached_targets=28 reattached_targets=27 revisited_targets=20`
- no fatal, hang, unsafe-state, or timeout marker was detected

An earlier identical run, job `7882649`, completed MILC and PEAK output on all
4096 ranks in every arm but received one isolated TACC/Intel MPI launcher
status 255 after A3. The strict runner correctly rejected that run. Terra High
and independent Sol High audits found no PR #71 non-CUDA exit or finalize path
that could produce the status; the unchanged full matrix was rerun rather than
relaxing validation or selecting a substitute case.
