### PR TITLE
Centralize numeric environment parsing with schema validation

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -5,6 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libopenblas-dev
       - run: cmake -S . -B build-tsan -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_TESTS=ON -DPEAK_FETCH_DEPS=ON -DBUILD_CUDA_PROFILE=OFF -DPEAK_ENABLE_MPI=OFF -DPEAK_ENABLE_TSAN_TESTS=ON
       - run: cmake --build build-tsan --target test_pthread_slot_registry
       - run: ctest --test-dir build-tsan --output-on-failure -R '^test_pthread_slot_registry$'

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ full output and teardown behavior.
 | `PEAK_HB_K_ERR`, `PEAK_HB_K_RATE` | Adaptive response coefficients. Defaults: `3.0` and `0.8`. |
 | `PEAK_HB_EMA_A` | Growth-rate EMA alpha in `(0, 1]`. Default: `0.3`. |
 
+Numeric overhead-control values must consume the complete value and be finite.
+Invalid present values emit one warning and use their documented default.
+`PEAK_COST` and the overhead ratios are nonnegative (zero keeps their existing
+disable behavior); heartbeat sleep bounds are positive, and a maximum below an
+accepted minimum is raised to that minimum. Global hysteresis requires a
+detach factor of at least `1`, a reattach factor in `(0, 1]`, and the reattach
+factor strictly below the detach factor; a conflicting reattach value uses its
+default. `PEAK_REATTACH_COOLDOWN_MS=60000` remains a policy default, not a
+safety requirement.
+
 For runtime behavior, accounting, and tuning, see
 [Heartbeat mechanism and runtime policy](docs/heartbeat.md).
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ in detail.
 | `PEAK_TEXT_OUTPUT` | Force or suppress the human-readable stderr report. |
 | `PEAK_VERBOSITY` | `silent`, `report`/`quiet`, `warn`, `info`, or `debug`; numeric levels `0` through `4` are also accepted. |
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
-| `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count. |
+| `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. |
 
 ### MPI Output
 
@@ -309,6 +309,7 @@ semantics, module lifetime, and supported boundaries.
 | `PEAK_GPU_TARGET` | Comma-separated demangled base kernel names. |
 | `PEAK_GPU_TARGET_FILE` | File containing one GPU kernel name per line. |
 | `PEAK_GPU_MONITOR_ALL` | Profile every observed GPU kernel. |
+| `PEAK_CUDA_EVENT_POOL_CAPACITY` | CUDA event-pool capacity. Default: `256` events; accepts `1` through `65536`. |
 | `PEAK_MEMORY_PROFILE` | Enable experimental memory allocation profiling for selected CPU targets. |
 | `PEAK_MEMORY_TRACK_ALL` | Track all allocation events instead of filtering by target backtraces. |
 | `PEAK_MEMLOG_PATH` | Memory CSV output prefix. Default: `./peak_memlog`. |

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ full output and teardown behavior.
 
 Numeric overhead-control values must consume the complete value and be finite.
 Invalid present values emit one warning and use their documented default.
-`PEAK_COST` and the overhead ratios are nonnegative (zero keeps their existing
-disable behavior); heartbeat sleep bounds are positive, and a maximum below an
+`PEAK_COST` and the overhead ratios are nonnegative; a zero ratio remains an
+immediate threshold for the existing `ratio > threshold` comparison. Heartbeat
+sleep bounds are positive, and a maximum below an
 accepted minimum is raised to that minimum. Global hysteresis requires a
 detach factor of at least `1`, a reattach factor in `(0, 1]`, and the reattach
 factor strictly below the detach factor; a conflicting reattach value uses its

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -538,14 +538,18 @@ The defaults below describe the current implementation.
 | `PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS` | `180000` | Baseline post-publication gate timeout. A path that attempted socket publication automatically raises the effective timeout to at least the peer release budget plus two socket-phase margins; MPI and rank-local paths retain this baseline. |
 | `MPI_LOCALNRANKS`, `OMPI_COMM_WORLD_LOCAL_SIZE`, `MV2_COMM_WORLD_LOCAL_SIZE`, `PMI_LOCAL_SIZE` | `1` fallback | Local rank count for reattach admission and diagnostic risk reporting. |
 
-All numeric values above require complete, finite input. A present invalid value
-emits one warning and uses its documented fallback. `PEAK_MAX_NUM_THREADS=0`
-uses one slot and values above `4096` clamp to `4096`; an invalid
-`PEAK_MEMLOG_CHUNK_EVENTS` disables memory logging. Sleep bounds must be
-positive; when the resolved maximum is below the accepted minimum, the maximum
-falls back to the minimum. The global detach multiplier is at least `1`, the
-reattach multiplier is in `(0, 1]`, and the reattach multiplier must remain
-below the detach multiplier; a conflict falls back to the reattach default.
+PEAK numeric controls above require complete, finite input. A present invalid
+PEAK value emits one warning and uses its documented fallback.
+`PEAK_MAX_NUM_THREADS=0` uses one slot and values above `4096` clamp to
+`4096`; an invalid `PEAK_MEMLOG_CHUNK_EVENTS` disables memory logging. The
+launcher-provided `MPI_LOCALNRANKS`, `OMPI_COMM_WORLD_LOCAL_SIZE`,
+`MV2_COMM_WORLD_LOCAL_SIZE`, and `PMI_LOCAL_SIZE` values are metadata rather
+than PEAK controls; missing or invalid values use the rank-count fallback
+without a configuration warning. Sleep bounds must be positive; when the
+resolved maximum is below the accepted minimum, the maximum falls back to the
+minimum. The global detach multiplier is at least `1`, the reattach multiplier
+is in `(0, 1]`, and the reattach multiplier must remain below the detach
+multiplier; a conflict falls back to the reattach default.
 The cooldown default is policy only: `PEAK_REATTACH_COOLDOWN_MS=60000` is not a
 new safety precondition.
 

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -522,6 +522,15 @@ The defaults below describe the current implementation.
 | `PEAK_HB_K_ERR` | `3.0` | Adaptive-sleep error gain. |
 | `PEAK_HB_K_RATE` | `0.8` | Gain on the EMA of global profile-pressure growth. |
 | `PEAK_HB_EMA_A` | `0.3` | Adaptive-sleep EMA weight. Invalid values outside `(0, 1]` reset to `0.3`. |
+
+All numeric values above require complete, finite input. A present invalid value
+emits one warning and uses its documented default. Sleep bounds must be
+positive; when the resolved maximum is below the accepted minimum, the maximum
+falls back to the minimum. The global detach multiplier is at least `1`, the
+reattach multiplier is in `(0, 1]`, and the reattach multiplier must remain
+below the detach multiplier; a conflict falls back to the reattach default.
+The cooldown default is policy only: `PEAK_REATTACH_COOLDOWN_MS=60000` is not a
+new safety precondition.
 | `PEAK_MAX_NUM_THREADS` | `2 * online CPUs` | Size of per-listener thread slots used for callback counters. |
 | `PEAK_COST` | `0` | Enables count-based detach using calibrated callback cost when positive. |
 | `PEAK_DETACH_COUNT` | unset | Overrides count-based detach threshold when set to a positive integer. |

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -539,7 +539,9 @@ The defaults below describe the current implementation.
 | `MPI_LOCALNRANKS`, `OMPI_COMM_WORLD_LOCAL_SIZE`, `MV2_COMM_WORLD_LOCAL_SIZE`, `PMI_LOCAL_SIZE` | `1` fallback | Local rank count for reattach admission and diagnostic risk reporting. |
 
 All numeric values above require complete, finite input. A present invalid value
-emits one warning and uses its documented default. Sleep bounds must be
+emits one warning and uses its documented fallback. `PEAK_MAX_NUM_THREADS=0`
+uses one slot and values above `4096` clamp to `4096`; an invalid
+`PEAK_MEMLOG_CHUNK_EVENTS` disables memory logging. Sleep bounds must be
 positive; when the resolved maximum is below the accepted minimum, the maximum
 falls back to the minimum. The global detach multiplier is at least `1`, the
 reattach multiplier is in `(0, 1]`, and the reattach multiplier must remain

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -522,15 +522,6 @@ The defaults below describe the current implementation.
 | `PEAK_HB_K_ERR` | `3.0` | Adaptive-sleep error gain. |
 | `PEAK_HB_K_RATE` | `0.8` | Gain on the EMA of global profile-pressure growth. |
 | `PEAK_HB_EMA_A` | `0.3` | Adaptive-sleep EMA weight. Invalid values outside `(0, 1]` reset to `0.3`. |
-
-All numeric values above require complete, finite input. A present invalid value
-emits one warning and uses its documented default. Sleep bounds must be
-positive; when the resolved maximum is below the accepted minimum, the maximum
-falls back to the minimum. The global detach multiplier is at least `1`, the
-reattach multiplier is in `(0, 1]`, and the reattach multiplier must remain
-below the detach multiplier; a conflict falls back to the reattach default.
-The cooldown default is policy only: `PEAK_REATTACH_COOLDOWN_MS=60000` is not a
-new safety precondition.
 | `PEAK_MAX_NUM_THREADS` | `2 * online CPUs` | Size of per-listener thread slots used for callback counters. |
 | `PEAK_COST` | `0` | Enables count-based detach using calibrated callback cost when positive. |
 | `PEAK_DETACH_COUNT` | unset | Overrides count-based detach threshold when set to a positive integer. |
@@ -546,6 +537,15 @@ new safety precondition.
 | `PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS` | `gather hard cap + 2 × socket phase timeout` | Peer-side end-to-end budget spanning gather, report publication, and confirmed release; smaller values are raised. |
 | `PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS` | `180000` | Baseline post-publication gate timeout. A path that attempted socket publication automatically raises the effective timeout to at least the peer release budget plus two socket-phase margins; MPI and rank-local paths retain this baseline. |
 | `MPI_LOCALNRANKS`, `OMPI_COMM_WORLD_LOCAL_SIZE`, `MV2_COMM_WORLD_LOCAL_SIZE`, `PMI_LOCAL_SIZE` | `1` fallback | Local rank count for reattach admission and diagnostic risk reporting. |
+
+All numeric values above require complete, finite input. A present invalid value
+emits one warning and uses its documented default. Sleep bounds must be
+positive; when the resolved maximum is below the accepted minimum, the maximum
+falls back to the minimum. The global detach multiplier is at least `1`, the
+reattach multiplier is in `(0, 1]`, and the reattach multiplier must remain
+below the detach multiplier; a conflict falls back to the reattach default.
+The cooldown default is policy only: `PEAK_REATTACH_COOLDOWN_MS=60000` is not a
+new safety precondition.
 
 Several backend safety variables, such as `PEAK_SAFE_DETACH_MODE`,
 `PEAK_DETACH_BACKEND`, `PEAK_DETACH_HELPER`, signal reservation controls, and

--- a/include/internal/general_listener/runtime_config.h
+++ b/include/internal/general_listener/runtime_config.h
@@ -73,11 +73,6 @@ peak_general_listener_report_timeout_budget_for_rank_count(
 bool peak_general_listener_parse_detach_count_override(
     unsigned long* count_out);
 
-/** Reads an unsigned environment value or returns @p default_value. */
-unsigned int peak_general_listener_parse_uint_env_default(
-    const char* name,
-    unsigned int default_value);
-
 /**
  * Snapshots launcher-local rank metadata before controller threads start.
  *

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -155,6 +155,13 @@ void peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,
                                                  int root_signal_fd);
 
 /**
+ * Configures a test-only root-listener readiness signal.  The root closes the
+ * descriptor after writing one byte once both transport listeners and gather
+ * allocations are ready; passing -1 clears a pending signal.
+ */
+void peak_socket_report_test_listener_ready_set(int root_signal_fd);
+
+/**
  * Returns the default socket aggregation port for the current shared
  * launcher identity.
  */

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -155,9 +155,10 @@ void peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,
                                                  int root_signal_fd);
 
 /**
- * Configures a test-only root-listener readiness signal.  The root closes the
- * descriptor after writing one byte once both transport listeners and gather
- * allocations are ready; passing -1 clears a pending signal.
+ * Configures a test-only root-listener readiness signal.  The root writes one
+ * byte once both transport listeners and gather allocations are ready, then
+ * retains the descriptor until a peer connection is accepted; passing -1
+ * clears a pending signal.
  */
 void peak_socket_report_test_listener_ready_set(int root_signal_fd);
 

--- a/include/utils/env_parser.h
+++ b/include/utils/env_parser.h
@@ -57,6 +57,10 @@ typedef struct {
 /** Parses a decimal unsigned value according to @p schema. */
 unsigned long long peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema);
 
+/** Validates a decimal unsigned value without emitting a warning. */
+bool peak_parse_env_unsigned_checked(const PeakEnvUnsignedSchema* schema,
+                                     unsigned long long* value_out);
+
 /** Parses a finite real value according to @p schema. */
 double peak_parse_env_real(const PeakEnvRealSchema* schema);
 

--- a/include/utils/env_parser.h
+++ b/include/utils/env_parser.h
@@ -3,177 +3,69 @@
 
 /**
  * @file env_parser.h
- * @brief Scalar environment-value parsing for PEAK.
+ * @brief Validated numeric environment configuration for PEAK.
  */
 
-#include <assert.h>
-#include <errno.h>
-#include <limits.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "target_config.h"
+#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * @brief Parses a single-precision value from an environment variable.
- *
- * Parsing uses strtof() and requires the complete string to be consumed. The
- * implementation does not check @c errno or clamp the result. An empty string
- * therefore produces 0.0; fully consumed NaN and infinity spellings, including
- * overflow results, are returned unchanged.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The parsed value, or 0.0 if the variable is unset or has unconsumed
- *         characters.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-float parse_env_to_float(const char* env_var);
+typedef struct {
+    float detach_cost;
+    unsigned int heartbeat_interval_us;
+    unsigned int hibernation_cycle;
+    float target_overhead_ratio;
+    float global_overhead_ratio;
+    float global_detach_factor;
+    float global_reattach_factor;
+    unsigned long long pause_timeout_ns;
+    unsigned long long sig_cont_timeout_ns;
+    unsigned int heartbeat_min_us;
+    unsigned int heartbeat_max_us;
+    double heartbeat_error_gain;
+    double heartbeat_rate_gain;
+    double heartbeat_ema_alpha;
+} PeakRuntimeNumericConfig;
+
+typedef struct {
+    const char* name;
+    const char* unit;
+    unsigned long long fallback;
+    unsigned long long minimum;
+    unsigned long long maximum;
+    bool zero_allowed;
+} PeakEnvUnsignedSchema;
+
+typedef struct {
+    const char* name;
+    const char* unit;
+    double fallback;
+    double minimum;
+    double maximum;
+    bool zero_allowed;
+} PeakEnvRealSchema;
+
+/** Parses a decimal unsigned value according to @p schema. */
+unsigned long long peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema);
+
+/** Parses a finite real value according to @p schema. */
+double peak_parse_env_real(const PeakEnvRealSchema* schema);
 
 /**
- * @brief Parses a single-precision ratio from an environment variable.
+ * Parses PEAK's numeric heartbeat and detach configuration.
  *
- * Parsing uses strtof() and requires the complete string to be consumed. The
- * result is not clamped and @c errno is not checked. Because the implementation
- * does not require at least one digit, an empty value returns 0.0 rather than
- * the fallback. Fully consumed NaN and infinity spellings, including overflow
- * results, are returned unchanged.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The parsed ratio, or 0.1 if the variable is unset or has unconsumed
- *         characters.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
+ * Each variable is parsed at its widest representation before being checked
+ * against its schema and narrowed. Invalid present values emit one warning and
+ * use the stated schema fallback. A conflicting heartbeat maximum falls back
+ * to the accepted minimum, and a conflicting reattach hysteresis factor falls
+ * back to its default.
  */
-float parse_env_to_float_ratio(const char* env_var);
+PeakRuntimeNumericConfig peak_parse_runtime_numeric_config(void);
 
-/**
- * @brief Parses the single-precision detach factor from an environment variable.
- *
- * Parsing uses strtof() and requires the complete string to be consumed. The
- * result is not clamped and @c errno is not checked. An empty value returns
- * 0.0 because the implementation does not require at least one digit. Fully
- * consumed NaN and infinity spellings, including overflow results, are returned.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The parsed factor, or 1.2 if the variable is unset or has unconsumed
- *         characters.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-float parse_env_to_float_detach_factor(const char* env_var);
-
-/**
- * @brief Parses the single-precision reattach factor from an environment variable.
- *
- * Parsing uses strtof() and requires the complete string to be consumed. The
- * result is not clamped and @c errno is not checked. An empty value returns
- * 0.0 because the implementation does not require at least one digit. Fully
- * consumed NaN and infinity spellings, including overflow results, are returned.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The parsed factor, or 0.85 if the variable is unset or has unconsumed
- *         characters.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-float parse_env_to_float_reattach_factor(const char* env_var);
-
-/**
- * @brief Parses seconds and converts them to microseconds.
- *
- * A missing, empty, negative, partially parsed, or strtod() range-error value
- * returns 100000 microseconds. Valid values above the representable range are
- * clamped to UINT_MAX; this includes positive infinity. Negative infinity
- * falls back. Other valid values are multiplied by 1e6 and truncated toward
- * zero when converted to unsigned int.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The interval in microseconds, or 100000 microseconds (0.1 seconds)
- *         when parsing fails.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- * @pre The environment value does not parse as NaN; the current implementation
- *      would otherwise perform an undefined floating-to-unsigned conversion.
- */
-unsigned int parse_env_to_time(const char* env_var);
-
-/**
- * @brief Parses an unsigned integer interval from an environment variable.
- *
- * Parsing uses strtoul() with base 10. An unset value, a range error, or
- * unconsumed characters returns 50. An empty value returns 0 because this
- * function does not require at least one digit. Otherwise strtoul() semantics,
- * including optional sign, apply; the converted result is not clamped before
- * it is first narrowed to unsigned int. Values between UINT_MAX and ULONG_MAX,
- * and accepted negative spellings, therefore follow unsigned narrowing rather
- * than selecting the fallback.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The converted interval, or 50 for the fallback cases above.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-unsigned int parse_env_to_interval(const char* env_var);
-
-/**
- * @brief Parses an unsigned integer with a caller-supplied fallback.
- *
- * Parsing uses strtoul() with base 10 and requires at least one character and
- * complete consumption. Range errors and values above UINT_MAX return the
- * fallback rather than being clamped.
- *
- * @param[in] env_var Name of the environment variable.
- * @param[in] default_value Value returned for an unset or invalid value.
- * @return The parsed unsigned integer, or @p default_value on failure.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-unsigned int parse_env_to_uint_default(const char* env_var, unsigned int default_value);
-
-/**
- * @brief Parses a double with a caller-supplied fallback.
- *
- * Parsing uses strtod(), requires at least one character and complete
- * consumption, and rejects range errors. Accepted values are not clamped;
- * literal NaN and positive or negative infinity are returned, while overflow
- * or underflow that sets @c ERANGE selects the fallback.
- *
- * @param[in] env_var Name of the environment variable.
- * @param[in] default_value Value returned for an unset or invalid value.
- * @return The parsed value, or @p default_value on failure.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
-double parse_env_to_double_default(const char* env_var, double default_value);
-
-/**
- * @brief Parses seconds and converts them to nanoseconds.
- *
- * A missing, empty, negative, partially parsed, or strtod() range-error value
- * returns 10000000 nanoseconds. Valid values are multiplied by 1e9 and
- * truncated toward zero. Unlike parse_env_to_time(), this function does not
- * clamp large values. Negative infinity falls back. NaN, positive infinity,
- * and finite products outside the unsigned long long range are unsupported.
- *
- * @param[in] env_var Name of the environment variable.
- * @return The interval in nanoseconds, or 10000000 nanoseconds (0.01 seconds)
- *         when parsing fails.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- * @pre A successfully parsed value is nonnegative and finite, and its product
- *      with 1e9 is representable as an unsigned long long; otherwise the
- *      current implementation may perform an undefined conversion.
- */
-unsigned long long parse_env_to_post_interval(const char* env_var);
-
-/**
- * @brief Parses a boolean environment variable.
- *
- * Only @c "true" (case-insensitive) and the exact string @c "1" produce true.
- * Unset, empty, and all other values produce false.
- *
- * @param[in] env_var Name of the environment variable.
- * @return true for the two accepted forms; false otherwise.
- * @pre @p env_var is a non-NULL, null-terminated environment-variable name.
- */
+/** Parses a boolean environment variable. */
 bool parse_env_to_bool(const char* env_var);
 
 #ifdef __cplusplus

--- a/include/utils/env_parser.h
+++ b/include/utils/env_parser.h
@@ -14,6 +14,10 @@ extern "C" {
 #endif
 
 typedef struct {
+    unsigned char emitted;
+} PeakEnvWarningState;
+
+typedef struct {
     float detach_cost;
     unsigned int heartbeat_interval_us;
     unsigned int hibernation_cycle;
@@ -37,6 +41,7 @@ typedef struct {
     unsigned long long minimum;
     unsigned long long maximum;
     bool zero_allowed;
+    PeakEnvWarningState* warning_emitted;
 } PeakEnvUnsignedSchema;
 
 typedef struct {
@@ -46,6 +51,7 @@ typedef struct {
     double minimum;
     double maximum;
     bool zero_allowed;
+    PeakEnvWarningState* warning_emitted;
 } PeakEnvRealSchema;
 
 /** Parses a decimal unsigned value according to @p schema. */

--- a/include/utils/env_parser.h
+++ b/include/utils/env_parser.h
@@ -42,6 +42,7 @@ typedef struct {
     unsigned long long maximum;
     bool zero_allowed;
     PeakEnvWarningState* warning_emitted;
+    bool decimal_digits_only;
 } PeakEnvUnsignedSchema;
 
 typedef struct {

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -8,6 +8,7 @@
 #include "internal/general_listener/mpi_report_transport.h"
 #endif
 #include "logging.h"
+#include "utils/env_parser.h"
 
 #define PEAK_CUDA_WRAPPER_EXPORT extern "C" __attribute__((visibility("default")))
 
@@ -86,6 +87,7 @@ typedef CUresult (*PeakCudaFuncGetNameFn)(const char** name,
 static PeakCudaFuncGetNameFn peak_cuda_func_get_name;
 static std::once_flag peak_cuda_func_get_name_once;
 static PeakCudaProfilerState peak_cuda_profiler_state;
+static PeakEnvWarningState peak_cuda_event_pool_capacity_warning_emitted;
 
 struct PeakCudaEventSlot {
     cudaEvent_t start;
@@ -313,20 +315,12 @@ void insert_cuda_graph_record(CUgraphExec_st* graph, gdouble elapsed_sec)
 static size_t
 peak_cuda_parse_event_pool_capacity()
 {
-    const gchar* value = g_getenv("PEAK_CUDA_EVENT_POOL_CAPACITY");
-    gchar* end = NULL;
-    guint64 parsed;
+    static const PeakEnvUnsignedSchema schema = {
+        "PEAK_CUDA_EVENT_POOL_CAPACITY", "events", 256, 1, 65536, false,
+        &peak_cuda_event_pool_capacity_warning_emitted, false,
+    };
 
-    if (value == NULL || value[0] == '\0') {
-        return 256;
-    }
-    parsed = g_ascii_strtoull(value, &end, 10);
-    if (end == value || *end != '\0' || parsed == 0 || parsed > 65536) {
-        peak_log_warn("[peak] invalid PEAK_CUDA_EVENT_POOL_CAPACITY=%s; using 256\n",
-                      value);
-        return 256;
-    }
-    return (size_t)parsed;
+    return (size_t)peak_parse_env_unsigned(&schema);
 }
 
 static void

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -213,6 +213,9 @@ static gsize peak_controller_shutdown_policy_initialized = 0;
 static unsigned int peak_controller_max_retry_count = 300;
 static double peak_controller_max_pending_age_s = 30.0;
 static double peak_reattach_cooldown_s = 60.0;
+static PeakEnvWarningState peak_reattach_cooldown_warning_emitted;
+static PeakEnvWarningState peak_controller_pending_age_warning_emitted;
+static PeakEnvWarningState peak_controller_retry_count_warning_emitted;
 static unsigned int peak_controller_configured_shutdown_drain_ms = 1000;
 static gsize peak_controller_trace_config_initialized = 0;
 static gchar* peak_controller_trace_path = NULL;
@@ -231,10 +234,13 @@ static gboolean peak_dynamic_attach_needed = FALSE;
 static void
 peak_general_listener_init_reattach_policy_once(void)
 {
+    PeakEnvUnsignedSchema schema = {
+        PEAK_REATTACH_COOLDOWN_MS_ENV, "milliseconds",
+        peak_reattach_default_cooldown_ms, 0, UINT_MAX, true,
+        &peak_reattach_cooldown_warning_emitted,
+    };
     unsigned int cooldown_ms =
-        peak_general_listener_parse_uint_env_default(
-            PEAK_REATTACH_COOLDOWN_MS_ENV,
-            peak_reattach_default_cooldown_ms);
+        (unsigned int)peak_parse_env_unsigned(&schema);
     peak_reattach_cooldown_s = (double)cooldown_ms / 1000.0;
 }
 
@@ -494,10 +500,11 @@ peak_env_truthy_general(const char* value)
 static unsigned int
 peak_general_controller_parse_uint_env(const char* name,
                                        const char* unit,
-                                       unsigned int default_value)
+                                       unsigned int default_value,
+                                       PeakEnvWarningState* warning_emitted)
 {
     PeakEnvUnsignedSchema schema = {
-        name, unit, default_value, 0, G_MAXUINT, true,
+        name, unit, default_value, 0, G_MAXUINT, true, warning_emitted,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);
@@ -510,7 +517,8 @@ peak_general_controller_init_retry_limits_once(void)
         peak_general_controller_parse_uint_env(
             PEAK_CONTROLLER_MAX_PENDING_AGE_MS_ENV,
             "milliseconds",
-            (unsigned int)(peak_controller_default_max_pending_age_s * 1000.0));
+            (unsigned int)(peak_controller_default_max_pending_age_s * 1000.0),
+            &peak_controller_pending_age_warning_emitted);
 
     peak_controller_max_pending_age_s =
         max_pending_age_ms == 0 ? 0.0 : (double)max_pending_age_ms / 1000.0;
@@ -518,7 +526,8 @@ peak_general_controller_init_retry_limits_once(void)
         peak_general_controller_parse_uint_env(
             PEAK_CONTROLLER_MAX_RETRY_COUNT_ENV,
             "retries",
-            peak_controller_default_max_retry_count);
+            peak_controller_default_max_retry_count,
+            &peak_controller_retry_count_warning_emitted);
 }
 
 static void

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -237,7 +237,7 @@ peak_general_listener_init_reattach_policy_once(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_REATTACH_COOLDOWN_MS_ENV, "milliseconds",
         peak_reattach_default_cooldown_ms, 0, UINT_MAX, true,
-        &peak_reattach_cooldown_warning_emitted,
+        &peak_reattach_cooldown_warning_emitted, false,
     };
     unsigned int cooldown_ms =
         (unsigned int)peak_parse_env_unsigned(&schema);
@@ -504,7 +504,7 @@ peak_general_controller_parse_uint_env(const char* name,
                                        PeakEnvWarningState* warning_emitted)
 {
     PeakEnvUnsignedSchema schema = {
-        name, unit, default_value, 0, G_MAXUINT, true, warning_emitted,
+        name, unit, default_value, 0, G_MAXUINT, true, warning_emitted, false,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -19,6 +19,7 @@
 #include "internal/unsafe_gum_prologue.h"
 #include "detach_controller.h"
 #include "logging.h"
+#include "utils/env_parser.h"
 #include "pthread_listener.h"
 #include <errno.h>
 #include <float.h>
@@ -492,24 +493,14 @@ peak_env_truthy_general(const char* value)
 
 static unsigned int
 peak_general_controller_parse_uint_env(const char* name,
+                                       const char* unit,
                                        unsigned int default_value)
 {
-    const char* value = g_getenv(name);
-    char* end = NULL;
-    unsigned long parsed;
+    PeakEnvUnsignedSchema schema = {
+        name, unit, default_value, 0, G_MAXUINT, true,
+    };
 
-    if (value == NULL || value[0] == '\0') {
-        return default_value;
-    }
-
-    errno = 0;
-    parsed = strtoul(value, &end, 10);
-    if (errno != 0 || end == value || *end != '\0' || parsed > G_MAXUINT) {
-        peak_log_info("[peak] ignoring invalid %s=%s\n", name, value);
-        return default_value;
-    }
-
-    return (unsigned int)parsed;
+    return (unsigned int)peak_parse_env_unsigned(&schema);
 }
 
 static void
@@ -518,6 +509,7 @@ peak_general_controller_init_retry_limits_once(void)
     unsigned int max_pending_age_ms =
         peak_general_controller_parse_uint_env(
             PEAK_CONTROLLER_MAX_PENDING_AGE_MS_ENV,
+            "milliseconds",
             (unsigned int)(peak_controller_default_max_pending_age_s * 1000.0));
 
     peak_controller_max_pending_age_s =
@@ -525,6 +517,7 @@ peak_general_controller_init_retry_limits_once(void)
     peak_controller_max_retry_count =
         peak_general_controller_parse_uint_env(
             PEAK_CONTROLLER_MAX_RETRY_COUNT_ENV,
+            "retries",
             peak_controller_default_max_retry_count);
 }
 

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -208,7 +208,7 @@ peak_mpi_output_collective_timeout_ms(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV, "milliseconds",
         PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
-        &peak_mpi_output_timeout_warning_emitted,
+        &peak_mpi_output_timeout_warning_emitted, false,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -47,6 +47,8 @@ _Static_assert(SIZE_MAX <= ULONG_MAX,
 #error No exact MPI datatype fallback is available for uint64_t
 #endif
 
+static PeakEnvWarningState peak_mpi_output_timeout_warning_emitted;
+
 typedef enum {
     PEAK_MPI_COLLECTIVE_ALLREDUCE = 0,
     PEAK_MPI_COLLECTIVE_REDUCE,
@@ -206,6 +208,7 @@ peak_mpi_output_collective_timeout_ms(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV, "milliseconds",
         PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
+        &peak_mpi_output_timeout_warning_emitted,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -6,6 +6,7 @@
 #include "internal/general_listener/report_model.h"
 #include "internal/general_listener/runtime_config.h"
 #include "logging.h"
+#include "utils/env_parser.h"
 #include "utils/timing.h"
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -202,12 +203,12 @@ peak_mpi_report_transport_test_fail_clone_once(void)
 static unsigned int
 peak_mpi_output_collective_timeout_ms(void)
 {
-    unsigned int timeout_ms = peak_general_listener_parse_uint_env_default(
-        PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV,
-        PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_DEFAULT);
+    PeakEnvUnsignedSchema schema = {
+        PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV, "milliseconds",
+        PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
+    };
 
-    return timeout_ms == 0 ? PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS_DEFAULT
-                           : timeout_ms;
+    return (unsigned int)peak_parse_env_unsigned(&schema);
 }
 
 static bool

--- a/src/general_listener/runtime_config.c
+++ b/src/general_listener/runtime_config.c
@@ -36,19 +36,20 @@ static bool
 peak_general_listener_parse_positive_uint_bounded(const char* name,
                                                   unsigned int maximum,
                                                   unsigned int* value_out,
-                                                  PeakEnvWarningState* warning_emitted)
+                                                  PeakEnvWarningState* warning_emitted,
+                                                  unsigned int fallback)
 {
     const char* value = getenv(name);
     PeakEnvUnsignedSchema schema = {
-        name, "milliseconds", 0, 1, maximum, false, warning_emitted,
+        name, "milliseconds", fallback, 1, maximum, false, warning_emitted,
     };
     unsigned long long parsed;
 
     if (value == NULL) {
         return false;
     }
-    parsed = peak_parse_env_unsigned(&schema);
-    if (parsed == 0) {
+    if (!peak_parse_env_unsigned_checked(&schema, &parsed)) {
+        (void)peak_parse_env_unsigned(&schema);
         return false;
     }
     if (value_out != NULL) {
@@ -114,7 +115,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
             PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV,
             (unsigned int)INT_MAX,
             &configured,
-            &peak_output_timeout_warning_emitted);
+            &peak_output_timeout_warning_emitted,
+            PEAK_SOCKET_PHASE_TIMEOUT_MS_DEFAULT);
     if (phase_was_configured) {
         budget.socket_phase_timeout_ms = configured;
     }
@@ -123,7 +125,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
             PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS_ENV,
             PEAK_SOCKET_GATHER_ADAPTIVE_MARGIN_MAX_MS,
             &configured,
-            NULL)) {
+            NULL,
+            0)) {
         wave_budget_ms = configured;
     }
 #endif
@@ -156,7 +159,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
             PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS_ENV,
             (unsigned int)INT_MAX,
             &configured,
-            &peak_output_release_timeout_warning_emitted)) {
+            &peak_output_release_timeout_warning_emitted,
+            minimum_socket_release)) {
         budget.socket_release_timeout_ms = configured;
         if (configured < minimum_socket_release) {
             budget.socket_release_timeout_ms = minimum_socket_release;
@@ -168,7 +172,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
             PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS_ENV,
             UINT_MAX,
             &configured,
-            &peak_mpi_release_timeout_warning_emitted)) {
+            &peak_mpi_release_timeout_warning_emitted,
+            PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS_DEFAULT)) {
         budget.mpi_report_release_timeout_ms = configured;
     }
     mpi_margin = peak_general_listener_multiply_saturated(

--- a/src/general_listener/runtime_config.c
+++ b/src/general_listener/runtime_config.c
@@ -26,15 +26,21 @@
 #define PEAK_MPI_RELEASE_MARGIN_PHASE_COUNT 2U
 
 static unsigned int configured_local_mpi_ranks = 1U;
+static PeakEnvWarningState peak_output_timeout_warning_emitted;
+static PeakEnvWarningState peak_output_release_timeout_warning_emitted;
+static PeakEnvWarningState peak_mpi_release_timeout_warning_emitted;
+static PeakEnvWarningState peak_detach_count_warning_emitted;
+static PeakEnvWarningState peak_uint_default_warning_emitted;
 
 static bool
 peak_general_listener_parse_positive_uint_bounded(const char* name,
                                                   unsigned int maximum,
-                                                  unsigned int* value_out)
+                                                  unsigned int* value_out,
+                                                  PeakEnvWarningState* warning_emitted)
 {
     const char* value = getenv(name);
     PeakEnvUnsignedSchema schema = {
-        name, "milliseconds", 0, 1, maximum, false,
+        name, "milliseconds", 0, 1, maximum, false, warning_emitted,
     };
     unsigned long long parsed;
 
@@ -107,7 +113,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
         peak_general_listener_parse_positive_uint_bounded(
             PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS_ENV,
             (unsigned int)INT_MAX,
-            &configured);
+            &configured,
+            &peak_output_timeout_warning_emitted);
     if (phase_was_configured) {
         budget.socket_phase_timeout_ms = configured;
     }
@@ -115,7 +122,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
     if (peak_general_listener_parse_positive_uint_bounded(
             PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS_ENV,
             PEAK_SOCKET_GATHER_ADAPTIVE_MARGIN_MAX_MS,
-            &configured)) {
+            &configured,
+            NULL)) {
         wave_budget_ms = configured;
     }
 #endif
@@ -147,7 +155,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
     if (peak_general_listener_parse_positive_uint_bounded(
             PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS_ENV,
             (unsigned int)INT_MAX,
-            &configured)) {
+            &configured,
+            &peak_output_release_timeout_warning_emitted)) {
         budget.socket_release_timeout_ms = configured;
         if (configured < minimum_socket_release) {
             budget.socket_release_timeout_ms = minimum_socket_release;
@@ -158,7 +167,8 @@ peak_general_listener_report_timeout_budget_for_rank_count(
     if (peak_general_listener_parse_positive_uint_bounded(
             PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS_ENV,
             UINT_MAX,
-            &configured)) {
+            &configured,
+            &peak_mpi_release_timeout_warning_emitted)) {
         budget.mpi_report_release_timeout_ms = configured;
     }
     mpi_margin = peak_general_listener_multiply_saturated(
@@ -189,11 +199,12 @@ peak_general_listener_parse_detach_count_override(unsigned long* count_out)
 {
     const char* value = getenv("PEAK_DETACH_COUNT");
 
-    if (value == NULL || value[0] == '\0') {
+    if (value == NULL) {
         return false;
     }
     PeakEnvUnsignedSchema schema = {
         "PEAK_DETACH_COUNT", "calls", 0, 1, ULONG_MAX, false,
+        &peak_detach_count_warning_emitted,
     };
     unsigned long long parsed = peak_parse_env_unsigned(&schema);
 
@@ -213,6 +224,7 @@ peak_general_listener_parse_uint_env_default(const char* name,
 {
     PeakEnvUnsignedSchema schema = {
         name, "milliseconds", default_value, 0, UINT_MAX, true,
+        &peak_uint_default_warning_emitted,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/general_listener/runtime_config.c
+++ b/src/general_listener/runtime_config.c
@@ -30,7 +30,6 @@ static PeakEnvWarningState peak_output_timeout_warning_emitted;
 static PeakEnvWarningState peak_output_release_timeout_warning_emitted;
 static PeakEnvWarningState peak_mpi_release_timeout_warning_emitted;
 static PeakEnvWarningState peak_detach_count_warning_emitted;
-static PeakEnvWarningState peak_uint_default_warning_emitted;
 
 static bool
 peak_general_listener_parse_positive_uint_bounded(const char* name,
@@ -42,6 +41,7 @@ peak_general_listener_parse_positive_uint_bounded(const char* name,
     const char* value = getenv(name);
     PeakEnvUnsignedSchema schema = {
         name, "milliseconds", fallback, 1, maximum, false, warning_emitted,
+        false,
     };
     unsigned long long parsed;
 
@@ -209,7 +209,7 @@ peak_general_listener_parse_detach_count_override(unsigned long* count_out)
     }
     PeakEnvUnsignedSchema schema = {
         "PEAK_DETACH_COUNT", "calls", 0, 1, ULONG_MAX, false,
-        &peak_detach_count_warning_emitted,
+        &peak_detach_count_warning_emitted, false,
     };
     unsigned long long parsed = peak_parse_env_unsigned(&schema);
 
@@ -221,18 +221,6 @@ peak_general_listener_parse_detach_count_override(unsigned long* count_out)
         *count_out = (unsigned long)parsed;
     }
     return true;
-}
-
-unsigned int
-peak_general_listener_parse_uint_env_default(const char* name,
-                                             unsigned int default_value)
-{
-    PeakEnvUnsignedSchema schema = {
-        name, "milliseconds", default_value, 0, UINT_MAX, true,
-        &peak_uint_default_warning_emitted,
-    };
-
-    return (unsigned int)peak_parse_env_unsigned(&schema);
 }
 
 static bool

--- a/src/general_listener/runtime_config.c
+++ b/src/general_listener/runtime_config.c
@@ -165,6 +165,18 @@ peak_general_listener_report_timeout_budget_for_rank_count(
         if (configured < minimum_socket_release) {
             budget.socket_release_timeout_ms = minimum_socket_release;
             budget.socket_release_was_raised = true;
+            if (__atomic_exchange_n(
+                    &peak_output_release_timeout_warning_emitted.emitted,
+                    1,
+                    __ATOMIC_RELAXED) == 0) {
+                peak_log_warn(
+                    "[peak] %s=%u is below required minimum %u milliseconds; "
+                    "using %u milliseconds\n",
+                    PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS_ENV,
+                    configured,
+                    minimum_socket_release,
+                    minimum_socket_release);
+            }
         }
     }
 

--- a/src/general_listener/runtime_config.c
+++ b/src/general_listener/runtime_config.c
@@ -1,6 +1,7 @@
 #include "internal/general_listener/runtime_config.h"
 
 #include "logging.h"
+#include "utils/env_parser.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -27,36 +28,21 @@
 static unsigned int configured_local_mpi_ranks = 1U;
 
 static bool
-peak_general_listener_unsigned_text_is_negative(const char* value)
-{
-    const unsigned char* cursor = (const unsigned char*)value;
-
-    if (cursor == NULL) {
-        return false;
-    }
-    while (*cursor != '\0' && isspace(*cursor)) {
-        cursor++;
-    }
-    return *cursor == '-';
-}
-
-static bool
 peak_general_listener_parse_positive_uint_bounded(const char* name,
                                                   unsigned int maximum,
                                                   unsigned int* value_out)
 {
     const char* value = getenv(name);
-    char* end = NULL;
-    unsigned long parsed;
+    PeakEnvUnsignedSchema schema = {
+        name, "milliseconds", 0, 1, maximum, false,
+    };
+    unsigned long long parsed;
 
-    if (value == NULL || value[0] == '\0' ||
-        peak_general_listener_unsigned_text_is_negative(value)) {
+    if (value == NULL) {
         return false;
     }
-    errno = 0;
-    parsed = strtoul(value, &end, 10);
-    if (errno == ERANGE || end == value || *end != '\0' || parsed == 0 ||
-        parsed > maximum) {
+    parsed = peak_parse_env_unsigned(&schema);
+    if (parsed == 0) {
         return false;
     }
     if (value_out != NULL) {
@@ -206,22 +192,17 @@ peak_general_listener_parse_detach_count_override(unsigned long* count_out)
     if (value == NULL || value[0] == '\0') {
         return false;
     }
-    if (peak_general_listener_unsigned_text_is_negative(value)) {
-        peak_log_info("[peak] ignoring invalid PEAK_DETACH_COUNT=%s\n", value);
-        return false;
-    }
+    PeakEnvUnsignedSchema schema = {
+        "PEAK_DETACH_COUNT", "calls", 0, 1, ULONG_MAX, false,
+    };
+    unsigned long long parsed = peak_parse_env_unsigned(&schema);
 
-    errno = 0;
-    char* end = NULL;
-    unsigned long parsed = strtoul(value, &end, 10);
-
-    if (errno == ERANGE || end == value || *end != '\0' || parsed == 0) {
-        peak_log_info("[peak] ignoring invalid PEAK_DETACH_COUNT=%s\n", value);
+    if (parsed == 0) {
         return false;
     }
 
     if (count_out != NULL) {
-        *count_out = parsed;
+        *count_out = (unsigned long)parsed;
     }
     return true;
 }
@@ -230,25 +211,11 @@ unsigned int
 peak_general_listener_parse_uint_env_default(const char* name,
                                              unsigned int default_value)
 {
-    const char* value = getenv(name);
-    if (value == NULL || value[0] == '\0') {
-        return default_value;
-    }
-    if (peak_general_listener_unsigned_text_is_negative(value)) {
-        peak_log_info("[peak] ignoring invalid %s=%s\n", name, value);
-        return default_value;
-    }
+    PeakEnvUnsignedSchema schema = {
+        name, "milliseconds", default_value, 0, UINT_MAX, true,
+    };
 
-    errno = 0;
-    char* end = NULL;
-    unsigned long parsed = strtoul(value, &end, 10);
-    if (errno == ERANGE || end == value || *end != '\0' ||
-        parsed > UINT_MAX) {
-        peak_log_info("[peak] ignoring invalid %s=%s\n", name, value);
-        return default_value;
-    }
-
-    return (unsigned int)parsed;
+    return (unsigned int)peak_parse_env_unsigned(&schema);
 }
 
 static bool

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -5,6 +5,7 @@
 #include "internal/general_listener/report_model.h"
 #include "internal/general_listener/runtime_config.h"
 #include "logging.h"
+#include "utils/env_parser.h"
 
 #include <errno.h>
 #include <float.h>
@@ -422,6 +423,7 @@ peak_socket_reduce_header_report_tuple(
     return tuple;
 }
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
 static int
 peak_socket_reduce_parse_positive_int_env(const char* name,
                                           int default_value)
@@ -444,6 +446,7 @@ peak_socket_reduce_parse_positive_int_env(const char* name,
 
     return (int)parsed;
 }
+#endif
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static bool
@@ -533,18 +536,13 @@ peak_socket_report_test_channel_port(PeakSocketReportChannel channel)
 static int
 peak_socket_reduce_port(void)
 {
-    int port = peak_socket_reduce_parse_positive_int_env(
-        PEAK_OUTPUT_AGGREGATION_PORT_ENV,
-        peak_socket_reduce_default_port());
+    PeakEnvUnsignedSchema schema = {
+        PEAK_OUTPUT_AGGREGATION_PORT_ENV, "TCP port",
+        (unsigned long long)peak_socket_reduce_default_port(), 1, 65535,
+        false,
+    };
 
-    if (port <= 0 || port > 65535) {
-        peak_log_info("[peak] Ignoring out-of-range %s=%d\n",
-                      PEAK_OUTPUT_AGGREGATION_PORT_ENV,
-                      port);
-        return peak_socket_reduce_default_port();
-    }
-
-    return port;
+    return (int)peak_parse_env_unsigned(&schema);
 }
 
 static int64_t

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -252,11 +252,9 @@ peak_socket_test_listener_ready_signal_root(void)
     if (fd < 0) {
         return 0;
     }
-    peak_socket_test_listener_ready_root_signal_fd = -1;
     do {
         written = send(fd, &signal, sizeof(signal), MSG_NOSIGNAL);
     } while (written < 0 && errno == EINTR);
-    close(fd);
     return written == (ssize_t)sizeof(signal) ? 1 : -1;
 }
 
@@ -2563,6 +2561,9 @@ peak_socket_reduce_root_gather(
     size_t peer_count;
     size_t active_limit;
     size_t poll_count;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    size_t test_control_index;
+#endif
     PeakSocketGatherConnection* connections = NULL;
     struct pollfd* descriptors = NULL;
     size_t accepted = 0;
@@ -2596,7 +2597,21 @@ peak_socket_reduce_root_gather(
         active_limit + 1 > SIZE_MAX / sizeof(*descriptors)) {
         return false;
     }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (test_wait_for_first_peer &&
+        (active_limit > SIZE_MAX - 2 ||
+         active_limit + 2 > (size_t)((nfds_t)-1) ||
+         active_limit + 2 > SIZE_MAX / sizeof(*descriptors))) {
+        return false;
+    }
+#endif
     poll_count = active_limit + 1;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    test_control_index = poll_count;
+    if (test_wait_for_first_peer) {
+        poll_count++;
+    }
+#endif
     connections = calloc(active_limit, sizeof(*connections));
     descriptors = calloc(poll_count, sizeof(*descriptors));
     if (connections == NULL || descriptors == NULL) {
@@ -2626,8 +2641,6 @@ peak_socket_reduce_root_gather(
 #endif
            ) {
         int poll_result;
-        int poll_timeout_ms = peak_socket_reduce_remaining_ms(
-            progress_deadline_us);
 
         descriptors[0].fd =
             accepted < peer_count && active < active_limit
@@ -2644,13 +2657,30 @@ peak_socket_reduce_root_gather(
                     : POLLIN;
             descriptors[i + 1].revents = 0;
         }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (test_wait_for_first_peer) {
+            descriptors[test_control_index].fd =
+                peak_socket_test_listener_ready_root_signal_fd;
+            descriptors[test_control_index].events = POLLIN;
+            descriptors[test_control_index].revents = 0;
+        } else if (test_control_index < poll_count) {
+            descriptors[test_control_index].fd = -1;
+            descriptors[test_control_index].events = 0;
+            descriptors[test_control_index].revents = 0;
+        }
+#endif
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
         if (test_wait_for_first_peer) {
-            poll_timeout_ms = -1;
-        }
+            poll_result = poll(descriptors, (nfds_t)poll_count, -1);
+        } else
 #endif
-        poll_result = poll(descriptors, (nfds_t)poll_count, poll_timeout_ms);
+        {
+            poll_result = poll(
+                descriptors,
+                (nfds_t)poll_count,
+                peak_socket_reduce_remaining_ms(progress_deadline_us));
+        }
         if (poll_result < 0) {
             if (errno == EINTR) {
                 continue;
@@ -2720,6 +2750,8 @@ peak_socket_reduce_root_gather(
                             hard_deadline_us,
                             progress_timeout_ms);
                     startup_grace_active = false;
+                    peak_socket_test_receipt_barrier_close(
+                        &peak_socket_test_listener_ready_root_signal_fd);
                     test_wait_for_first_peer = false;
                 }
 #endif
@@ -2739,6 +2771,13 @@ peak_socket_reduce_root_gather(
                 break;
             }
         }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (test_wait_for_first_peer &&
+            descriptors[test_control_index].revents != 0) {
+            ok = false;
+            break;
+        }
+#endif
 
         for (size_t i = 0; i < active_limit && ok; i++) {
             PeakSocketGatherConnection* connection =
@@ -3314,6 +3353,8 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
         if (listener_ready < 0) {
             close(listener);
             close(release_listener);
+            peak_socket_test_receipt_barrier_close(
+                &peak_socket_test_listener_ready_root_signal_fd);
             free(local_records);
             free(release_targets);
             free(claimed_ranks);
@@ -3336,6 +3377,11 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
 #endif
                                              &gather_aggregate,
                                              &received);
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_socket_test_receipt_barrier_close(
+        &peak_socket_test_listener_ready_root_signal_fd);
+#endif
 
     close(listener);
     free(local_records);

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -540,7 +540,7 @@ peak_socket_reduce_port(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_OUTPUT_AGGREGATION_PORT_ENV, "TCP port",
         (unsigned long long)peak_socket_reduce_default_port(), 1, 65535,
-        false, &peak_socket_port_warning_emitted,
+        false, &peak_socket_port_warning_emitted, false,
     };
 
     return (int)peak_parse_env_unsigned(&schema);

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -189,6 +189,7 @@ static PeakSocketReportTestTelemetry peak_socket_test_telemetry = {
 };
 static int peak_socket_test_receipt_barrier_peer_wait_fd = -1;
 static int peak_socket_test_receipt_barrier_root_signal_fd = -1;
+static int peak_socket_test_listener_ready_root_signal_fd = -1;
 static bool peak_socket_test_receipt_failure_injected;
 
 static void
@@ -230,6 +231,33 @@ peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,
     peak_socket_test_receipt_barrier_peer_wait_fd = peer_wait_fd;
     peak_socket_test_receipt_barrier_root_signal_fd = root_signal_fd;
     peak_socket_test_receipt_failure_injected = false;
+}
+
+void
+peak_socket_report_test_listener_ready_set(int root_signal_fd)
+{
+    peak_socket_test_receipt_barrier_close(
+        &peak_socket_test_listener_ready_root_signal_fd);
+    peak_socket_test_listener_ready_root_signal_fd = root_signal_fd;
+}
+
+/* Returns 1 when a configured peer was released, 0 when disabled, -1 on I/O. */
+static int
+peak_socket_test_listener_ready_signal_root(void)
+{
+    const unsigned char signal = 0x73U;
+    int fd = peak_socket_test_listener_ready_root_signal_fd;
+    ssize_t written;
+
+    if (fd < 0) {
+        return 0;
+    }
+    peak_socket_test_listener_ready_root_signal_fd = -1;
+    do {
+        written = send(fd, &signal, sizeof(signal), MSG_NOSIGNAL);
+    } while (written < 0 && errno == EINTR);
+    close(fd);
+    return written == (ssize_t)sizeof(signal) ? 1 : -1;
 }
 
 static bool
@@ -2526,6 +2554,9 @@ peak_socket_reduce_root_gather(
     int progress_timeout_ms,
     int gather_hard_timeout_ms,
     int64_t hard_deadline_us,
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    bool test_wait_for_first_peer,
+#endif
     PeakSocketGatherAggregate* aggregate,
     unsigned int* received_out)
 {
@@ -2586,8 +2617,17 @@ peak_socket_reduce_root_gather(
 #endif
 
     while (completed < peer_count &&
-           peak_socket_reduce_remaining_ms(progress_deadline_us) > 0) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+           (test_wait_for_first_peer ||
+#endif
+            peak_socket_reduce_remaining_ms(progress_deadline_us) > 0
+#ifdef PEAK_ENABLE_TEST_HOOKS
+            )
+#endif
+           ) {
         int poll_result;
+        int poll_timeout_ms = peak_socket_reduce_remaining_ms(
+            progress_deadline_us);
 
         descriptors[0].fd =
             accepted < peer_count && active < active_limit
@@ -2605,10 +2645,12 @@ peak_socket_reduce_root_gather(
             descriptors[i + 1].revents = 0;
         }
 
-        poll_result = poll(descriptors,
-                           (nfds_t)poll_count,
-                           peak_socket_reduce_remaining_ms(
-                               progress_deadline_us));
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (test_wait_for_first_peer) {
+            poll_timeout_ms = -1;
+        }
+#endif
+        poll_result = poll(descriptors, (nfds_t)poll_count, poll_timeout_ms);
         if (poll_result < 0) {
             if (errno == EINTR) {
                 continue;
@@ -2627,8 +2669,15 @@ peak_socket_reduce_root_gather(
         if ((descriptors[0].revents & POLLIN) != 0) {
             while (accepted < peer_count &&
                    active < active_limit &&
-                   peak_socket_reduce_remaining_ms(
-                       progress_deadline_us) > 0) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+                   (test_wait_for_first_peer ||
+#endif
+                    peak_socket_reduce_remaining_ms(
+                        progress_deadline_us) > 0
+#ifdef PEAK_ENABLE_TEST_HOOKS
+                    )
+#endif
+                   ) {
                 size_t slot = active_limit;
                 int fd = accept(listener, NULL, NULL);
 
@@ -2662,7 +2711,7 @@ peak_socket_reduce_root_gather(
                 connections[slot].phase =
                     PEAK_SOCKET_GATHER_READING_HEADER;
 #ifdef PEAK_ENABLE_TEST_HOOKS
-                if (startup_grace_active) {
+                if (test_wait_for_first_peer || startup_grace_active) {
                     /* First transport progress restores the normal budget. */
                     hard_deadline_us = peak_socket_reduce_deadline_us(
                         gather_hard_timeout_ms);
@@ -2671,6 +2720,7 @@ peak_socket_reduce_root_gather(
                             hard_deadline_us,
                             progress_timeout_ms);
                     startup_grace_active = false;
+                    test_wait_for_first_peer = false;
                 }
 #endif
                 accepted++;
@@ -3213,6 +3263,9 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     bool socket_accounting_valid = local->overhead.accounting_valid;
     unsigned int received = 0;
     bool failed;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    bool test_wait_for_first_peer = false;
+#endif
     PeakSocketGatherAggregate gather_aggregate;
 
     if (record_bytes != 0) {
@@ -3254,11 +3307,33 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     gather_aggregate.dropped_calls = &socket_dropped_calls;
     gather_aggregate.dropped_threads = &socket_dropped_threads;
     gather_aggregate.accounting_valid = &socket_accounting_valid;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    {
+        int listener_ready = peak_socket_test_listener_ready_signal_root();
+
+        if (listener_ready < 0) {
+            close(listener);
+            close(release_listener);
+            free(local_records);
+            free(release_targets);
+            free(claimed_ranks);
+            free(aggregate_records);
+            return PEAK_SOCKET_REPORT_FAILED;
+        }
+        if (listener_ready > 0) {
+            /* The fixture, rather than transport timing, owns peer launch. */
+            test_wait_for_first_peer = true;
+        }
+    }
+#endif
     failed = !peak_socket_reduce_root_gather(listener,
                                              size,
                                              timeout_ms,
                                              gather_hard_timeout_ms,
                                              deadline_us,
+#ifdef PEAK_ENABLE_TEST_HOOKS
+                                             test_wait_for_first_peer,
+#endif
                                              &gather_aggregate,
                                              &received);
 

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -181,6 +181,7 @@ static bool peak_socket_reduce_channel_ports(PeakSocketReportChannel channel,
                                              int* release_port);
 static _Thread_local PeakSocketReportChannel peak_socket_report_channel =
     PEAK_SOCKET_REPORT_CHANNEL_CPU;
+static PeakEnvWarningState peak_socket_port_warning_emitted;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static PeakSocketReportTestTelemetry peak_socket_test_telemetry = {
@@ -539,7 +540,7 @@ peak_socket_reduce_port(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_OUTPUT_AGGREGATION_PORT_ENV, "TCP port",
         (unsigned long long)peak_socket_reduce_default_port(), 1, 65535,
-        false,
+        false, &peak_socket_port_warning_emitted,
     };
 
     return (int)peak_parse_env_unsigned(&schema);

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -37,6 +37,8 @@ static unsigned long configured_jit_not_exec_retry_timeout_ms =
     PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS;
 static unsigned long configured_jit_drain_record_budget =
     PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET;
+static PeakEnvWarningState peak_jit_retry_timeout_warning_emitted;
+static PeakEnvWarningState peak_jit_drain_budget_warning_emitted;
 static char* peak_jit_perfmap_path = NULL;
 static off_t peak_jit_perfmap_offset = 0;
 static gboolean peak_jit_perfmap_identity_known = FALSE;
@@ -105,11 +107,12 @@ static unsigned long
 peak_jit_parse_ulong_env(const char* name,
                          const char* unit,
                          unsigned long fallback,
-                         bool zero_allowed)
+                         bool zero_allowed,
+                         PeakEnvWarningState* warning_emitted)
 {
     PeakEnvUnsignedSchema schema = {
         name, unit, fallback, zero_allowed ? 0UL : 1UL, ULONG_MAX,
-        zero_allowed,
+        zero_allowed, warning_emitted,
     };
 
     return (unsigned long)peak_parse_env_unsigned(&schema);
@@ -524,12 +527,14 @@ peak_jit_init_runtime_config_once(void)
         peak_jit_parse_ulong_env(PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS_ENV,
                                  "milliseconds",
                                  PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS,
-                                 true);
+                                 true,
+                                 &peak_jit_retry_timeout_warning_emitted);
     budget =
         peak_jit_parse_ulong_env(PEAK_JIT_DRAIN_RECORD_BUDGET_ENV,
                                  "records",
                                  PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET,
-                                 false);
+                                 false,
+                                 &peak_jit_drain_budget_warning_emitted);
     configured_jit_drain_record_budget = budget;
 #ifdef PEAK_ENABLE_TEST_HOOKS
     const char* attach_sequence =

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -112,7 +112,7 @@ peak_jit_parse_ulong_env(const char* name,
 {
     PeakEnvUnsignedSchema schema = {
         name, unit, fallback, zero_allowed ? 0UL : 1UL, ULONG_MAX,
-        zero_allowed, warning_emitted,
+        zero_allowed, warning_emitted, false,
     };
 
     return (unsigned long)peak_parse_env_unsigned(&schema);

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "internal/jit_provider.h"
 #include "internal/general_listener_internal.h"
+#include "utils/env_parser.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -101,22 +102,17 @@ peak_jit_default_perfmap_path(void)
 }
 
 static unsigned long
-peak_jit_parse_ulong_env(const char* name, unsigned long fallback)
+peak_jit_parse_ulong_env(const char* name,
+                         const char* unit,
+                         unsigned long fallback,
+                         bool zero_allowed)
 {
-    const char* value = g_getenv(name);
-    char* end = NULL;
-    unsigned long parsed;
+    PeakEnvUnsignedSchema schema = {
+        name, unit, fallback, zero_allowed ? 0UL : 1UL, ULONG_MAX,
+        zero_allowed,
+    };
 
-    if (value == NULL || value[0] == '\0') {
-        return fallback;
-    }
-
-    errno = 0;
-    parsed = strtoul(value, &end, 10);
-    if (errno != 0 || end == value || *end != '\0') {
-        return fallback;
-    }
-    return parsed;
+    return (unsigned long)peak_parse_env_unsigned(&schema);
 }
 
 static const char*
@@ -526,12 +522,15 @@ peak_jit_init_runtime_config_once(void)
     }
     configured_jit_not_exec_retry_timeout_ms =
         peak_jit_parse_ulong_env(PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS_ENV,
-                                 PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS);
+                                 "milliseconds",
+                                 PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS,
+                                 true);
     budget =
         peak_jit_parse_ulong_env(PEAK_JIT_DRAIN_RECORD_BUDGET_ENV,
-                                 PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET);
-    configured_jit_drain_record_budget =
-        budget == 0 ? PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET : budget;
+                                 "records",
+                                 PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET,
+                                 false);
+    configured_jit_drain_record_budget = budget;
 #ifdef PEAK_ENABLE_TEST_HOOKS
     const char* attach_sequence =
         g_getenv(PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV);

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -2,6 +2,7 @@
 #include "malloc_interceptor.h"
 #include "malloc_otf2.h"
 #include "logging.h"
+#include "utils/env_parser.h"
 #include <sched.h>
 
 /*=========================
@@ -56,6 +57,7 @@ static PeakMemLog          g_memlog = {
 };
 static __thread int        in_peak_alloc_hook = 0;
 static __thread int        in_backtrace = 0;
+static PeakEnvWarningState peak_memlog_capacity_warning_emitted;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic PeakMemLogTestFailure g_memlog_test_failure = PEAK_MEMLOG_TEST_FAIL_NONE;
@@ -174,15 +176,15 @@ static int size_fits_off_t(size_t size) {
     return (uintmax_t) size <= max_off;
 }
 
-static int parse_memlog_capacity(const char* value, size_t* out) {
-    char* end = NULL;
+static int parse_memlog_capacity(size_t* out) {
+    static const PeakEnvUnsignedSchema schema = {
+        "PEAK_MEMLOG_CHUNK_EVENTS", "events", PEAK_MEMLOG_CHUNK_EVENTS,
+        1, SIZE_MAX, false,
+        &peak_memlog_capacity_warning_emitted, false,
+    };
     unsigned long long parsed;
 
-    if (!value || !*value || value[0] == '-') return 0;
-    errno = 0;
-    parsed = strtoull(value, &end, 10);
-    if (errno == ERANGE || end == value || *end != '\0' ||
-        parsed == 0 || parsed > SIZE_MAX) {
+    if (!peak_parse_env_unsigned_checked(&schema, &parsed)) {
         return 0;
     }
     *out = (size_t) parsed;
@@ -445,8 +447,12 @@ static void peak_memlog_open(void) {
         PEAK_MEMLOG_UNINITIALIZED) return;
 
     env_capacity = getenv("PEAK_MEMLOG_CHUNK_EVENTS");
-    if (env_capacity && !parse_memlog_capacity(env_capacity, &capacity_events)) {
-        peak_log_warn("[peak] memlog: invalid PEAK_MEMLOG_CHUNK_EVENTS; disabling log\n");
+    if (env_capacity && !parse_memlog_capacity(&capacity_events)) {
+        if (__atomic_exchange_n(&peak_memlog_capacity_warning_emitted.emitted,
+                                1,
+                                __ATOMIC_RELAXED) == 0) {
+            peak_log_warn("[peak] memlog: invalid PEAK_MEMLOG_CHUNK_EVENTS; disabling log\n");
+        }
         atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
         return;
     }

--- a/src/mpi_teardown_guard.c
+++ b/src/mpi_teardown_guard.c
@@ -29,6 +29,7 @@ static _Atomic int peak_mpi_teardown_failed_closed;
 static _Atomic(PeakMpiTeardownRequest*)
     peak_mpi_teardown_quarantine = NULL;
 static _Atomic size_t peak_mpi_teardown_quarantine_count;
+static PeakEnvWarningState peak_mpi_finalize_timeout_warning_emitted;
 
 #if defined(PEAK_ENABLE_TEST_HOOKS) && \
     (defined(__GNUC__) || defined(__clang__))
@@ -161,6 +162,7 @@ peak_mpi_teardown_finalize_timeout_ms(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS, "milliseconds",
         PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
+        &peak_mpi_finalize_timeout_warning_emitted,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/mpi_teardown_guard.c
+++ b/src/mpi_teardown_guard.c
@@ -162,7 +162,7 @@ peak_mpi_teardown_finalize_timeout_ms(void)
     PeakEnvUnsignedSchema schema = {
         PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS, "milliseconds",
         PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
-        &peak_mpi_finalize_timeout_warning_emitted,
+        &peak_mpi_finalize_timeout_warning_emitted, false,
     };
 
     return (unsigned int)peak_parse_env_unsigned(&schema);

--- a/src/mpi_teardown_guard.c
+++ b/src/mpi_teardown_guard.c
@@ -158,13 +158,12 @@ peak_mpi_teardown_observe_request(PeakMpiTeardownRequest* pending)
 static unsigned int
 peak_mpi_teardown_finalize_timeout_ms(void)
 {
-    unsigned int timeout_ms = parse_env_to_uint_default(
-        PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS,
-        PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS_DEFAULT);
+    PeakEnvUnsignedSchema schema = {
+        PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS, "milliseconds",
+        PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS_DEFAULT, 1, UINT_MAX, false,
+    };
 
-    return timeout_ms == 0
-               ? PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS_DEFAULT
-               : timeout_ms;
+    return (unsigned int)peak_parse_env_unsigned(&schema);
 }
 
 static bool

--- a/src/peak.c
+++ b/src/peak.c
@@ -110,6 +110,7 @@ static _Atomic int peak_exit_status_known = 0;
 static _Atomic int peak_exit_status_value = 0;
 static _Atomic int peak_runtime_active = 0;
 static _Atomic pid_t peak_runtime_owner_pid = 0;
+static PeakEnvWarningState peak_max_num_threads_warning_emitted;
 typedef enum {
     PEAK_RUNTIME_ACTIVATION_NOT_READY = 0,
     PEAK_RUNTIME_ACTIVATION_READY = 1,
@@ -733,6 +734,8 @@ peak_parse_max_num_threads(void)
     const char* value = getenv(PEAK_MAX_NUM_THREADS_ENV);
     long online_cpus = sysconf(_SC_NPROCESSORS_ONLN);
     gulong default_value = 2;
+    PeakEnvUnsignedSchema schema;
+    unsigned long long parsed;
 
     if (online_cpus > 0) {
         if ((unsigned long)online_cpus > PEAK_MAX_NUM_THREADS_LIMIT / 2UL) {
@@ -742,41 +745,35 @@ peak_parse_max_num_threads(void)
         }
     }
 
-    if (value == NULL || value[0] == '\0') {
+    if (value == NULL) {
         return default_value;
     }
-    for (const unsigned char* cursor = (const unsigned char*)value;
-         *cursor != '\0';
-         cursor++) {
-        if (*cursor < (unsigned char)'0' || *cursor > (unsigned char)'9') {
-            peak_log_warn("[peak] invalid %s=%s; using %lu\n",
-                          PEAK_MAX_NUM_THREADS_ENV,
-                          value,
-                          (unsigned long)default_value);
-            return default_value;
-        }
-    }
-    errno = 0;
-    char* end = NULL;
-    unsigned long long parsed = strtoull(value, &end, 10);
-    if (errno == ERANGE || end == value || *end != '\0' ||
-        parsed > (unsigned long long)G_MAXULONG) {
-        peak_log_warn("[peak] invalid %s=%s; using %lu\n",
-                      PEAK_MAX_NUM_THREADS_ENV,
-                      value,
-                      (unsigned long)default_value);
-        return default_value;
+    schema = (PeakEnvUnsignedSchema){
+        PEAK_MAX_NUM_THREADS_ENV, "thread slots", default_value,
+        0, G_MAXULONG, true, &peak_max_num_threads_warning_emitted,
+        true,
+    };
+    if (!peak_parse_env_unsigned_checked(&schema, &parsed)) {
+        return (gulong)peak_parse_env_unsigned(&schema);
     }
     if (parsed == 0) {
-        peak_log_warn("[peak] %s=0 is unsafe; using 1\n",
-                      PEAK_MAX_NUM_THREADS_ENV);
+        if (__atomic_exchange_n(&peak_max_num_threads_warning_emitted.emitted,
+                                1,
+                                __ATOMIC_RELAXED) == 0) {
+            peak_log_warn("[peak] %s=0 is unsafe; using 1\n",
+                          PEAK_MAX_NUM_THREADS_ENV);
+        }
         return 1;
     }
     if (parsed > PEAK_MAX_NUM_THREADS_LIMIT) {
-        peak_log_warn("[peak] %s=%s exceeds supported capacity %lu; clamping\n",
-                      PEAK_MAX_NUM_THREADS_ENV,
-                      value,
-                      PEAK_MAX_NUM_THREADS_LIMIT);
+        if (__atomic_exchange_n(&peak_max_num_threads_warning_emitted.emitted,
+                                1,
+                                __ATOMIC_RELAXED) == 0) {
+            peak_log_warn("[peak] %s=%s exceeds supported capacity %lu; clamping\n",
+                          PEAK_MAX_NUM_THREADS_ENV,
+                          value,
+                          PEAK_MAX_NUM_THREADS_LIMIT);
+        }
         return PEAK_MAX_NUM_THREADS_LIMIT;
     }
     return (gulong)parsed;

--- a/src/peak.c
+++ b/src/peak.c
@@ -34,6 +34,7 @@
 #include "malloc_interceptor.h"
 #include "utils/env_parser.h"
 #include "utils/mpi_utils.h"
+#include "utils/target_config.h"
 #include "utils/utils.h"
 
 #define PEAK_TARGET_ENV                        "PEAK_TARGET"
@@ -44,23 +45,9 @@
 #define PEAK_GPU_MONITOR_ALL                   "PEAK_GPU_MONITOR_ALL"
 #define PEAK_NAME_TRUNCATE                     "PEAK_NAME_TRUNCATE"
 #define PEAK_TARGET_DELIM                     ','
-#define PEAK_COST_ENV                          "PEAK_COST"
-#define PEAK_HEARTBEAT_INTERVAL_ENV            "PEAK_HEARTBEAT_INTERVAL"
-#define PEAK_HIBERNATION_CYCLE_ENV             "PEAK_HIBERNATION_CYCLE"
-#define PEAK_OVERHEAD_RATIO_ENV                "PEAK_OVERHEAD_RATIO"
-#define PEAK_GLOBAL_OVERHEAD_RATIO_ENV         "PEAK_GLOBAL_OVERHEAD_RATIO"
-#define PEAK_GLOBAL_DETACH_FACTOR_ENV          "PEAK_GLOBAL_DETACH_FACTOR"
-#define PEAK_GLOBAL_REATTACH_FACTOR_ENV        "PEAK_GLOBAL_REATTACH_FACTOR"
 #define PEAK_ENABLE_PER_TARGET_HEARTBEAT_ENV   "PEAK_ENABLE_PER_TARGET_HEARTBEAT"
 #define PEAK_ENABLE_GLOBAL_HEARTBEAT_ENV       "PEAK_ENABLE_GLOBAL_HEARTBEAT"
 #define PEAK_ENABLE_REATTACH_ENV               "PEAK_ENABLE_REATTACH"
-#define PEAK_PAUSE_TIMEOUT_ENV                 "PEAK_PAUSE_TIMEOUT"
-#define PEAK_SIG_CONT_TIMEOUT_ENV              "PEAK_SIG_CONT_TIMEOUT"
-#define PEAK_HB_MIN_US_ENV                     "PEAK_HB_MIN_US"
-#define PEAK_HB_MAX_US_ENV                     "PEAK_HB_MAX_US"
-#define PEAK_HB_K_ERR_ENV                      "PEAK_HB_K_ERR"
-#define PEAK_HB_K_RATE_ENV                     "PEAK_HB_K_RATE"
-#define PEAK_HB_EMA_A_ENV                      "PEAK_HB_EMA_A"
 #define PEAK_MAX_NUM_THREADS_ENV               "PEAK_MAX_NUM_THREADS"
 /* Each target owns a 64-byte hot slot (plus optional checkpoint storage).
  * Keep the process-wide knob bounded so large target groups cannot turn an
@@ -807,6 +794,8 @@ peak_test_parse_max_num_threads(void)
 
 void peak_init()
 {
+    PeakRuntimeNumericConfig numeric_config;
+
     peak_log_configure();
     peak_max_num_threads = peak_parse_max_num_threads();
     peak_hook_address_count = parse_env_w_delim(PEAK_TARGET_ENV, PEAK_TARGET_DELIM, &peak_hook_strings);
@@ -817,33 +806,28 @@ void peak_init()
         peak_hook_address_count);
     peak_gpu_hook_address_count = parse_env_w_delim(PEAK_GPU_TARGET_ENV, PEAK_TARGET_DELIM, &peak_gpu_hook_strings);
     peak_gpu_hook_address_count += load_profiling_symbols(PEAK_GPU_TARGET_FILE_ENV, &peak_gpu_hook_strings, peak_gpu_hook_address_count);
-    peak_detach_cost = parse_env_to_float(PEAK_COST_ENV);
+    numeric_config = peak_parse_runtime_numeric_config();
+    peak_detach_cost = numeric_config.detach_cost;
     peak_gpu_monitor_all = parse_env_to_bool(PEAK_GPU_MONITOR_ALL);
     peak_truncate_function_name = parse_env_to_bool(PEAK_NAME_TRUNCATE);
-    heartbeat_time = parse_env_to_time(PEAK_HEARTBEAT_INTERVAL_ENV);
-    check_interval = parse_env_to_interval(PEAK_HIBERNATION_CYCLE_ENV);
-    target_profile_ratio = parse_env_to_float_ratio(PEAK_OVERHEAD_RATIO_ENV);
-    global_target_ratio = parse_env_to_float_ratio(PEAK_GLOBAL_OVERHEAD_RATIO_ENV);
-    peak_global_detach_factor = parse_env_to_float_detach_factor(PEAK_GLOBAL_DETACH_FACTOR_ENV);
-    peak_global_reattach_factor = parse_env_to_float_reattach_factor(PEAK_GLOBAL_REATTACH_FACTOR_ENV);
+    heartbeat_time = numeric_config.heartbeat_interval_us;
+    check_interval = numeric_config.hibernation_cycle;
+    target_profile_ratio = numeric_config.target_overhead_ratio;
+    global_target_ratio = numeric_config.global_overhead_ratio;
+    peak_global_detach_factor = numeric_config.global_detach_factor;
+    peak_global_reattach_factor = numeric_config.global_reattach_factor;
     enable_per_target_heartbeat = parse_env_to_bool(PEAK_ENABLE_PER_TARGET_HEARTBEAT_ENV);
     enable_global_heartbeat = parse_env_to_bool(PEAK_ENABLE_GLOBAL_HEARTBEAT_ENV);
     const char* enable_reattach_env = getenv(PEAK_ENABLE_REATTACH_ENV);
     enable_reattach =
         (enable_reattach_env == NULL) || parse_env_to_bool(PEAK_ENABLE_REATTACH_ENV);
-    sig_stop_ack_wait_interval = parse_env_to_post_interval(PEAK_PAUSE_TIMEOUT_ENV);
-    sig_cont_wait_interval = parse_env_to_post_interval(PEAK_SIG_CONT_TIMEOUT_ENV);
-    hb_min_us = parse_env_to_uint_default(PEAK_HB_MIN_US_ENV, 10000);
-    hb_max_us = parse_env_to_uint_default(PEAK_HB_MAX_US_ENV, 500000);
-    hb_k_err = parse_env_to_double_default(PEAK_HB_K_ERR_ENV, 3.0);
-    hb_k_rate = parse_env_to_double_default(PEAK_HB_K_RATE_ENV, 0.8);
-    hb_ema_a = parse_env_to_double_default(PEAK_HB_EMA_A_ENV, 0.3);
-    if (hb_max_us < hb_min_us) {
-        hb_max_us = hb_min_us;
-    }
-    if (hb_ema_a <= 0.0 || hb_ema_a > 1.0) {
-        hb_ema_a = 0.3;
-    }
+    sig_stop_ack_wait_interval = numeric_config.pause_timeout_ns;
+    sig_cont_wait_interval = numeric_config.sig_cont_timeout_ns;
+    hb_min_us = numeric_config.heartbeat_min_us;
+    hb_max_us = numeric_config.heartbeat_max_us;
+    hb_k_err = numeric_config.heartbeat_error_gain;
+    hb_k_rate = numeric_config.heartbeat_rate_gain;
+    hb_ema_a = numeric_config.heartbeat_ema_alpha;
     peak_memory_profile = parse_env_to_bool(PEAK_MEMORY_PROFILE);
     peak_memory_track_all = parse_env_to_bool(PEAK_MEMORY_TRACK_ALL);
 

--- a/src/utils/env_parser.c
+++ b/src/utils/env_parser.c
@@ -8,7 +8,6 @@
 #include <limits.h>
 #include <math.h>
 #include <stdlib.h>
-#include <stdatomic.h>
 #include <string.h>
 #include <strings.h>
 
@@ -25,97 +24,85 @@ typedef struct {
     double minimum;
     double maximum;
     bool zero_allowed;
+    PeakEnvWarningState* warning_emitted;
 } PeakEnvNumberSchema;
 
 #define PEAK_SECONDS_PER_MICROSECOND 1000000.0
 #define PEAK_SECONDS_PER_NANOSECOND 1000000000.0
-/* The current production numeric schemas use fewer than 32 variable names. */
-#define PEAK_ENV_WARNING_LIMIT 64U
 
-static atomic_flag peak_env_warning_lock = ATOMIC_FLAG_INIT;
-static const char* peak_env_warned_names[PEAK_ENV_WARNING_LIMIT];
-
-static bool
-peak_env_warning_first_for(const char* name)
-{
-    bool first = false;
-
-    while (atomic_flag_test_and_set_explicit(&peak_env_warning_lock,
-                                             memory_order_acquire)) {
-    }
-    for (size_t index = 0; index < PEAK_ENV_WARNING_LIMIT; index++) {
-        if (peak_env_warned_names[index] == NULL) {
-            peak_env_warned_names[index] = name;
-            first = true;
-            break;
-        }
-        if (strcmp(peak_env_warned_names[index], name) == 0) {
-            break;
-        }
-    }
-    if (!first && peak_env_warned_names[PEAK_ENV_WARNING_LIMIT - 1] != NULL) {
-        /* Preserve visibility if a future schema set outgrows this small cache. */
-        first = true;
-    }
-    atomic_flag_clear_explicit(&peak_env_warning_lock, memory_order_release);
-    return first;
-}
+static PeakEnvWarningState peak_detach_cost_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_interval_warning_emitted;
+static PeakEnvWarningState peak_hibernation_cycle_warning_emitted;
+static PeakEnvWarningState peak_target_ratio_warning_emitted;
+static PeakEnvWarningState peak_global_ratio_warning_emitted;
+static PeakEnvWarningState peak_detach_factor_warning_emitted;
+static PeakEnvWarningState peak_reattach_factor_warning_emitted;
+static PeakEnvWarningState peak_pause_timeout_warning_emitted;
+static PeakEnvWarningState peak_sig_cont_timeout_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_min_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_max_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_error_gain_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_rate_gain_warning_emitted;
+static PeakEnvWarningState peak_heartbeat_ema_alpha_warning_emitted;
 
 static const PeakEnvNumberSchema peak_detach_cost_schema = {
     "PEAK_COST", PEAK_ENV_NUMBER_REAL, "seconds", 0.0,
-    0.0, FLT_MAX, true,
+    0.0, FLT_MAX, true, &peak_detach_cost_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_interval_schema = {
     "PEAK_HEARTBEAT_INTERVAL", PEAK_ENV_NUMBER_REAL, "seconds", 0.1,
     0.0, (double)UINT_MAX / PEAK_SECONDS_PER_MICROSECOND, true,
+    &peak_heartbeat_interval_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_hibernation_cycle_schema = {
     "PEAK_HIBERNATION_CYCLE", PEAK_ENV_NUMBER_UNSIGNED, "cycles", 50.0,
-    0.0, UINT_MAX, true,
+    0.0, UINT_MAX, true, &peak_hibernation_cycle_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_target_ratio_schema = {
     "PEAK_OVERHEAD_RATIO", PEAK_ENV_NUMBER_REAL, "ratio", 0.1,
-    0.0, FLT_MAX, true,
+    0.0, FLT_MAX, true, &peak_target_ratio_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_global_ratio_schema = {
     "PEAK_GLOBAL_OVERHEAD_RATIO", PEAK_ENV_NUMBER_REAL, "ratio", 0.1,
-    0.0, FLT_MAX, true,
+    0.0, FLT_MAX, true, &peak_global_ratio_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_detach_factor_schema = {
     "PEAK_GLOBAL_DETACH_FACTOR", PEAK_ENV_NUMBER_REAL, "multiplier", 1.2,
-    1.0, FLT_MAX, false,
+    1.0, FLT_MAX, false, &peak_detach_factor_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_reattach_factor_schema = {
     "PEAK_GLOBAL_REATTACH_FACTOR", PEAK_ENV_NUMBER_REAL, "multiplier", 0.85,
-    0.0, 1.0, false,
+    0.0, 1.0, false, &peak_reattach_factor_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_pause_timeout_schema = {
     "PEAK_PAUSE_TIMEOUT", PEAK_ENV_NUMBER_REAL, "seconds", 0.01,
     0.0, (double)ULLONG_MAX / PEAK_SECONDS_PER_NANOSECOND, true,
+    &peak_pause_timeout_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_sig_cont_timeout_schema = {
     "PEAK_SIG_CONT_TIMEOUT", PEAK_ENV_NUMBER_REAL, "seconds", 0.01,
     0.0, (double)ULLONG_MAX / PEAK_SECONDS_PER_NANOSECOND, true,
+    &peak_sig_cont_timeout_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_min_schema = {
     "PEAK_HB_MIN_US", PEAK_ENV_NUMBER_UNSIGNED, "microseconds", 10000.0,
-    1.0, UINT_MAX, false,
+    1.0, UINT_MAX, false, &peak_heartbeat_min_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_max_schema = {
     "PEAK_HB_MAX_US", PEAK_ENV_NUMBER_UNSIGNED, "microseconds", 500000.0,
-    1.0, UINT_MAX, false,
+    1.0, UINT_MAX, false, &peak_heartbeat_max_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_error_gain_schema = {
     "PEAK_HB_K_ERR", PEAK_ENV_NUMBER_REAL, "gain", 3.0,
-    0.0, DBL_MAX, true,
+    0.0, DBL_MAX, true, &peak_heartbeat_error_gain_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_rate_gain_schema = {
     "PEAK_HB_K_RATE", PEAK_ENV_NUMBER_REAL, "gain", 0.8,
-    0.0, DBL_MAX, true,
+    0.0, DBL_MAX, true, &peak_heartbeat_rate_gain_warning_emitted,
 };
 static const PeakEnvNumberSchema peak_heartbeat_ema_alpha_schema = {
     "PEAK_HB_EMA_A", PEAK_ENV_NUMBER_REAL, "ratio", 0.3,
-    0.0, 1.0, false,
+    0.0, 1.0, false, &peak_heartbeat_ema_alpha_warning_emitted,
 };
 
 static void
@@ -123,7 +110,10 @@ peak_env_warn_fallback(const PeakEnvNumberSchema* schema,
                        const char* value,
                        double fallback)
 {
-    if (!peak_env_warning_first_for(schema->name)) {
+    if (schema->warning_emitted != NULL &&
+        __atomic_exchange_n(&schema->warning_emitted->emitted,
+                            1,
+                            __ATOMIC_RELAXED) != 0) {
         return;
     }
     peak_log_warn("[peak] invalid %s=%s; using %.17g %s\n",
@@ -137,7 +127,10 @@ static void
 peak_env_warn_unsigned_fallback(const PeakEnvUnsignedSchema* schema,
                                 const char* value)
 {
-    if (!peak_env_warning_first_for(schema->name)) {
+    if (schema->warning_emitted != NULL &&
+        __atomic_exchange_n(&schema->warning_emitted->emitted,
+                            1,
+                            __ATOMIC_RELAXED) != 0) {
         return;
     }
     peak_log_warn("[peak] invalid %s=%s; using %llu %s\n",
@@ -264,6 +257,7 @@ peak_parse_env_real(const PeakEnvRealSchema* schema)
     PeakEnvNumberSchema number_schema = {
         schema->name, PEAK_ENV_NUMBER_REAL, schema->unit, schema->fallback,
         schema->minimum, schema->maximum, schema->zero_allowed,
+        schema->warning_emitted,
     };
 
     return peak_env_parse_number(&number_schema, NULL, true);
@@ -348,7 +342,10 @@ peak_parse_runtime_numeric_config(void)
                                    value,
                                    (double)config.heartbeat_min_us);
         } else {
-            if (peak_env_warning_first_for(peak_heartbeat_min_schema.name)) {
+            if (__atomic_exchange_n(
+                    &peak_heartbeat_min_schema.warning_emitted->emitted,
+                    1,
+                    __ATOMIC_RELAXED) == 0) {
                 peak_log_warn("[peak] %s=%u requires %s >= %u; using %u microseconds\n",
                               peak_heartbeat_min_schema.name,
                               config.heartbeat_min_us,

--- a/src/utils/env_parser.c
+++ b/src/utils/env_parser.c
@@ -233,6 +233,18 @@ peak_parse_env_unsigned_checked(const PeakEnvUnsignedSchema* schema,
     if (value == NULL) {
         return false;
     }
+    if (schema->decimal_digits_only) {
+        if (value[0] == '\0') {
+            return false;
+        }
+        for (const unsigned char* digit = (const unsigned char*)value;
+             *digit != '\0';
+             digit++) {
+            if (*digit < (unsigned char)'0' || *digit > (unsigned char)'9') {
+                return false;
+            }
+        }
+    }
     cursor = (const unsigned char*)value;
     while (isspace(*cursor)) {
         cursor++;
@@ -257,9 +269,14 @@ unsigned long long
 peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema)
 {
     unsigned long long parsed;
+    const char* value = getenv(schema->name);
+
+    if (value == NULL) {
+        return schema->fallback;
+    }
 
     if (!peak_parse_env_unsigned_checked(schema, &parsed)) {
-        peak_env_warn_unsigned_fallback(schema, getenv(schema->name));
+        peak_env_warn_unsigned_fallback(schema, value);
         return schema->fallback;
     }
     return parsed;
@@ -284,7 +301,8 @@ peak_env_seconds_to_microseconds(const PeakEnvNumberSchema* schema)
     double seconds = peak_env_parse_number(schema, &valid, true);
     double microseconds = seconds * PEAK_SECONDS_PER_MICROSECOND;
 
-    if (valid && seconds != 0.0 && microseconds < 1.0) {
+    if (valid && seconds != 0.0 &&
+        (microseconds < 1.0 || microseconds >= 0x1p32)) {
         const char* value = getenv(schema->name);
         peak_env_warn_fallback(schema, value, schema->fallback);
         microseconds = schema->fallback * PEAK_SECONDS_PER_MICROSECOND;
@@ -301,7 +319,7 @@ peak_env_seconds_to_nanoseconds(const PeakEnvNumberSchema* schema)
         (long double)seconds * PEAK_SECONDS_PER_NANOSECOND;
 
     if (valid && seconds != 0.0 &&
-        (nanoseconds < 1.0L || nanoseconds > (long double)ULLONG_MAX)) {
+        (nanoseconds < 1.0L || nanoseconds >= 0x1p64L)) {
         const char* value = getenv(schema->name);
         peak_env_warn_fallback(schema, value, schema->fallback);
         nanoseconds = (long double)schema->fallback *

--- a/src/utils/env_parser.c
+++ b/src/utils/env_parser.c
@@ -1,190 +1,385 @@
 #include "env_parser.h"
 
+#include "logging.h"
+
 #include <errno.h>
+#include <ctype.h>
+#include <float.h>
 #include <limits.h>
+#include <math.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <string.h>
 #include <strings.h>
 
-float parse_env_to_float(const char* env_var)
+typedef enum {
+    PEAK_ENV_NUMBER_UNSIGNED,
+    PEAK_ENV_NUMBER_REAL,
+} PeakEnvNumberType;
+
+typedef struct {
+    const char* name;
+    PeakEnvNumberType type;
+    const char* unit;
+    double fallback;
+    double minimum;
+    double maximum;
+    bool zero_allowed;
+} PeakEnvNumberSchema;
+
+#define PEAK_SECONDS_PER_MICROSECOND 1000000.0
+#define PEAK_SECONDS_PER_NANOSECOND 1000000000.0
+/* The current production numeric schemas use fewer than 32 variable names. */
+#define PEAK_ENV_WARNING_LIMIT 64U
+
+static atomic_flag peak_env_warning_lock = ATOMIC_FLAG_INIT;
+static const char* peak_env_warned_names[PEAK_ENV_WARNING_LIMIT];
+
+static bool
+peak_env_warning_first_for(const char* name)
 {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        // Environment variable is not set or is empty
-        return 0.0f;
+    bool first = false;
+
+    while (atomic_flag_test_and_set_explicit(&peak_env_warning_lock,
+                                             memory_order_acquire)) {
     }
-
-    // Parse the string as a floating point number
-    char* endptr;
-    float result = strtof(varvalue, &endptr);
-
-    // Check for errors during parsing
-    if (*endptr != '\0') {
-        // The string contains invalid characters
-        return 0.0f;
+    for (size_t index = 0; index < PEAK_ENV_WARNING_LIMIT; index++) {
+        if (peak_env_warned_names[index] == NULL) {
+            peak_env_warned_names[index] = name;
+            first = true;
+            break;
+        }
+        if (strcmp(peak_env_warned_names[index], name) == 0) {
+            break;
+        }
     }
-
-    return result;
+    if (!first && peak_env_warned_names[PEAK_ENV_WARNING_LIMIT - 1] != NULL) {
+        /* Preserve visibility if a future schema set outgrows this small cache. */
+        first = true;
+    }
+    atomic_flag_clear_explicit(&peak_env_warning_lock, memory_order_release);
+    return first;
 }
 
+static const PeakEnvNumberSchema peak_detach_cost_schema = {
+    "PEAK_COST", PEAK_ENV_NUMBER_REAL, "seconds", 0.0,
+    0.0, FLT_MAX, true,
+};
+static const PeakEnvNumberSchema peak_heartbeat_interval_schema = {
+    "PEAK_HEARTBEAT_INTERVAL", PEAK_ENV_NUMBER_REAL, "seconds", 0.1,
+    0.0, (double)UINT_MAX / PEAK_SECONDS_PER_MICROSECOND, true,
+};
+static const PeakEnvNumberSchema peak_hibernation_cycle_schema = {
+    "PEAK_HIBERNATION_CYCLE", PEAK_ENV_NUMBER_UNSIGNED, "cycles", 50.0,
+    0.0, UINT_MAX, true,
+};
+static const PeakEnvNumberSchema peak_target_ratio_schema = {
+    "PEAK_OVERHEAD_RATIO", PEAK_ENV_NUMBER_REAL, "ratio", 0.1,
+    0.0, FLT_MAX, true,
+};
+static const PeakEnvNumberSchema peak_global_ratio_schema = {
+    "PEAK_GLOBAL_OVERHEAD_RATIO", PEAK_ENV_NUMBER_REAL, "ratio", 0.1,
+    0.0, FLT_MAX, true,
+};
+static const PeakEnvNumberSchema peak_detach_factor_schema = {
+    "PEAK_GLOBAL_DETACH_FACTOR", PEAK_ENV_NUMBER_REAL, "multiplier", 1.2,
+    1.0, FLT_MAX, false,
+};
+static const PeakEnvNumberSchema peak_reattach_factor_schema = {
+    "PEAK_GLOBAL_REATTACH_FACTOR", PEAK_ENV_NUMBER_REAL, "multiplier", 0.85,
+    0.0, 1.0, false,
+};
+static const PeakEnvNumberSchema peak_pause_timeout_schema = {
+    "PEAK_PAUSE_TIMEOUT", PEAK_ENV_NUMBER_REAL, "seconds", 0.01,
+    0.0, (double)ULLONG_MAX / PEAK_SECONDS_PER_NANOSECOND, true,
+};
+static const PeakEnvNumberSchema peak_sig_cont_timeout_schema = {
+    "PEAK_SIG_CONT_TIMEOUT", PEAK_ENV_NUMBER_REAL, "seconds", 0.01,
+    0.0, (double)ULLONG_MAX / PEAK_SECONDS_PER_NANOSECOND, true,
+};
+static const PeakEnvNumberSchema peak_heartbeat_min_schema = {
+    "PEAK_HB_MIN_US", PEAK_ENV_NUMBER_UNSIGNED, "microseconds", 10000.0,
+    1.0, UINT_MAX, false,
+};
+static const PeakEnvNumberSchema peak_heartbeat_max_schema = {
+    "PEAK_HB_MAX_US", PEAK_ENV_NUMBER_UNSIGNED, "microseconds", 500000.0,
+    1.0, UINT_MAX, false,
+};
+static const PeakEnvNumberSchema peak_heartbeat_error_gain_schema = {
+    "PEAK_HB_K_ERR", PEAK_ENV_NUMBER_REAL, "gain", 3.0,
+    0.0, DBL_MAX, true,
+};
+static const PeakEnvNumberSchema peak_heartbeat_rate_gain_schema = {
+    "PEAK_HB_K_RATE", PEAK_ENV_NUMBER_REAL, "gain", 0.8,
+    0.0, DBL_MAX, true,
+};
+static const PeakEnvNumberSchema peak_heartbeat_ema_alpha_schema = {
+    "PEAK_HB_EMA_A", PEAK_ENV_NUMBER_REAL, "ratio", 0.3,
+    0.0, 1.0, false,
+};
 
-float parse_env_to_float_ratio(const char* env_var)
+static void
+peak_env_warn_fallback(const PeakEnvNumberSchema* schema,
+                       const char* value,
+                       double fallback)
 {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        // Environment variable is not set or is empty
-        return 0.1f;
+    if (!peak_env_warning_first_for(schema->name)) {
+        return;
     }
-
-    // Parse the string as a floating point number
-    char* endptr;
-    float result = strtof(varvalue, &endptr);
-
-    // Check for errors during parsing
-    if (*endptr != '\0') {
-        // The string contains invalid characters
-        return 0.1f;
-    }
-
-    return result;
+    peak_log_warn("[peak] invalid %s=%s; using %.17g %s\n",
+                  schema->name,
+                  value,
+                  fallback,
+                  schema->unit);
 }
 
-
-float parse_env_to_float_detach_factor(const char* env_var)
+static void
+peak_env_warn_unsigned_fallback(const PeakEnvUnsignedSchema* schema,
+                                const char* value)
 {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        // Environment variable is not set or is empty
-        return 1.2f;
+    if (!peak_env_warning_first_for(schema->name)) {
+        return;
     }
-
-    // Parse the string as a floating point number
-    char* endptr;
-    float result = strtof(varvalue, &endptr);
-
-    // Check for errors during parsing
-    if (*endptr != '\0') {
-        // The string contains invalid characters
-        return 1.2f;
-    }
-
-    return result;
+    peak_log_warn("[peak] invalid %s=%s; using %llu %s\n",
+                  schema->name, value, schema->fallback, schema->unit);
 }
 
-float parse_env_to_float_reattach_factor(const char* env_var)
+static double
+peak_env_parse_number(const PeakEnvNumberSchema* schema,
+                      bool* valid_out,
+                      bool warn)
 {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        // Environment variable is not set or is empty
-        return 0.85f;
+    const char* value = getenv(schema->name);
+    char* end = NULL;
+    double parsed;
+
+    if (value == NULL) {
+        if (valid_out != NULL) {
+            *valid_out = true;
+        }
+        return schema->fallback;
+    }
+    if (value[0] == '\0') {
+        if (warn) {
+            peak_env_warn_fallback(schema, value, schema->fallback);
+        }
+        if (valid_out != NULL) {
+            *valid_out = false;
+        }
+        return schema->fallback;
     }
 
-    // Parse the string as a floating point number
-    char* endptr;
-    float result = strtof(varvalue, &endptr);
-
-    // Check for errors during parsing
-    if (*endptr != '\0') {
-        // The string contains invalid characters
-        return 0.85f;
-    }
-
-    return result;
-}
-
-
-unsigned int parse_env_to_time(const char* env_var) {
-    const double max_heartbeat_seconds = (double)UINT_MAX / 1e6;
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return 100000;
-    }
-
-    char* endptr;
     errno = 0;
-    double seconds = strtod(varvalue, &endptr);
+    if (schema->type == PEAK_ENV_NUMBER_UNSIGNED) {
+        unsigned long long integer;
+        const unsigned char* cursor = (const unsigned char*)value;
 
-    if (errno == ERANGE || seconds < 0 || endptr == varvalue || *endptr != '\0') {
-        return 100000;
+        while (isspace(*cursor)) {
+            cursor++;
+        }
+        if (*cursor == '-') {
+            if (warn) {
+                peak_env_warn_fallback(schema, value, schema->fallback);
+            }
+            if (valid_out != NULL) {
+                *valid_out = false;
+            }
+            return schema->fallback;
+        }
+        integer = strtoull(value, &end, 10);
+        parsed = (double)integer;
+        if (errno == ERANGE || end == value || *end != '\0' ||
+            integer > (unsigned long long)schema->maximum) {
+            if (warn) {
+                peak_env_warn_fallback(schema, value, schema->fallback);
+            }
+            if (valid_out != NULL) {
+                *valid_out = false;
+            }
+            return schema->fallback;
+        }
+    } else {
+        parsed = strtod(value, &end);
+        if (errno == ERANGE || end == value || *end != '\0' ||
+            !isfinite(parsed)) {
+            if (warn) {
+                peak_env_warn_fallback(schema, value, schema->fallback);
+            }
+            if (valid_out != NULL) {
+                *valid_out = false;
+            }
+            return schema->fallback;
+        }
     }
 
-    if (seconds > max_heartbeat_seconds) {
-        return UINT_MAX;
+    if (parsed < schema->minimum || parsed > schema->maximum ||
+        (!schema->zero_allowed && parsed == 0.0)) {
+        if (warn) {
+            peak_env_warn_fallback(schema, value, schema->fallback);
+        }
+        if (valid_out != NULL) {
+            *valid_out = false;
+        }
+        return schema->fallback;
     }
-
-    return (unsigned int)(seconds * 1e6);
+    if (valid_out != NULL) {
+        *valid_out = true;
+    }
+    return parsed;
 }
 
-unsigned int parse_env_to_interval(const char* env_var) {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return 50;
-    }
+unsigned long long
+peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema)
+{
+    const char* value = getenv(schema->name);
+    const unsigned char* cursor;
+    char* end = NULL;
+    unsigned long long parsed;
 
-    char* endptr;
+    if (value == NULL) {
+        return schema->fallback;
+    }
+    cursor = (const unsigned char*)value;
+    while (isspace(*cursor)) {
+        cursor++;
+    }
+    if (value[0] == '\0' || *cursor == '-') {
+        peak_env_warn_unsigned_fallback(schema, value);
+        return schema->fallback;
+    }
     errno = 0;
-    unsigned int result = strtoul(varvalue, &endptr, 10);
-    if (errno == ERANGE || result > UINT_MAX || *endptr != '\0') {
-        return 50;
+    parsed = strtoull(value, &end, 10);
+    if (errno == ERANGE || end == value || *end != '\0' ||
+        parsed < schema->minimum || parsed > schema->maximum ||
+        (!schema->zero_allowed && parsed == 0)) {
+        peak_env_warn_unsigned_fallback(schema, value);
+        return schema->fallback;
     }
-    return (unsigned int)result;
+    return parsed;
 }
 
-unsigned int parse_env_to_uint_default(const char* env_var, unsigned int default_value) {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return default_value;
-    }
+double
+peak_parse_env_real(const PeakEnvRealSchema* schema)
+{
+    PeakEnvNumberSchema number_schema = {
+        schema->name, PEAK_ENV_NUMBER_REAL, schema->unit, schema->fallback,
+        schema->minimum, schema->maximum, schema->zero_allowed,
+    };
 
-    char* endptr;
-    errno = 0;
-    unsigned long result = strtoul(varvalue, &endptr, 10);
-    if (errno == ERANGE || result > UINT_MAX || endptr == varvalue || *endptr != '\0') {
-        return default_value;
-    }
-    return (unsigned int)result;
+    return peak_env_parse_number(&number_schema, NULL, true);
 }
 
-double parse_env_to_double_default(const char* env_var, double default_value) {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return default_value;
-    }
+static unsigned int
+peak_env_seconds_to_microseconds(const PeakEnvNumberSchema* schema)
+{
+    bool valid;
+    double seconds = peak_env_parse_number(schema, &valid, true);
+    double microseconds = seconds * PEAK_SECONDS_PER_MICROSECOND;
 
-    char* endptr;
-    errno = 0;
-    double result = strtod(varvalue, &endptr);
-    if (errno == ERANGE || endptr == varvalue || *endptr != '\0') {
-        return default_value;
+    if (valid && seconds != 0.0 && microseconds < 1.0) {
+        const char* value = getenv(schema->name);
+        peak_env_warn_fallback(schema, value, schema->fallback);
+        microseconds = schema->fallback * PEAK_SECONDS_PER_MICROSECOND;
     }
-    return result;
+    return (unsigned int)microseconds;
 }
 
-unsigned long long parse_env_to_post_interval(const char* env_var) {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return 10000000ULL;
+static unsigned long long
+peak_env_seconds_to_nanoseconds(const PeakEnvNumberSchema* schema)
+{
+    bool valid;
+    double seconds = peak_env_parse_number(schema, &valid, true);
+    long double nanoseconds =
+        (long double)seconds * PEAK_SECONDS_PER_NANOSECOND;
+
+    if (valid && seconds != 0.0 &&
+        (nanoseconds < 1.0L || nanoseconds > (long double)ULLONG_MAX)) {
+        const char* value = getenv(schema->name);
+        peak_env_warn_fallback(schema, value, schema->fallback);
+        nanoseconds = (long double)schema->fallback *
+                      PEAK_SECONDS_PER_NANOSECOND;
     }
-
-    char* endptr;
-    errno = 0;
-    double seconds = strtod(varvalue, &endptr);
-
-    if (errno == ERANGE || seconds < 0 || endptr == varvalue || *endptr != '\0') {
-        return 10000000ULL;
-    }
-
-    return (unsigned long long)(seconds * 1e9);
+    return (unsigned long long)nanoseconds;
 }
 
-bool parse_env_to_bool(const char* env_var) {
-    char* varvalue = getenv(env_var);
-    if (varvalue == NULL) {
-        return false;
-    }
+PeakRuntimeNumericConfig
+peak_parse_runtime_numeric_config(void)
+{
+    bool heartbeat_max_valid;
+    PeakRuntimeNumericConfig config = {
+        .detach_cost =
+            (float)peak_env_parse_number(&peak_detach_cost_schema, NULL, true),
+        .heartbeat_interval_us =
+            peak_env_seconds_to_microseconds(&peak_heartbeat_interval_schema),
+        .hibernation_cycle =
+            (unsigned int)peak_env_parse_number(&peak_hibernation_cycle_schema,
+                                                NULL, true),
+        .target_overhead_ratio =
+            (float)peak_env_parse_number(&peak_target_ratio_schema, NULL, true),
+        .global_overhead_ratio =
+            (float)peak_env_parse_number(&peak_global_ratio_schema, NULL, true),
+        .global_detach_factor =
+            (float)peak_env_parse_number(&peak_detach_factor_schema, NULL, true),
+        .global_reattach_factor =
+            (float)peak_env_parse_number(&peak_reattach_factor_schema, NULL, true),
+        .pause_timeout_ns =
+            peak_env_seconds_to_nanoseconds(&peak_pause_timeout_schema),
+        .sig_cont_timeout_ns =
+            peak_env_seconds_to_nanoseconds(&peak_sig_cont_timeout_schema),
+        .heartbeat_min_us =
+            (unsigned int)peak_env_parse_number(&peak_heartbeat_min_schema,
+                                                NULL, true),
+        .heartbeat_max_us =
+            (unsigned int)peak_env_parse_number(&peak_heartbeat_max_schema,
+                                                &heartbeat_max_valid, false),
+        .heartbeat_error_gain =
+            peak_env_parse_number(&peak_heartbeat_error_gain_schema, NULL, true),
+        .heartbeat_rate_gain =
+            peak_env_parse_number(&peak_heartbeat_rate_gain_schema, NULL, true),
+        .heartbeat_ema_alpha =
+            peak_env_parse_number(&peak_heartbeat_ema_alpha_schema, NULL, true),
+    };
 
-    if (strcasecmp(varvalue, "true") == 0 || strcmp(varvalue, "1") == 0) {
-        return true;
+    if (config.heartbeat_max_us < config.heartbeat_min_us) {
+        const char* value = getenv(peak_heartbeat_max_schema.name);
+
+        if (value != NULL) {
+            peak_env_warn_fallback(&peak_heartbeat_max_schema,
+                                   value,
+                                   (double)config.heartbeat_min_us);
+        } else {
+            if (peak_env_warning_first_for(peak_heartbeat_min_schema.name)) {
+                peak_log_warn("[peak] %s=%u requires %s >= %u; using %u microseconds\n",
+                              peak_heartbeat_min_schema.name,
+                              config.heartbeat_min_us,
+                              peak_heartbeat_max_schema.name,
+                              config.heartbeat_min_us,
+                              config.heartbeat_min_us);
+            }
+        }
+        config.heartbeat_max_us = config.heartbeat_min_us;
+    } else if (!heartbeat_max_valid) {
+        peak_env_warn_fallback(&peak_heartbeat_max_schema,
+                               getenv(peak_heartbeat_max_schema.name),
+                               peak_heartbeat_max_schema.fallback);
     }
-    return false;
+    if (config.global_reattach_factor >= config.global_detach_factor) {
+        const char* value = getenv(peak_reattach_factor_schema.name);
+
+        peak_env_warn_fallback(&peak_reattach_factor_schema,
+                               value,
+                               peak_reattach_factor_schema.fallback);
+        config.global_reattach_factor =
+            (float)peak_reattach_factor_schema.fallback;
+    }
+    return config;
+}
+
+bool
+parse_env_to_bool(const char* env_var)
+{
+    const char* varvalue = getenv(env_var);
+
+    return varvalue != NULL &&
+           (strcasecmp(varvalue, "true") == 0 || strcmp(varvalue, "1") == 0);
 }

--- a/src/utils/env_parser.c
+++ b/src/utils/env_parser.c
@@ -221,8 +221,9 @@ peak_env_parse_number(const PeakEnvNumberSchema* schema,
     return parsed;
 }
 
-unsigned long long
-peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema)
+bool
+peak_parse_env_unsigned_checked(const PeakEnvUnsignedSchema* schema,
+                                unsigned long long* value_out)
 {
     const char* value = getenv(schema->name);
     const unsigned char* cursor;
@@ -230,22 +231,35 @@ peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema)
     unsigned long long parsed;
 
     if (value == NULL) {
-        return schema->fallback;
+        return false;
     }
     cursor = (const unsigned char*)value;
     while (isspace(*cursor)) {
         cursor++;
     }
     if (value[0] == '\0' || *cursor == '-') {
-        peak_env_warn_unsigned_fallback(schema, value);
-        return schema->fallback;
+        return false;
     }
     errno = 0;
     parsed = strtoull(value, &end, 10);
     if (errno == ERANGE || end == value || *end != '\0' ||
         parsed < schema->minimum || parsed > schema->maximum ||
         (!schema->zero_allowed && parsed == 0)) {
-        peak_env_warn_unsigned_fallback(schema, value);
+        return false;
+    }
+    if (value_out != NULL) {
+        *value_out = parsed;
+    }
+    return true;
+}
+
+unsigned long long
+peak_parse_env_unsigned(const PeakEnvUnsignedSchema* schema)
+{
+    unsigned long long parsed;
+
+    if (!peak_parse_env_unsigned_checked(schema, &parsed)) {
+        peak_env_warn_unsigned_fallback(schema, getenv(schema->name));
         return schema->fallback;
     }
     return parsed;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -305,6 +305,14 @@ if(BUILD_TESTING)
     set_tests_properties(test_runtime_config
         PROPERTIES
             PASS_REGULAR_EXPRESSION "runtime_config_test_ok")
+    add_test(NAME test_runtime_config_detach_empty_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_DETACH_COUNT=; using 0 calls"
+                --stderr-count-regex "invalid PEAK_DETACH_COUNT=; using 0 calls"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_runtime_config> detach-empty-warning)
 
     add_executable(test_numeric_env_parser
         utils/test_numeric_env_parser.c
@@ -316,6 +324,12 @@ if(BUILD_TESTING)
     add_test(NAME test_numeric_env_parser COMMAND test_numeric_env_parser)
     set_tests_properties(test_numeric_env_parser
         PROPERTIES PASS_REGULAR_EXPRESSION "numeric_env_parser_test_ok")
+    add_executable(test_env_parser_header_cxx
+        utils/test_env_parser_header_cxx.cpp)
+    target_include_directories(test_env_parser_header_cxx PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils)
+    add_test(NAME test_env_parser_header_cxx COMMAND test_env_parser_header_cxx)
     add_test(NAME test_numeric_env_parser_single_warning
         COMMAND ${Python3_EXECUTABLE}
                 ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1288,6 +1288,9 @@ if(BUILD_TESTING)
                 PASS_REGULAR_EXPRESSION "hotloop_trace_check_ok")
         # Hosted runners can perturb these short baselines substantially. Keep
         # this smoke test structural; Frontera same-node B-A-B owns performance.
+        add_test(NAME test_detach_milc_like_timed_window_scheduler
+            COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_detach_milc_like
+                    --timed-window-scheduler-self-test)
         add_test(NAME test_detach_milc_like_ab_strict
             COMMAND ${Python3_EXECUTABLE}
                     ${PROJECT_SOURCE_DIR}/test/detach_runtime/run_detach_milc_like_ab_check.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -362,6 +362,22 @@ if(BUILD_TESTING)
                 --stderr-count-regex "invalid PEAK_COST=nan"
                 --stderr-count 1
                 -- $<TARGET_FILE:test_numeric_env_parser> repeated-warning)
+    add_test(NAME test_numeric_env_parser_cuda_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_CUDA_EVENT_POOL_CAPACITY=; using 256 events"
+                --stderr-count-regex "invalid PEAK_CUDA_EVENT_POOL_CAPACITY="
+                --stderr-count 1
+                -- $<TARGET_FILE:test_numeric_env_parser> cuda-warning)
+    add_test(NAME test_numeric_env_parser_unsigned_unset
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "^$"
+                --stderr-count-regex "invalid PEAK_CUDA_EVENT_POOL_CAPACITY="
+                --stderr-count 0
+                -- $<TARGET_FILE:test_numeric_env_parser> cuda-unset)
 
     add_executable(test_attach_policy
         report/test_attach_policy.c
@@ -673,6 +689,30 @@ if(BUILD_TESTING)
             PROPERTIES
                 ENVIRONMENT "${PRELOAD_VAR}"
                 PASS_REGULAR_EXPRESSION "max_threads_parser_ok"
+                TIMEOUT 20)
+        add_test(NAME test_max_threads_parser_warning
+            COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_MAX_NUM_THREADS=junk; using [0-9]+ thread slots"
+                --stderr-count-regex "PEAK_MAX_NUM_THREADS=junk"
+                --stderr-count 1
+                -- ${PROJECT_BINARY_DIR}/test/detach_runtime/test_max_threads_parser warning)
+        set_tests_properties(test_max_threads_parser_warning
+            PROPERTIES
+                ENVIRONMENT "${PRELOAD_VAR}"
+                TIMEOUT 20)
+        add_test(NAME test_max_threads_parser_empty_warning
+            COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_MAX_NUM_THREADS=; using [0-9]+ thread slots"
+                --stderr-count-regex "PEAK_MAX_NUM_THREADS="
+                --stderr-count 1
+                -- ${PROJECT_BINARY_DIR}/test/detach_runtime/test_max_threads_parser empty-warning)
+        set_tests_properties(test_max_threads_parser_empty_warning
+            PROPERTIES
+                ENVIRONMENT "${PRELOAD_VAR}"
                 TIMEOUT 20)
 
         add_test(NAME test_fastpath_thread_exit_slot_reuse

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,6 +196,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/utils)
     target_compile_options(test_report_formatter PRIVATE -UNDEBUG)
+    target_link_libraries(test_report_formatter PRIVATE Threads::Threads)
     add_test(NAME test_report_formatter COMMAND test_report_formatter)
     set_tests_properties(test_report_formatter
         PROPERTIES
@@ -254,6 +255,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/include/utils
         ${FRIDA_GUM_INCLUDE_DIRS})
     target_link_libraries(test_mpi_report_request_lifetime PRIVATE
+        Threads::Threads
         ${RT_LIBRARY}
         ${M_LIBRARY})
     add_test(NAME test_mpi_report_request_lifetime
@@ -283,6 +285,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/utils)
     target_link_libraries(test_mpi_teardown_guard PRIVATE
+        Threads::Threads
         ${RT_LIBRARY})
     add_test(NAME test_mpi_teardown_guard COMMAND test_mpi_teardown_guard)
     set_tests_properties(test_mpi_teardown_guard
@@ -302,6 +305,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_runtime_config PRIVATE
         PEAK_RUNTIME_CONFIG_TEST_MUTABLE_ENV=1
         PEAK_ENABLE_TEST_HOOKS=1)
+    target_link_libraries(test_runtime_config PRIVATE Threads::Threads)
     add_test(NAME test_runtime_config COMMAND test_runtime_config)
     set_tests_properties(test_runtime_config
         PROPERTIES
@@ -338,6 +342,7 @@ if(BUILD_TESTING)
     target_include_directories(test_numeric_env_parser PRIVATE
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/utils)
+    target_link_libraries(test_numeric_env_parser PRIVATE Threads::Threads)
     add_test(NAME test_numeric_env_parser COMMAND test_numeric_env_parser)
     set_tests_properties(test_numeric_env_parser
         PROPERTIES PASS_REGULAR_EXPRESSION "numeric_env_parser_test_ok")
@@ -357,6 +362,8 @@ if(BUILD_TESTING)
         target_link_options(test_numeric_env_parser_long_double_64 PRIVATE
             -fsanitize=undefined,float-cast-overflow
             -fno-sanitize-recover=all)
+        target_link_libraries(test_numeric_env_parser_long_double_64
+            PRIVATE Threads::Threads)
         add_test(NAME test_numeric_env_parser_long_double_64
             COMMAND test_numeric_env_parser_long_double_64)
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -313,6 +313,14 @@ if(BUILD_TESTING)
                 --stderr-count-regex "invalid PEAK_DETACH_COUNT=; using 0 calls"
                 --stderr-count 1
                 -- $<TARGET_FILE:test_runtime_config> detach-empty-warning)
+    add_test(NAME test_runtime_config_timeout_fallback_warnings
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "(?s)invalid PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS=junk; using 60000 milliseconds.*invalid PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS=junk; using 340000 milliseconds.*invalid PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS=junk; using 180000 milliseconds"
+                --stderr-count-regex "invalid PEAK_(OUTPUT_AGGREGATION_TIMEOUT_MS|OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS|MPI_REPORT_RELEASE_TIMEOUT_MS)=junk"
+                --stderr-count 3
+                -- $<TARGET_FILE:test_runtime_config> timeout-warning)
 
     add_executable(test_numeric_env_parser
         utils/test_numeric_env_parser.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(CTest)
 if(BUILD_TESTING)
+    include(CheckCCompilerFlag)
     option(PEAK_BUILD_DYNAMIC_LIB_TESTS "Build dynamic dlopen/Python extension tests" ON)
 
     # Find or download blas only for tests
@@ -321,6 +322,14 @@ if(BUILD_TESTING)
                 --stderr-count-regex "invalid PEAK_(OUTPUT_AGGREGATION_TIMEOUT_MS|OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS|MPI_REPORT_RELEASE_TIMEOUT_MS)=junk"
                 --stderr-count 3
                 -- $<TARGET_FILE:test_runtime_config> timeout-warning)
+    add_test(NAME test_runtime_config_timeout_raise_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS=100 is below required minimum 4510 milliseconds; using 4510 milliseconds"
+                --stderr-count-regex "PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS=100 is below required minimum 4510 milliseconds"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_runtime_config> timeout-raise-warning)
 
     add_executable(test_numeric_env_parser
         utils/test_numeric_env_parser.c
@@ -332,6 +341,25 @@ if(BUILD_TESTING)
     add_test(NAME test_numeric_env_parser COMMAND test_numeric_env_parser)
     set_tests_properties(test_numeric_env_parser
         PROPERTIES PASS_REGULAR_EXPRESSION "numeric_env_parser_test_ok")
+    check_c_compiler_flag("-mlong-double-64" PEAK_HAVE_LONG_DOUBLE_64_FLAG)
+    if(PEAK_HAVE_LONG_DOUBLE_64_FLAG)
+        add_executable(test_numeric_env_parser_long_double_64
+            utils/test_numeric_env_parser.c
+            ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
+            ${PROJECT_SOURCE_DIR}/src/logging.c)
+        target_include_directories(test_numeric_env_parser_long_double_64 PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/include/utils)
+        target_compile_options(test_numeric_env_parser_long_double_64 PRIVATE
+            -mlong-double-64
+            -fsanitize=undefined,float-cast-overflow
+            -fno-sanitize-recover=all)
+        target_link_options(test_numeric_env_parser_long_double_64 PRIVATE
+            -fsanitize=undefined,float-cast-overflow
+            -fno-sanitize-recover=all)
+        add_test(NAME test_numeric_env_parser_long_double_64
+            COMMAND test_numeric_env_parser_long_double_64)
+    endif()
     add_executable(test_env_parser_header_cxx
         utils/test_env_parser_header_cxx.cpp)
     target_include_directories(test_env_parser_header_cxx PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,9 +189,11 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
         ${PROJECT_SOURCE_DIR}/src/logging.c)
     target_include_directories(test_report_formatter PRIVATE
-        ${PROJECT_SOURCE_DIR}/include)
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils)
     target_compile_options(test_report_formatter PRIVATE -UNDEBUG)
     add_test(NAME test_report_formatter COMMAND test_report_formatter)
     set_tests_properties(test_report_formatter
@@ -205,11 +207,13 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_maxima.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
         ${PROJECT_SOURCE_DIR}/src/logging.c)
     target_compile_definitions(test_socket_report_transport PRIVATE
         PEAK_ENABLE_TEST_HOOKS=1)
     target_include_directories(test_socket_report_transport PRIVATE
         ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils
         ${FRIDA_GUM_INCLUDE_DIRS})
     target_link_libraries(test_socket_report_transport PRIVATE
         Threads::Threads
@@ -236,6 +240,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_maxima.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
         ${PROJECT_SOURCE_DIR}/src/utils/timing.c
         ${PROJECT_SOURCE_DIR}/src/logging.c)
     target_compile_definitions(test_mpi_report_request_lifetime PRIVATE
@@ -288,9 +293,11 @@ if(BUILD_TESTING)
     add_executable(test_runtime_config
         report/test_runtime_config.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
         ${PROJECT_SOURCE_DIR}/src/logging.c)
     target_include_directories(test_runtime_config PRIVATE
-        ${PROJECT_SOURCE_DIR}/include)
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils)
     target_compile_definitions(test_runtime_config PRIVATE
         PEAK_RUNTIME_CONFIG_TEST_MUTABLE_ENV=1
         PEAK_ENABLE_TEST_HOOKS=1)
@@ -299,14 +306,51 @@ if(BUILD_TESTING)
         PROPERTIES
             PASS_REGULAR_EXPRESSION "runtime_config_test_ok")
 
+    add_executable(test_numeric_env_parser
+        utils/test_numeric_env_parser.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
+        ${PROJECT_SOURCE_DIR}/src/logging.c)
+    target_include_directories(test_numeric_env_parser PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils)
+    add_test(NAME test_numeric_env_parser COMMAND test_numeric_env_parser)
+    set_tests_properties(test_numeric_env_parser
+        PROPERTIES PASS_REGULAR_EXPRESSION "numeric_env_parser_test_ok")
+    add_test(NAME test_numeric_env_parser_single_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_HB_MAX_US=junk; using 600000 microseconds"
+                --stderr-count-regex "invalid PEAK_HB_MAX_US=junk"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_numeric_env_parser> warning)
+    add_test(NAME test_numeric_env_parser_unset_maximum_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "PEAK_HB_MIN_US=600000 requires PEAK_HB_MAX_US >= 600000"
+                --stderr-count-regex "PEAK_HB_MIN_US=600000 requires PEAK_HB_MAX_US >= 600000"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_numeric_env_parser> unset-warning)
+    add_test(NAME test_numeric_env_parser_repeated_warning
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "invalid PEAK_COST=nan"
+                --stderr-count-regex "invalid PEAK_COST=nan"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_numeric_env_parser> repeated-warning)
+
     add_executable(test_attach_policy
         report/test_attach_policy.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/attach_policy.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
+        ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
         ${PROJECT_SOURCE_DIR}/src/unsafe_gum_prologue.c
         ${PROJECT_SOURCE_DIR}/src/logging.c)
     target_include_directories(test_attach_policy PRIVATE
         ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include/utils
         ${FRIDA_GUM_INCLUDE_DIRS})
     target_compile_options(test_attach_policy PRIVATE -UNDEBUG)
     target_link_libraries(test_attach_policy PRIVATE

--- a/test/detach_runtime/test_detach_milc_like.c
+++ b/test/detach_runtime/test_detach_milc_like.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include <errno.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <sched.h>
 #include <stdatomic.h>
@@ -143,15 +144,15 @@ typedef struct {
 } CallCheckpoint;
 
 typedef struct {
-    double duration;
-    double window_seconds;
+    uint64_t duration_seconds;
+    uint64_t window_ms;
     double previous_elapsed;
     uint64_t previous_calls;
-    unsigned int next_index;
+    uint64_t next_index;
 } TimedWindowScheduler;
 
 typedef struct {
-    unsigned int index;
+    uint64_t index;
     double elapsed;
     uint64_t true_calls;
 } TimedWindow;
@@ -467,9 +468,9 @@ sleep_until(double deadline)
 }
 
 static void
-print_window(unsigned int index, double elapsed, uint64_t true_calls)
+print_window(uint64_t index, double elapsed, uint64_t true_calls)
 {
-    printf("milc_like_window index=%u elapsed=%.9f true_calls=%llu\n",
+    printf("milc_like_window index=%" PRIu64 " elapsed=%.9f true_calls=%llu\n",
            index,
            elapsed,
            (unsigned long long)true_calls);
@@ -510,16 +511,43 @@ interpolate_window_calls(double previous_elapsed,
 }
 
 static int
+timed_window_is_before_duration(uint64_t index,
+                                uint64_t window_ms,
+                                uint64_t duration_seconds)
+{
+    uint64_t whole_seconds = window_ms / 1000;
+    uint64_t remainder_ms = window_ms % 1000;
+    uint64_t elapsed_seconds = 0;
+    uint64_t remainder_seconds;
+
+    /* Split milliseconds so neither side of the boundary comparison wraps. */
+    if (whole_seconds > 0) {
+        if (index > duration_seconds / whole_seconds) {
+            return 0;
+        }
+        elapsed_seconds = index * whole_seconds;
+    }
+    remainder_seconds =
+        (index / 1000) * remainder_ms +
+        ((index % 1000) * remainder_ms) / 1000;
+    return elapsed_seconds < duration_seconds &&
+           remainder_seconds < duration_seconds - elapsed_seconds;
+}
+
+static int
 timed_window_scheduler_next(TimedWindowScheduler* scheduler,
                             double observed_elapsed,
                             uint64_t observed_calls,
                             TimedWindow* window)
 {
     double window_elapsed =
-        (double)scheduler->next_index * scheduler->window_seconds;
+        (double)scheduler->next_index * (double)scheduler->window_ms / 1000.0;
 
     /* A periodic boundary at the deadline belongs to the final sample. */
-    if (window_elapsed >= scheduler->duration ||
+    if (scheduler->next_index == UINT64_MAX ||
+        !timed_window_is_before_duration(scheduler->next_index,
+                                         scheduler->window_ms,
+                                         scheduler->duration_seconds) ||
         window_elapsed > observed_elapsed) {
         return 0;
     }
@@ -551,14 +579,14 @@ static int
 run_timed_window_scheduler_self_test(void)
 {
     TimedWindowScheduler scheduler = {
-        .duration = 6.0,
-        .window_seconds = 1.0,
+        .duration_seconds = 6,
+        .window_ms = 1000,
         .previous_elapsed = 0.0,
         .previous_calls = 100,
         .next_index = 1,
     };
     TimedWindow window;
-    unsigned int expected_index = 1;
+    uint64_t expected_index = 1;
 
     while (timed_window_scheduler_next(&scheduler, 6.0, 700, &window)) {
         uint64_t expected_calls = 100 + (uint64_t)expected_index * 100;
@@ -576,6 +604,46 @@ run_timed_window_scheduler_self_test(void)
         return 1;
     }
     timed_window_scheduler_observe(&scheduler, 6.0, 700);
+
+    scheduler = (TimedWindowScheduler){
+        .duration_seconds = 27,
+        .window_ms = 9,
+        .previous_elapsed = 0.0,
+        .previous_calls = 0,
+        .next_index = 1,
+    };
+    expected_index = 1;
+    {
+        uint64_t previous_calls = 0;
+
+        while (timed_window_scheduler_next(&scheduler,
+                                           27.0,
+                                           UINT64_C(3000000),
+                                           &window)) {
+            if (window.index != expected_index ||
+                window.elapsed >= 27.0 ||
+                window.true_calls <= previous_calls) {
+                fprintf(stderr,
+                        "timed window scheduler missed-boundary failed\n");
+                return 1;
+            }
+            previous_calls = window.true_calls;
+            expected_index++;
+        }
+    }
+    if (expected_index != 3000 || scheduler.next_index != 3000 ||
+        !timed_window_is_before_duration(2999, 9, 27) ||
+        timed_window_is_before_duration(3000, 9, 27)) {
+        fprintf(stderr, "timed window scheduler boundary classification failed\n");
+        return 1;
+    }
+    if (!timed_window_is_before_duration(UINT64_MAX, 1, UINT64_MAX) ||
+        timed_window_is_before_duration(UINT64_MAX, 1000, UINT64_MAX) ||
+        !timed_window_is_before_duration(UINT64_MAX, 999, UINT64_MAX) ||
+        timed_window_is_before_duration(UINT64_MAX, 1001, UINT64_MAX)) {
+        fprintf(stderr, "timed window scheduler overflow check failed\n");
+        return 1;
+    }
     printf("timed_window_scheduler_ok\n");
     return 0;
 }
@@ -796,10 +864,9 @@ main(int argc, char** argv)
         next_checkpoint_calls = initial_calls + (uint64_t)checkpoint_calls;
     }
     if (iterations == 0) {
-        double window_seconds = (double)window_ms / 1000.0;
         TimedWindowScheduler window_scheduler = {
-            .duration = (double)seconds,
-            .window_seconds = window_seconds,
+            .duration_seconds = (uint64_t)seconds,
+            .window_ms = (uint64_t)window_ms,
             .previous_elapsed = 0.0,
             .previous_calls = initial_calls,
             .next_index = 1,
@@ -834,8 +901,8 @@ main(int argc, char** argv)
             double final_elapsed = monotonic_seconds() - start;
             uint64_t final_calls = load_total_target_count();
 
-            if (final_elapsed < window_scheduler.duration) {
-                final_elapsed = window_scheduler.duration;
+            if (final_elapsed < (double)window_scheduler.duration_seconds) {
+                final_elapsed = (double)window_scheduler.duration_seconds;
             }
             while (timed_window_scheduler_next(&window_scheduler,
                                                final_elapsed,

--- a/test/detach_runtime/test_detach_milc_like.c
+++ b/test/detach_runtime/test_detach_milc_like.c
@@ -142,6 +142,20 @@ typedef struct {
     uint64_t true_calls;
 } CallCheckpoint;
 
+typedef struct {
+    double duration;
+    double window_seconds;
+    double previous_elapsed;
+    uint64_t previous_calls;
+    unsigned int next_index;
+} TimedWindowScheduler;
+
+typedef struct {
+    unsigned int index;
+    double elapsed;
+    uint64_t true_calls;
+} TimedWindow;
+
 static double
 monotonic_seconds(void)
 {
@@ -462,6 +476,110 @@ print_window(unsigned int index, double elapsed, uint64_t true_calls)
     fflush(stdout);
 }
 
+static uint64_t
+interpolate_window_calls(double previous_elapsed,
+                         uint64_t previous_calls,
+                         double observed_elapsed,
+                         uint64_t observed_calls,
+                         double window_elapsed)
+{
+    long double fraction;
+    long double increment;
+    uint64_t delta;
+
+    if (observed_calls <= previous_calls ||
+        observed_elapsed <= previous_elapsed ||
+        window_elapsed <= previous_elapsed) {
+        return previous_calls;
+    }
+    if (window_elapsed >= observed_elapsed) {
+        return observed_calls;
+    }
+
+    delta = observed_calls - previous_calls;
+    fraction = ((long double)window_elapsed - previous_elapsed) /
+               ((long double)observed_elapsed - previous_elapsed);
+    increment = fraction * delta;
+    if (increment <= 0.0L) {
+        return previous_calls;
+    }
+    if (increment >= delta) {
+        return observed_calls;
+    }
+    return previous_calls + (uint64_t)increment;
+}
+
+static int
+timed_window_scheduler_next(TimedWindowScheduler* scheduler,
+                            double observed_elapsed,
+                            uint64_t observed_calls,
+                            TimedWindow* window)
+{
+    double window_elapsed =
+        (double)scheduler->next_index * scheduler->window_seconds;
+
+    /* A periodic boundary at the deadline belongs to the final sample. */
+    if (window_elapsed >= scheduler->duration ||
+        window_elapsed > observed_elapsed) {
+        return 0;
+    }
+
+    window->index = scheduler->next_index;
+    window->elapsed = window_elapsed;
+    window->true_calls = interpolate_window_calls(scheduler->previous_elapsed,
+                                                   scheduler->previous_calls,
+                                                   observed_elapsed,
+                                                   observed_calls,
+                                                   window_elapsed);
+    scheduler->next_index++;
+    return 1;
+}
+
+static void
+timed_window_scheduler_observe(TimedWindowScheduler* scheduler,
+                               double observed_elapsed,
+                               uint64_t observed_calls)
+{
+    if (observed_elapsed >= scheduler->previous_elapsed &&
+        observed_calls >= scheduler->previous_calls) {
+        scheduler->previous_elapsed = observed_elapsed;
+        scheduler->previous_calls = observed_calls;
+    }
+}
+
+static int
+run_timed_window_scheduler_self_test(void)
+{
+    TimedWindowScheduler scheduler = {
+        .duration = 6.0,
+        .window_seconds = 1.0,
+        .previous_elapsed = 0.0,
+        .previous_calls = 100,
+        .next_index = 1,
+    };
+    TimedWindow window;
+    unsigned int expected_index = 1;
+
+    while (timed_window_scheduler_next(&scheduler, 6.0, 700, &window)) {
+        uint64_t expected_calls = 100 + (uint64_t)expected_index * 100;
+
+        if (window.index != expected_index ||
+            window.elapsed != (double)expected_index ||
+            window.true_calls != expected_calls) {
+            fprintf(stderr, "timed window scheduler interpolation failed\n");
+            return 1;
+        }
+        expected_index++;
+    }
+    if (expected_index != 6 || scheduler.next_index != 6) {
+        fprintf(stderr, "timed window scheduler included deadline boundary\n");
+        return 1;
+    }
+    timed_window_scheduler_observe(&scheduler, 6.0, 700);
+    printf("timed_window_scheduler_ok\n");
+    return 0;
+}
+
 static void
 print_checkpoint(unsigned int index, double elapsed, uint64_t true_calls)
 {
@@ -591,6 +709,10 @@ main(int argc, char** argv)
     unsigned int allowed_cpu_count = 0;
     unsigned int pinned_worker_count = 0;
 
+    if (has_flag(argc, argv, "--timed-window-scheduler-self-test")) {
+        return run_timed_window_scheduler_self_test();
+    }
+
     target_inner_work = (unsigned int)inner_work;
     if (thread_count > 256) {
         thread_count = 256;
@@ -675,32 +797,56 @@ main(int argc, char** argv)
     }
     if (iterations == 0) {
         double window_seconds = (double)window_ms / 1000.0;
-        double next_window = start + window_seconds;
-        unsigned int window_index = 0;
+        TimedWindowScheduler window_scheduler = {
+            .duration = (double)seconds,
+            .window_seconds = window_seconds,
+            .previous_elapsed = 0.0,
+            .previous_calls = initial_calls,
+            .next_index = 1,
+        };
+        TimedWindow window;
 
-        print_window(window_index, 0.0, initial_calls);
+        print_window(0, 0.0, initial_calls);
         while (monotonic_seconds() < deadline) {
             double now = monotonic_seconds();
+            double elapsed_window = now - start;
             uint64_t true_calls = load_total_target_count();
 
-            if (now >= next_window) {
-                window_index++;
-                print_window(window_index, now - start, true_calls);
-                next_window += window_seconds;
+            while (timed_window_scheduler_next(&window_scheduler,
+                                               elapsed_window,
+                                               true_calls,
+                                               &window)) {
+                print_window(window.index, window.elapsed, window.true_calls);
             }
+            timed_window_scheduler_observe(&window_scheduler,
+                                           elapsed_window,
+                                           true_calls);
             record_timed_checkpoint_sample(checkpoints,
                                            &checkpoint_count,
                                            (unsigned int)checkpoint_limit,
                                            checkpoint_calls,
                                            &next_checkpoint_calls,
-                                           now - start,
+                                           elapsed_window,
                                            true_calls);
             sleep_until(now + 0.001);
         }
-        window_index++;
-        print_window(window_index,
-                     monotonic_seconds() - start,
-                     load_total_target_count());
+        {
+            double final_elapsed = monotonic_seconds() - start;
+            uint64_t final_calls = load_total_target_count();
+
+            if (final_elapsed < window_scheduler.duration) {
+                final_elapsed = window_scheduler.duration;
+            }
+            while (timed_window_scheduler_next(&window_scheduler,
+                                               final_elapsed,
+                                               final_calls,
+                                               &window)) {
+                print_window(window.index, window.elapsed, window.true_calls);
+            }
+            print_window(window_scheduler.next_index,
+                         final_elapsed,
+                         final_calls);
+        }
     } else {
         while (atomic_load_explicit(&completed_worker_count,
                                     memory_order_acquire) <

--- a/test/detach_runtime/test_max_threads_parser.c
+++ b/test/detach_runtime/test_max_threads_parser.c
@@ -3,11 +3,12 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 typedef unsigned long (*PeakParseMaxThreads)(void);
 
 int
-main(void)
+main(int argc, char** argv)
 {
     static const struct {
         const char* value;
@@ -26,6 +27,21 @@ main(void)
     if (parse == NULL) {
         fputs("missing max-thread parser test hook\n", stderr);
         return 1;
+    }
+
+    if (argc == 2 &&
+        (strcmp(argv[1], "warning") == 0 ||
+         strcmp(argv[1], "empty-warning") == 0)) {
+        unsigned long fallback;
+
+        setenv("PEAK_MAX_NUM_THREADS",
+               strcmp(argv[1], "empty-warning") == 0 ? "" : "junk", 1);
+        fallback = parse();
+        if (fallback == 0 || parse() != fallback) {
+            fputs("invalid max-thread fallback mismatch\n", stderr);
+            return 1;
+        }
+        return 0;
     }
 
     unsetenv("PEAK_MAX_NUM_THREADS");

--- a/test/dgemm_mpi/CMakeLists.txt
+++ b/test/dgemm_mpi/CMakeLists.txt
@@ -64,6 +64,7 @@ target_compile_definitions(test_mpi_report_transport
     PRIVATE PEAK_ENABLE_TEST_HOOKS=1 HAVE_MPI=1)
 target_link_libraries(test_mpi_report_transport PRIVATE
     MPI::MPI_C
+    Threads::Threads
     ${RT_LIBRARY}
     m)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/test/dgemm_mpi/CMakeLists.txt
+++ b/test/dgemm_mpi/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(test_mpi_report_transport
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_maxima.c
+    ${PROJECT_SOURCE_DIR}/src/utils/env_parser.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/runtime_config.c
     ${PROJECT_SOURCE_DIR}/src/utils/timing.c
     ${PROJECT_SOURCE_DIR}/src/logging.c)

--- a/test/report/test_runtime_config.c
+++ b/test/report/test_runtime_config.c
@@ -9,7 +9,6 @@
 
 static const char* const peak_test_environment_names[] = {
     "PEAK_DETACH_COUNT",
-    "PEAK_TEST_UINT",
     "MPI_LOCALNRANKS",
     "OMPI_COMM_WORLD_LOCAL_SIZE",
     "MV2_COMM_WORLD_LOCAL_SIZE",
@@ -55,72 +54,6 @@ check_truthy_values(void)
            !peak_general_listener_env_value_truthy("on") ||
            peak_general_listener_env_value_truthy("0") ||
            peak_general_listener_env_value_truthy("true ");
-}
-
-static int
-check_unsigned_parser(void)
-{
-    char negative[64];
-    char spaced_negative[66];
-
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "0", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 0U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "42", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 42U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "42junk", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U ||
-        snprintf(negative, sizeof(negative), "-%lu", ULONG_MAX) >=
-            (int)sizeof(negative) ||
-        snprintf(spaced_negative,
-                 sizeof(spaced_negative),
-                 "  -%lu",
-                 ULONG_MAX) >= (int)sizeof(spaced_negative)) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", negative, 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", spaced_negative, 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "-0", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "-1", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 7U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", "+42", 1);
-    if (peak_general_listener_parse_uint_env_default(
-            "PEAK_TEST_UINT", 7U) != 42U) {
-        return 1;
-    }
-    setenv("PEAK_TEST_UINT", " 42", 1);
-    return peak_general_listener_parse_uint_env_default(
-               "PEAK_TEST_UINT", 7U) != 42U;
 }
 
 static int
@@ -662,7 +595,7 @@ main(int argc, char** argv)
                    : 0;
     }
     clear_test_environment();
-    if (check_truthy_values() || check_unsigned_parser() ||
+    if (check_truthy_values() ||
         check_detach_override()) {
         fputs("runtime_config_test_failed\n", stderr);
         return 1;

--- a/test/report/test_runtime_config.c
+++ b/test/report/test_runtime_config.c
@@ -594,6 +594,26 @@ main(int argc, char** argv)
                    ? 1
                    : 0;
     }
+    if (argc == 2 && strcmp(argv[1], "timeout-raise-warning") == 0) {
+        PeakReportTimeoutBudget budget;
+
+        clear_test_environment();
+        setenv("PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS", "1500", 1);
+        setenv("PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS", "10", 1);
+        setenv("PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS", "100", 1);
+        budget = peak_general_listener_report_timeout_budget_for_rank_count(
+            2U);
+        if (budget.socket_release_timeout_ms != 4510U ||
+            !budget.socket_release_was_raised) {
+            return 1;
+        }
+        budget = peak_general_listener_report_timeout_budget_for_rank_count(
+            2U);
+        return budget.socket_release_timeout_ms != 4510U ||
+                       !budget.socket_release_was_raised
+                   ? 1
+                   : 0;
+    }
     clear_test_environment();
     if (check_truthy_values() ||
         check_detach_override()) {

--- a/test/report/test_runtime_config.c
+++ b/test/report/test_runtime_config.c
@@ -646,6 +646,21 @@ main(int argc, char** argv)
                    ? 1
                    : 0;
     }
+    if (argc == 2 && strcmp(argv[1], "timeout-warning") == 0) {
+        PeakReportTimeoutBudget budget;
+
+        clear_test_environment();
+        setenv("PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS", "junk", 1);
+        setenv("PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS", "junk", 1);
+        setenv("PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS", "junk", 1);
+        budget = peak_general_listener_report_timeout_budget_for_rank_count(
+            4096U);
+        return budget.socket_phase_timeout_ms != 60000U ||
+                       budget.socket_release_timeout_ms != 340000U ||
+                       budget.mpi_report_release_timeout_ms != 180000U
+                   ? 1
+                   : 0;
+    }
     clear_test_environment();
     if (check_truthy_values() || check_unsigned_parser() ||
         check_detach_override()) {

--- a/test/report/test_runtime_config.c
+++ b/test/report/test_runtime_config.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 static const char* const peak_test_environment_names[] = {
     "PEAK_DETACH_COUNT",
@@ -349,6 +350,11 @@ check_detach_override(void)
         count != 99U) {
         return 1;
     }
+    setenv("PEAK_DETACH_COUNT", "", 1);
+    if (peak_general_listener_parse_detach_count_override(&count) ||
+        count != 99U) {
+        return 1;
+    }
     setenv("PEAK_DETACH_COUNT", "12", 1);
     if (!peak_general_listener_parse_detach_count_override(&count) ||
         count != 12U) {
@@ -628,8 +634,18 @@ check_output_policies(void)
 }
 
 int
-main(void)
+main(int argc, char** argv)
 {
+    if (argc == 2 && strcmp(argv[1], "detach-empty-warning") == 0) {
+        unsigned long count = 1U;
+
+        clear_test_environment();
+        setenv("PEAK_DETACH_COUNT", "", 1);
+        return peak_general_listener_parse_detach_count_override(&count) ||
+                       count != 1U
+                   ? 1
+                   : 0;
+    }
     clear_test_environment();
     if (check_truthy_values() || check_unsigned_parser() ||
         check_detach_override()) {

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -472,9 +472,10 @@ report_many_rank_case_diagnostic(
 }
 
 static int
-run_two_rank_case(int port,
-                  TestRootAction action,
-                  bool mismatched_peer_name)
+run_two_rank_case_with_peer_start_delay(int port,
+                                        TestRootAction action,
+                                        bool mismatched_peer_name,
+                                        bool delay_peer_start)
 {
     PeakReportSnapshot* root = fixture_snapshot(0, false);
     PeakReportSnapshot* aggregate = NULL;
@@ -518,6 +519,7 @@ run_two_rank_case(int port,
         action == TEST_GATHER_RECEIPT_FAILURE;
     char port_text[16];
     char token_text[64];
+    int peer_ready_fds[2] = {-1, -1};
     int receipt_barrier_fds[2] = {-1, -1};
     pid_t child;
     int64_t case_started_ms;
@@ -562,7 +564,7 @@ run_two_rank_case(int port,
     } else {
         /* Test-only grace isolates launcher scheduling before transport I/O. */
         (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS",
-                     "10000",
+                     delay_peer_start ? "100" : "10000",
                      1);
     }
     (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_WAVE_BUDGET_MS",
@@ -723,8 +725,20 @@ run_two_rank_case(int port,
     }
 
     peak_socket_report_test_receipt_barrier_set(-1, -1);
+    /*
+     * Keep fork/fixture launch out of root transport timing.  The child
+     * announces readiness immediately before it enters the peer transport;
+     * the root still has its normal startup and protocol deadlines after
+     * that point.
+     */
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, peer_ready_fds) != 0) {
+        peak_report_snapshot_destroy(root);
+        return 1;
+    }
     if (receipt_failure_barrier &&
         socketpair(AF_UNIX, SOCK_STREAM, 0, receipt_barrier_fds) != 0) {
+        close(peer_ready_fds[0]);
+        close(peer_ready_fds[1]);
         peak_report_snapshot_destroy(root);
         return 1;
     }
@@ -732,6 +746,8 @@ run_two_rank_case(int port,
     case_started_ms = test_monotonic_ms();
     child = fork();
     if (child < 0) {
+        close(peer_ready_fds[0]);
+        close(peer_ready_fds[1]);
         if (receipt_barrier_fds[0] >= 0) {
             close(receipt_barrier_fds[0]);
         }
@@ -747,6 +763,10 @@ run_two_rank_case(int port,
         PeakSocketReportSession* peer_session = NULL;
         PeakSocketReportStatus peer_status;
         PeakSocketReportTestTelemetry telemetry;
+        const unsigned char ready = 0x71U;
+
+        close(peer_ready_fds[1]);
+        peer_ready_fds[1] = -1;
 
         if (receipt_failure_barrier) {
             close(receipt_barrier_fds[1]);
@@ -756,9 +776,20 @@ run_two_rank_case(int port,
             receipt_barrier_fds[0] = -1;
         }
         set_test_rank(1, 2);
-        if (peer == NULL) {
+        if (delay_peer_start) {
+            /* Without the rendezvous, root exhausts its 100 ms grace. */
+            usleep(250000);
+        }
+        if (peer == NULL ||
+            send(peer_ready_fds[0],
+                 &ready,
+                 sizeof(ready),
+                 MSG_NOSIGNAL) != (ssize_t)sizeof(ready)) {
+            close(peer_ready_fds[0]);
             _exit(99);
         }
+        close(peer_ready_fds[0]);
+        peer_ready_fds[0] = -1;
         peer_status = peak_socket_report_transport_begin(
             peer,
             PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
@@ -806,12 +837,26 @@ run_two_rank_case(int port,
             -1, receipt_barrier_fds[1]);
         receipt_barrier_fds[1] = -1;
     }
-    set_test_rank(0, 2);
-    root_status = peak_socket_report_transport_begin(
-        root,
-        PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
-        &session,
-        &aggregate);
+    {
+        unsigned char ready = 0;
+
+        close(peer_ready_fds[0]);
+        peer_ready_fds[0] = -1;
+        if (recv(peer_ready_fds[1], &ready, sizeof(ready), 0) !=
+            (ssize_t)sizeof(ready) || ready != 0x71U) {
+            result = 1;
+        }
+        close(peer_ready_fds[1]);
+        peer_ready_fds[1] = -1;
+    }
+    if (result == 0) {
+        set_test_rank(0, 2);
+        root_status = peak_socket_report_transport_begin(
+            root,
+            PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
+            &session,
+            &aggregate);
+    }
     memset(&root_telemetry, 0, sizeof(root_telemetry));
     peak_socket_report_test_telemetry_get(&root_telemetry);
     if (receipt_failure_barrier) {
@@ -1005,6 +1050,17 @@ run_two_rank_case(int port,
                                         &root_telemetry);
     }
     return result;
+}
+
+static int
+run_two_rank_case(int port,
+                  TestRootAction action,
+                  bool mismatched_peer_name)
+{
+    return run_two_rank_case_with_peer_start_delay(port,
+                                                    action,
+                                                    mismatched_peer_name,
+                                                    false);
 }
 
 static int
@@ -1989,6 +2045,13 @@ main(void)
         run_two_rank_case(base_port + 40,
                           TEST_ROOT_SESSION_ALLOC_FAILURE,
                           false));
+    CHECK_SOCKET_CASE(
+        "session-allocation-fallback-delayed-peer",
+        run_two_rank_case_with_peer_start_delay(
+            base_port + 52,
+            TEST_ROOT_SESSION_ALLOC_FAILURE,
+            false,
+            true));
     CHECK_SOCKET_CASE(
         "gather-partial-success",
         run_two_rank_case(base_port + 18,

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -441,6 +441,36 @@ report_two_rank_case_diagnostic(
             telemetry->root_release_decision);
 }
 
+static void
+report_many_rank_case_diagnostic(
+    int size,
+    bool exercise_concurrency,
+    PeakSocketReportStatus root_status,
+    bool commit_attempted,
+    bool committed,
+    const PeakSocketReportTestTelemetry* telemetry)
+{
+    fprintf(stderr,
+            "socket many-rank diagnostic: size=%d concurrency=%d "
+            "root_status=%d commit_attempted=%d commit_result=%d "
+            "root={wire=%u payload=%u receipt=%u confirmation=%u "
+            "max_active=%u release_targets=%u release_confirmed=%u "
+            "release_decision=%u}\n",
+            size,
+            exercise_concurrency,
+            root_status,
+            commit_attempted,
+            committed,
+            telemetry->wire_version,
+            telemetry->root_payload_count,
+            telemetry->root_receipt_count,
+            telemetry->root_confirmation_count,
+            telemetry->root_max_active,
+            telemetry->root_release_target_count,
+            telemetry->root_release_confirmed_count,
+            telemetry->root_release_decision);
+}
+
 static int
 run_two_rank_case(int port,
                   TestRootAction action,
@@ -1432,6 +1462,10 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
     char token_text[64];
     int started = 0;
     int result = 0;
+    PeakSocketReportStatus root_status = PEAK_SOCKET_REPORT_FAILED;
+    PeakSocketReportTestTelemetry root_telemetry = {0};
+    bool commit_attempted = false;
+    bool committed = false;
 
     if (root == NULL || size <= 2) {
         peak_report_snapshot_destroy(root);
@@ -1453,12 +1487,16 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
     /*
      * Launching 31 peers on a hosted runner can take longer than the normal
      * per-phase budget even when every connection makes progress. Keep this
-     * many-rank regression bounded but allow a scheduling margin beyond the
-     * default three-second budget.
+     * many-rank regression bounded but allow a scheduling margin before the
+     * normal five-second protocol budget begins.
      */
     (void)setenv("PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS", "5000", 1);
     (void)setenv("PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS",
                  "15000",
+                 1);
+    /* Allow fork/scheduler startup only; transport progress stays at 5 s. */
+    (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS",
+                 "10000",
                  1);
     (void)setenv("PEAK_OUTPUT_AGGREGATION_TOKEN", token_text, 1);
     (void)unsetenv("PEAK_TEST_OUTPUT_AGGREGATION_RELEASE_FAIL");
@@ -1546,29 +1584,25 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
     }
 
     if (!result) {
-        PeakSocketReportStatus root_status;
-        PeakSocketReportTestTelemetry telemetry;
-
         set_test_rank(0, size);
         root_status = peak_socket_report_transport_begin(
             root,
             PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
             &session,
             &aggregate);
-        memset(&telemetry, 0, sizeof(telemetry));
-        peak_socket_report_test_telemetry_get(&telemetry);
+        peak_socket_report_test_telemetry_get(&root_telemetry);
         if (root_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
             session == NULL || aggregate == NULL ||
-            telemetry.wire_version != 12U ||
-            telemetry.root_payload_count != (uint32_t)(size - 1) ||
-            telemetry.root_receipt_count != (uint32_t)(size - 1) ||
-            telemetry.root_confirmation_count !=
+            root_telemetry.wire_version != 12U ||
+            root_telemetry.root_payload_count != (uint32_t)(size - 1) ||
+            root_telemetry.root_receipt_count != (uint32_t)(size - 1) ||
+            root_telemetry.root_confirmation_count !=
                 (uint32_t)(size - 1) ||
-            telemetry.root_max_active == 0U ||
-            telemetry.root_max_active > (uint32_t)(size - 1) ||
+            root_telemetry.root_max_active == 0U ||
+            root_telemetry.root_max_active > (uint32_t)(size - 1) ||
             (exercise_concurrency &&
-             telemetry.root_max_active <= 1U) ||
-            telemetry.root_release_target_count !=
+             root_telemetry.root_max_active <= 1U) ||
+            root_telemetry.root_release_target_count !=
                 (uint32_t)(size - 1) ||
             aggregate->rank_count != size ||
             aggregate->num_calls[0] !=
@@ -1578,18 +1612,21 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
             result = 1;
             peak_socket_report_transport_abort(session);
             session = NULL;
-        } else if (!peak_socket_report_transport_commit(session)) {
-            result = 1;
-            session = NULL;
         } else {
-            session = NULL;
-            memset(&telemetry, 0, sizeof(telemetry));
-            peak_socket_report_test_telemetry_get(&telemetry);
-            if (telemetry.root_release_decision !=
-                    TEST_RELEASE_ACK ||
-                telemetry.root_release_confirmed_count !=
-                    (uint32_t)(size - 1)) {
+            commit_attempted = true;
+            committed = peak_socket_report_transport_commit(session);
+            if (!committed) {
                 result = 1;
+                session = NULL;
+            } else {
+                session = NULL;
+                peak_socket_report_test_telemetry_get(&root_telemetry);
+                if (root_telemetry.root_release_decision !=
+                        TEST_RELEASE_ACK ||
+                    root_telemetry.root_release_confirmed_count !=
+                        (uint32_t)(size - 1)) {
+                    result = 1;
+                }
             }
         }
     } else {
@@ -1598,10 +1635,35 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
     }
 
     for (int i = 0; i < started; i++) {
+        int child_status;
+
         if (wait_for_expected_child(
-                children[i], PEAK_SOCKET_REPORT_PEER_RELEASED, NULL) != 0) {
+                children[i],
+                PEAK_SOCKET_REPORT_PEER_RELEASED,
+                &child_status) != 0) {
+            fprintf(stderr,
+                    "socket many-rank child diagnostic: rank=%d pid=%ld "
+                    "wait_status=%d exited=%d exit=%d signal=%d\n",
+                    i + 1,
+                    (long)children[i],
+                    child_status,
+                    child_status >= 0 && WIFEXITED(child_status),
+                    child_status >= 0 && WIFEXITED(child_status)
+                        ? WEXITSTATUS(child_status)
+                        : -1,
+                    child_status >= 0 && WIFSIGNALED(child_status)
+                        ? WTERMSIG(child_status)
+                        : -1);
             result = 1;
         }
+    }
+    if (result != 0) {
+        report_many_rank_case_diagnostic(size,
+                                         exercise_concurrency,
+                                         root_status,
+                                         commit_attempted,
+                                         committed,
+                                         &root_telemetry);
     }
     peak_report_snapshot_destroy(aggregate);
     peak_report_snapshot_destroy(root);
@@ -1614,6 +1676,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DELAY_RANK");
     (void)unsetenv(
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_PRECONNECT_DELAY_MS");
+    (void)unsetenv("PEAK_TEST_OUTPUT_AGGREGATION_STARTUP_GRACE_MS");
     (void)unsetenv(
         "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DISABLE_JITTER");
     return result;

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -475,7 +475,8 @@ static int
 run_two_rank_case_with_peer_start_delay(int port,
                                         TestRootAction action,
                                         bool mismatched_peer_name,
-                                        bool delay_peer_start)
+                                        bool delay_peer_start,
+                                        bool exit_after_listener_ready)
 {
     PeakReportSnapshot* root = fixture_snapshot(0, false);
     PeakReportSnapshot* aggregate = NULL;
@@ -517,12 +518,14 @@ run_two_rank_case_with_peer_start_delay(int port,
         action == TEST_ROOT_SESSION_ALLOC_FAILURE;
     bool receipt_failure_barrier =
         action == TEST_GATHER_RECEIPT_FAILURE;
+    bool peer_exits_before_connect = exit_after_listener_ready;
     char port_text[16];
     char token_text[64];
     int peer_ready_fds[2] = {-1, -1};
     int receipt_barrier_fds[2] = {-1, -1};
     pid_t child;
     int64_t case_started_ms;
+    int64_t root_started_ms = -1;
     int peer_wait_status = -1;
     bool peer_wait_complete = false;
     bool commit_attempted = false;
@@ -791,8 +794,9 @@ run_two_rank_case_with_peer_start_delay(int port,
             close(peer_ready_fds[0]);
             _exit(99);
         }
-        close(peer_ready_fds[0]);
-        peer_ready_fds[0] = -1;
+        if (exit_after_listener_ready) {
+            _exit(0);
+        }
         if (delay_peer_start) {
             /* Old one-way startup expired its 100 ms grace here. */
             usleep(250000);
@@ -802,6 +806,8 @@ run_two_rank_case_with_peer_start_delay(int port,
             PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
             &peer_session,
             &peer_aggregate);
+        close(peer_ready_fds[0]);
+        peer_ready_fds[0] = -1;
         memset(&telemetry, 0, sizeof(telemetry));
         peak_socket_report_test_telemetry_get(&telemetry);
         if (telemetry.wire_version != 12U ||
@@ -856,6 +862,7 @@ run_two_rank_case_with_peer_start_delay(int port,
     }
     if (result == 0) {
         set_test_rank(0, 2);
+        root_started_ms = test_monotonic_ms();
         root_status = peak_socket_report_transport_begin(
             root,
             PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
@@ -871,7 +878,8 @@ run_two_rank_case_with_peer_start_delay(int port,
         /* Also releases the peer if root failed before receipt preparation. */
         peak_socket_report_test_receipt_barrier_set(-1, -1);
     }
-    if (root_telemetry.wire_version != 12U ||
+    if (!peer_exits_before_connect &&
+        (root_telemetry.wire_version != 12U ||
         (!early_drop_may_skip_accept &&
          root_telemetry.root_max_active != 1U) ||
         (early_drop_may_skip_accept &&
@@ -890,7 +898,7 @@ run_two_rank_case_with_peer_start_delay(int port,
           root_telemetry.root_receipt_count != 1U ||
           root_telemetry.root_confirmation_count != 1U)) ||
         root_telemetry.root_release_target_count !=
-            root_telemetry.root_receipt_count) {
+            root_telemetry.root_receipt_count)) {
         result = 1;
     }
     if (action == TEST_GATHER_RECEIPT_FAILURE &&
@@ -962,7 +970,8 @@ run_two_rank_case_with_peer_start_delay(int port,
 
     memset(&root_telemetry, 0, sizeof(root_telemetry));
     peak_socket_report_test_telemetry_get(&root_telemetry);
-    if ((expected_peer == PEAK_SOCKET_REPORT_PEER_RELEASED &&
+    if (!peer_exits_before_connect &&
+        ((expected_peer == PEAK_SOCKET_REPORT_PEER_RELEASED &&
          (root_telemetry.root_release_decision != TEST_RELEASE_ACK ||
           root_telemetry.root_release_confirmed_count != 1U)) ||
         ((action == TEST_ROOT_ABORT ||
@@ -973,10 +982,26 @@ run_two_rank_case_with_peer_start_delay(int port,
           root_telemetry.root_release_confirmed_count != 1U)) ||
         (action == TEST_ROOT_COMMIT_FAILURE &&
          (root_telemetry.root_release_decision != TEST_RELEASE_ACK ||
-          root_telemetry.root_release_confirmed_count != 0U))) {
+          root_telemetry.root_release_confirmed_count != 0U)))) {
         result = 1;
     }
-    if (!peer_wait_complete &&
+    if (peer_exits_before_connect) {
+        int64_t elapsed_ms = test_monotonic_ms() - root_started_ms;
+
+        if ((!peer_wait_complete &&
+             (waitpid(child, &peer_wait_status, 0) != child)) ||
+            !WIFEXITED(peer_wait_status) ||
+            WEXITSTATUS(peer_wait_status) != 0 ||
+            root_status != PEAK_SOCKET_REPORT_FAILED || session != NULL ||
+            aggregate != NULL || root_telemetry.root_payload_count != 0U ||
+            root_telemetry.root_receipt_count != 0U ||
+            root_telemetry.root_confirmation_count != 0U ||
+            root_telemetry.root_max_active != 0U || root_started_ms < 0 ||
+            elapsed_ms > 5000) {
+            result = 1;
+        }
+        peer_wait_complete = true;
+    } else if (!peer_wait_complete &&
         wait_for_expected_child(child, expected_peer, &peer_wait_status) !=
             0) {
         result = 1;
@@ -1068,6 +1093,7 @@ run_two_rank_case(int port,
     return run_two_rank_case_with_peer_start_delay(port,
                                                     action,
                                                     mismatched_peer_name,
+                                                    false,
                                                     false);
 }
 
@@ -1967,7 +1993,7 @@ main(void)
 {
     /*
      * Hold the UDP endpoint paired with a 64-port TCP slot. The test currently
-     * consumes base..base+53, and the kernel lock prevents parallel CTest
+     * consumes base..base+55, and the kernel lock prevents parallel CTest
      * processes, including different UIDs, from choosing the same range.
      */
     int port_lock_fd = -1;
@@ -2058,6 +2084,15 @@ main(void)
         run_two_rank_case_with_peer_start_delay(
             base_port + 52,
             TEST_ROOT_SESSION_ALLOC_FAILURE,
+            false,
+            true,
+            false));
+    CHECK_SOCKET_CASE(
+        "listener-ready-peer-exit",
+        run_two_rank_case_with_peer_start_delay(
+            base_port + 54,
+            TEST_ROOT_SESSION_ALLOC_FAILURE,
+            false,
             false,
             true));
     CHECK_SOCKET_CASE(

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -725,20 +725,21 @@ run_two_rank_case_with_peer_start_delay(int port,
     }
 
     peak_socket_report_test_receipt_barrier_set(-1, -1);
+    peak_socket_report_test_listener_ready_set(-1);
     /*
      * Keep fork/fixture launch out of root transport timing.  The child
-     * announces readiness immediately before it enters the peer transport;
-     * the root still has its normal startup and protocol deadlines after
-     * that point.
+     * announces fixture readiness, then waits for the root to finish binding
+     * both listeners and allocating gather state before peer timing starts.
      */
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, peer_ready_fds) != 0) {
         peak_report_snapshot_destroy(root);
         return 1;
     }
+    peak_socket_report_test_listener_ready_set(peer_ready_fds[1]);
     if (receipt_failure_barrier &&
         socketpair(AF_UNIX, SOCK_STREAM, 0, receipt_barrier_fds) != 0) {
         close(peer_ready_fds[0]);
-        close(peer_ready_fds[1]);
+        peak_socket_report_test_listener_ready_set(-1);
         peak_report_snapshot_destroy(root);
         return 1;
     }
@@ -747,7 +748,7 @@ run_two_rank_case_with_peer_start_delay(int port,
     child = fork();
     if (child < 0) {
         close(peer_ready_fds[0]);
-        close(peer_ready_fds[1]);
+        peak_socket_report_test_listener_ready_set(-1);
         if (receipt_barrier_fds[0] >= 0) {
             close(receipt_barrier_fds[0]);
         }
@@ -763,7 +764,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         PeakSocketReportSession* peer_session = NULL;
         PeakSocketReportStatus peer_status;
         PeakSocketReportTestTelemetry telemetry;
-        const unsigned char ready = 0x71U;
+        unsigned char ready = 0x71U;
 
         close(peer_ready_fds[1]);
         peer_ready_fds[1] = -1;
@@ -776,10 +777,6 @@ run_two_rank_case_with_peer_start_delay(int port,
             receipt_barrier_fds[0] = -1;
         }
         set_test_rank(1, 2);
-        if (delay_peer_start) {
-            /* Without the rendezvous, root exhausts its 100 ms grace. */
-            usleep(250000);
-        }
         if (peer == NULL ||
             send(peer_ready_fds[0],
                  &ready,
@@ -788,8 +785,18 @@ run_two_rank_case_with_peer_start_delay(int port,
             close(peer_ready_fds[0]);
             _exit(99);
         }
+        if (recv(peer_ready_fds[0], &ready, sizeof(ready), 0) !=
+                (ssize_t)sizeof(ready) ||
+            ready != 0x73U) {
+            close(peer_ready_fds[0]);
+            _exit(99);
+        }
         close(peer_ready_fds[0]);
         peer_ready_fds[0] = -1;
+        if (delay_peer_start) {
+            /* Old one-way startup expired its 100 ms grace here. */
+            usleep(250000);
+        }
         peer_status = peak_socket_report_transport_begin(
             peer,
             PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
@@ -846,8 +853,6 @@ run_two_rank_case_with_peer_start_delay(int port,
             (ssize_t)sizeof(ready) || ready != 0x71U) {
             result = 1;
         }
-        close(peer_ready_fds[1]);
-        peer_ready_fds[1] = -1;
     }
     if (result == 0) {
         set_test_rank(0, 2);
@@ -857,6 +862,9 @@ run_two_rank_case_with_peer_start_delay(int port,
             &session,
             &aggregate);
     }
+    /* Wakes a waiting child by EOF if root failed before listener readiness. */
+    peak_socket_report_test_listener_ready_set(-1);
+    peer_ready_fds[1] = -1;
     memset(&root_telemetry, 0, sizeof(root_telemetry));
     peak_socket_report_test_telemetry_get(&root_telemetry);
     if (receipt_failure_barrier) {

--- a/test/utils/test_env_parser_header_cxx.cpp
+++ b/test/utils/test_env_parser_header_cxx.cpp
@@ -1,0 +1,11 @@
+#include "utils/env_parser.h"
+
+int
+main()
+{
+    PeakEnvWarningState state{};
+    PeakEnvUnsignedSchema schema{};
+
+    schema.warning_emitted = &state;
+    return 0;
+}

--- a/test/utils/test_numeric_env_parser.c
+++ b/test/utils/test_numeric_env_parser.c
@@ -2,7 +2,9 @@
 
 #include "utils/env_parser.h"
 
+#include <limits.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -30,6 +32,77 @@ clear_numeric_environment(void)
          index++) {
         unsetenv(numeric_names[index]);
     }
+}
+
+static int
+check_production_unsigned_schemas(void)
+{
+    static const struct {
+        const char* name;
+        unsigned long long minimum;
+        unsigned long long maximum;
+        const char* valid;
+        const char* invalid;
+    } cases[] = {
+        { "PEAK_MAX_NUM_THREADS", 0, ULONG_MAX, "4097", "18446744073709551616" },
+        { "PEAK_MEMLOG_CHUNK_EVENTS", 1, SIZE_MAX, "1024", "0" },
+        { "PEAK_CUDA_EVENT_POOL_CAPACITY", 1, 65536, "65536", "65537" },
+    };
+
+    for (size_t index = 0; index < sizeof(cases) / sizeof(cases[0]); index++) {
+        PeakEnvUnsignedSchema schema = {
+            cases[index].name, "events", 0, cases[index].minimum,
+            cases[index].maximum, cases[index].minimum == 0, NULL, false,
+        };
+        unsigned long long parsed;
+
+        setenv(schema.name, cases[index].valid, 1);
+        if (!peak_parse_env_unsigned_checked(&schema, &parsed)) {
+            fprintf(stderr, "valid production schema rejected: %s=%s\n",
+                    schema.name, cases[index].valid);
+            return 0;
+        }
+        setenv(schema.name, cases[index].invalid, 1);
+        if (peak_parse_env_unsigned_checked(&schema, &parsed)) {
+            fprintf(stderr, "invalid production schema accepted: %s=%s\n",
+                    schema.name, cases[index].invalid);
+            return 0;
+        }
+        unsetenv(schema.name);
+    }
+    return 1;
+}
+
+static int
+check_unsigned_parser(void)
+{
+    PeakEnvWarningState warning_emitted = {0};
+    PeakEnvUnsignedSchema schema = {
+        "PEAK_TEST_UINT", "values", 7, 0, UINT_MAX, true,
+        &warning_emitted, false,
+    };
+    static const struct {
+        const char* value;
+        unsigned long long expected;
+    } cases[] = {
+        { "", 7 }, { "0", 0 }, { "42", 42 }, { "42junk", 7 },
+        { "-1", 7 }, { " -1", 7 }, { "-0", 7 }, { "+42", 42 },
+        { " 42", 42 },
+    };
+
+    unsetenv(schema.name);
+    if (peak_parse_env_unsigned(&schema) != 7) {
+        return 0;
+    }
+    for (size_t index = 0; index < sizeof(cases) / sizeof(cases[0]); index++) {
+        setenv(schema.name, cases[index].value, 1);
+        if (peak_parse_env_unsigned(&schema) != cases[index].expected) {
+            fprintf(stderr, "unsigned parser mismatch: %s\n", cases[index].value);
+            return 0;
+        }
+    }
+    unsetenv(schema.name);
+    return 1;
 }
 
 int
@@ -60,6 +133,30 @@ main(int argc, char** argv)
         (void)peak_parse_runtime_numeric_config();
         return 0;
     }
+    if (argc == 2 && strcmp(argv[1], "cuda-warning") == 0) {
+        PeakEnvWarningState warning_emitted = {0};
+        PeakEnvUnsignedSchema schema = {
+            "PEAK_CUDA_EVENT_POOL_CAPACITY", "events", 256, 1, 65536,
+            false, &warning_emitted, false,
+        };
+
+        setenv(schema.name, "", 1);
+        if (peak_parse_env_unsigned(&schema) != 256 ||
+            peak_parse_env_unsigned(&schema) != 256) {
+            return 1;
+        }
+        return 0;
+    }
+    if (argc == 2 && strcmp(argv[1], "cuda-unset") == 0) {
+        PeakEnvWarningState warning_emitted = {0};
+        PeakEnvUnsignedSchema schema = {
+            "PEAK_CUDA_EVENT_POOL_CAPACITY", "events", 256, 1, 65536,
+            false, &warning_emitted, false,
+        };
+
+        unsetenv(schema.name);
+        return peak_parse_env_unsigned(&schema) == 256 ? 0 : 1;
+    }
 
     static const struct {
         const char* name;
@@ -80,6 +177,7 @@ main(int argc, char** argv)
         { "PEAK_GLOBAL_REATTACH_FACTOR", "0" },
         { "PEAK_PAUSE_TIMEOUT", "-0.01" },
         { "PEAK_PAUSE_TIMEOUT", "18446744073.709551616" },
+        { "PEAK_PAUSE_TIMEOUT", "18446744073.709553" },
         { "PEAK_HB_MIN_US", "0" },
         { "PEAK_HB_MAX_US", "0" },
         { "PEAK_HB_K_ERR", "-1" },
@@ -124,6 +222,13 @@ main(int argc, char** argv)
     }
 
     clear_numeric_environment();
+    setenv("PEAK_HEARTBEAT_INTERVAL", "4294.967296", 1);
+    if (peak_parse_runtime_numeric_config().heartbeat_interval_us != 100000U) {
+        fputs("unrepresentable microsecond boundary was accepted\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
     setenv("PEAK_HB_MIN_US", "600000", 1);
     if (peak_parse_runtime_numeric_config().heartbeat_max_us != 600000U) {
         fputs("unset heartbeat maximum did not follow the minimum\n", stderr);
@@ -159,6 +264,9 @@ main(int argc, char** argv)
     }
 
     clear_numeric_environment();
+    if (!check_production_unsigned_schemas() || !check_unsigned_parser()) {
+        return 1;
+    }
     puts("numeric_env_parser_test_ok");
     return 0;
 }

--- a/test/utils/test_numeric_env_parser.c
+++ b/test/utils/test_numeric_env_parser.c
@@ -214,9 +214,9 @@ main(int argc, char** argv)
     }
 
     clear_numeric_environment();
-    setenv("PEAK_PAUSE_TIMEOUT", "18446744073", 1);
+    setenv("PEAK_PAUSE_TIMEOUT", "18446744000", 1);
     if (peak_parse_runtime_numeric_config().pause_timeout_ns !=
-        18446744073000000000ULL) {
+        18446744000000000000ULL) {
         fputs("safe nanosecond boundary was rejected\n", stderr);
         return 1;
     }

--- a/test/utils/test_numeric_env_parser.c
+++ b/test/utils/test_numeric_env_parser.c
@@ -1,0 +1,164 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "utils/env_parser.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char* const numeric_names[] = {
+    "PEAK_COST",
+    "PEAK_HEARTBEAT_INTERVAL",
+    "PEAK_HIBERNATION_CYCLE",
+    "PEAK_OVERHEAD_RATIO",
+    "PEAK_GLOBAL_OVERHEAD_RATIO",
+    "PEAK_GLOBAL_DETACH_FACTOR",
+    "PEAK_GLOBAL_REATTACH_FACTOR",
+    "PEAK_PAUSE_TIMEOUT",
+    "PEAK_SIG_CONT_TIMEOUT",
+    "PEAK_HB_MIN_US",
+    "PEAK_HB_MAX_US",
+    "PEAK_HB_K_ERR",
+    "PEAK_HB_K_RATE",
+    "PEAK_HB_EMA_A",
+};
+
+static void
+clear_numeric_environment(void)
+{
+    for (size_t index = 0; index < sizeof(numeric_names) / sizeof(numeric_names[0]);
+         index++) {
+        unsetenv(numeric_names[index]);
+    }
+}
+
+int
+main(int argc, char** argv)
+{
+    if (argc == 2 && strcmp(argv[1], "warning") == 0) {
+        clear_numeric_environment();
+        setenv("PEAK_HB_MIN_US", "600000", 1);
+        setenv("PEAK_HB_MAX_US", "junk", 1);
+        if (peak_parse_runtime_numeric_config().heartbeat_max_us != 600000U) {
+            return 1;
+        }
+        return 0;
+    }
+    if (argc == 2 && strcmp(argv[1], "unset-warning") == 0) {
+        clear_numeric_environment();
+        setenv("PEAK_HB_MIN_US", "600000", 1);
+        if (peak_parse_runtime_numeric_config().heartbeat_max_us != 600000U ||
+            peak_parse_runtime_numeric_config().heartbeat_max_us != 600000U) {
+            return 1;
+        }
+        return 0;
+    }
+    if (argc == 2 && strcmp(argv[1], "repeated-warning") == 0) {
+        clear_numeric_environment();
+        setenv("PEAK_COST", "nan", 1);
+        (void)peak_parse_runtime_numeric_config();
+        (void)peak_parse_runtime_numeric_config();
+        return 0;
+    }
+
+    static const struct {
+        const char* name;
+        const char* value;
+    } invalid[] = {
+        { "PEAK_COST", "" },
+        { "PEAK_COST", "1seconds" },
+        { "PEAK_COST", "nan" },
+        { "PEAK_COST", "inf" },
+        { "PEAK_COST", "-1" },
+        { "PEAK_COST", "1e999" },
+        { "PEAK_COST", "1e-999" },
+        { "PEAK_HEARTBEAT_INTERVAL", "0.0000001" },
+        { "PEAK_HIBERNATION_CYCLE", "-1" },
+        { "PEAK_HIBERNATION_CYCLE", "4294967296" },
+        { "PEAK_OVERHEAD_RATIO", "-0.1" },
+        { "PEAK_GLOBAL_DETACH_FACTOR", "0.5" },
+        { "PEAK_GLOBAL_REATTACH_FACTOR", "0" },
+        { "PEAK_PAUSE_TIMEOUT", "-0.01" },
+        { "PEAK_PAUSE_TIMEOUT", "18446744073.709551616" },
+        { "PEAK_HB_MIN_US", "0" },
+        { "PEAK_HB_MAX_US", "0" },
+        { "PEAK_HB_K_ERR", "-1" },
+        { "PEAK_HB_K_RATE", "nan" },
+        { "PEAK_HB_EMA_A", "0" },
+        { "PEAK_HB_EMA_A", "1.1" },
+    };
+
+    for (size_t index = 0; index < sizeof(invalid) / sizeof(invalid[0]);
+         index++) {
+        PeakRuntimeNumericConfig config;
+
+        clear_numeric_environment();
+        setenv(invalid[index].name, invalid[index].value, 1);
+        config = peak_parse_runtime_numeric_config();
+        if (config.detach_cost != 0.0f ||
+            config.heartbeat_interval_us != 100000U ||
+            config.hibernation_cycle != 50U ||
+            config.target_overhead_ratio != 0.1f ||
+            config.global_overhead_ratio != 0.1f ||
+            config.global_detach_factor != 1.2f ||
+            config.global_reattach_factor != 0.85f ||
+            config.pause_timeout_ns != 10000000ULL ||
+            config.sig_cont_timeout_ns != 10000000ULL ||
+            config.heartbeat_min_us != 10000U ||
+            config.heartbeat_max_us != 500000U ||
+            config.heartbeat_error_gain != 3.0 ||
+            config.heartbeat_rate_gain != 0.8 ||
+            config.heartbeat_ema_alpha != 0.3) {
+            fprintf(stderr, "invalid numeric value accepted: %s=%s\n",
+                    invalid[index].name, invalid[index].value);
+            return 1;
+        }
+    }
+
+    clear_numeric_environment();
+    setenv("PEAK_PAUSE_TIMEOUT", "18446744073", 1);
+    if (peak_parse_runtime_numeric_config().pause_timeout_ns !=
+        18446744073000000000ULL) {
+        fputs("safe nanosecond boundary was rejected\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
+    setenv("PEAK_HB_MIN_US", "600000", 1);
+    if (peak_parse_runtime_numeric_config().heartbeat_max_us != 600000U) {
+        fputs("unset heartbeat maximum did not follow the minimum\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
+    setenv("PEAK_HB_MIN_US", "20000", 1);
+    setenv("PEAK_HB_MAX_US", "10000", 1);
+    if (peak_parse_runtime_numeric_config().heartbeat_max_us != 20000U) {
+        fputs("heartbeat bound conflict did not use the minimum\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
+    setenv("PEAK_GLOBAL_DETACH_FACTOR", "1", 1);
+    setenv("PEAK_GLOBAL_REATTACH_FACTOR", "1", 1);
+    if (peak_parse_runtime_numeric_config().global_reattach_factor != 0.85f) {
+        fputs("hysteresis conflict did not use the reattach fallback\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
+    setenv("PEAK_HEARTBEAT_INTERVAL", "0", 1);
+    setenv("PEAK_HIBERNATION_CYCLE", "0", 1);
+    setenv("PEAK_OVERHEAD_RATIO", "0", 1);
+    setenv("PEAK_GLOBAL_OVERHEAD_RATIO", "0", 1);
+    setenv("PEAK_PAUSE_TIMEOUT", "0", 1);
+    if (peak_parse_runtime_numeric_config().heartbeat_interval_us != 0U ||
+        peak_parse_runtime_numeric_config().hibernation_cycle != 0U) {
+        fputs("documented zero disable value rejected\n", stderr);
+        return 1;
+    }
+
+    clear_numeric_environment();
+    puts("numeric_env_parser_test_ok");
+    return 0;
+}


### PR DESCRIPTION
Closes #57.

## Summary

- define per-variable numeric schemas with type, unit, fallback, bounds, and zero policy
- centralize checked unsigned and finite-real parsing with full input consumption, overflow/underflow checks, and bounds checks before narrowing
- emit at most one actionable warning for each invalid PEAK variable, including dynamic socket-release fallback and heartbeat/hysteresis cross-field violations
- migrate heartbeat/runtime timeouts, controller/JIT/socket/MPI settings, tracked-thread capacity, memlog capacity, and CUDA event-pool capacity
- preserve the existing `PEAK_MAX_NUM_THREADS` zero/clamp policy and the memlog fail-closed policy
- document launcher-provided MPI rank metadata separately from PEAK-owned numeric controls

## Safety boundary

- detach/reattach FSM and the six hard redline files are byte-for-byte unchanged from `main` (`bae14767a46d015304418e050c711171bb029681`)
- no detach/reattach threshold, transition, or state-machine semantic changed
- the strict-gate timeout parser remains local in the redline controller file and is intentionally unchanged

## Review and local validation

- exact reviewed head: `f6bf8ac80143d0050cd1928750c9cc5ea263d91b`
- implementation and follow-up fixes: GPT-5.6 Terra High
- primary review: ACCEPT
- independent GPT-5.6 Sol High review: ACCEPT on the exact head
- fresh Clang/GCC builds and focused parser/runtime/socket/fake-MPI/FSM suites pass
- `-mlong-double-64` UBSan/float-cast-overflow coverage and integer MILC-window boundary oracles pass
- socket test rendezvous has deterministic old-code negative controls for delayed peers and pre-connect peer exit; production non-test object code is unchanged
- `git diff --check` and all six redline comparisons pass

## CI and HPC certification

- GitHub CI: 14/14 checks pass on exact head `f6bf8ac80143d0050cd1928750c9cc5ea263d91b`
- Vista high-thread stress: job `898337`, 72 workers + 8 transient spawners, 6/6 strict detach/reattach/redetach samples pass; the later changes are confined to standalone-test linking, test-only socket synchronization, and CI dependency setup, so the valid Vista runtime evidence was retained without an unnecessary rerun
- Frontera high-thread stress: job `7893640`, 18/18 focused tests, malloc/free rollback 100/100 each, and 56 workers + 8 transient spawners with 6/6 strict detach/reattach/redetach samples pass; 24.7–25.4B calls/s
- Frontera artifact provenance: job `7893642`, source archive `4f64c09259537c2dca6931f3be465565a5cb2c5549d616f3f9e2f4c2a3ea6907`, source product `b36f312b04783feeacde5b16494543e8a6c26aaaf76b147612fc4c2aaa854f82` (100 files), libpeak `21ab721865fef5b35bbc5d6dbdfbc29b5a17f3cf0c121ce3d2fcfef199b9f3b1`, helper `a7f55de2a807df6c8c2d768894157528dab7a8013a1d9a32c66350c9298f6ebb`, provenance `0d957385fb3ea5461db5bf729ec3c440466710ddce8da880b0036ab91e1ae459`
- Frontera 1024-node/4096-rank MILC certification: job `7893735`, `large`, 1024 nodes, 4096 ranks, 12 CPUs/rank, completed `0:0` in 23:06. The full unchanged backend-repeat matrix `B0/A1/S1/A2/S2/A3/S3/Bend` passed with `launcher_rc=0`, `validation=pass`, `failures=0`, and `run_complete=1` for every arm.
- Every arm has exactly one MILC `RUNNING COMPLETED` and no fatal/hang marker. Each PEAK arm has aggregate scope over 4096 MPI ranks, exactly one 4096-call `normal_exit` row, exactly one successful PEAK publication completion, and exactly one CSV.
- All six PEAK arms report `failed control windows: windows=0 snapshot_valid=1`; transition coverage is `detached_targets=28`, `reattached_targets=27`, and `revisited_targets=20-21`. Both `B0` and `Bend` have zero PEAK markers and zero PEAK CSVs, proving no baseline contamination before or after the matrix.
- Earlier unusable allocations failed inside Hydra/MPI/UCX before complete MILC/PEAK evidence. The successful rerun excluded only the directly implicated nodes `c122-123` and `c171-091`; code, artifact, MILC case, eight-arm order, PEAK thresholds, and detach/reattach FSM remained unchanged.

All required review, CI, redline, high-thread, provenance, and MILC gates are satisfied. The PR is ready for review; it must not be merged automatically.
