### PR TITLE
Bound finalization waits for exec checkpoint readers

### DIFF
--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -92,6 +92,9 @@ PEAK_EXEC_API int peak_test_fini_checkpoint_reader_wait_count(void);
 /** @return Nonzero after the bounded checkpoint-reader wait timed out. */
 PEAK_EXEC_API int peak_test_fini_checkpoint_reader_timeout_observed(void);
 
+/** @return Number of condition-variable waits by non-owner finalizers. */
+PEAK_EXEC_API int peak_test_fini_completion_wait_count(void);
+
 /** Invokes the normal `peak_fini()` path for lifetime-gate testing. */
 PEAK_EXEC_API void peak_test_fini(void);
 

--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -86,6 +86,12 @@ PEAK_EXEC_API void peak_test_checkpoint_reader_release(void);
 /** @return Nonzero once finalization is waiting for the paused reader. */
 PEAK_EXEC_API int peak_test_fini_waiting_for_checkpoint_reader(void);
 
+/** @return Number of condition-variable waits used by finalization. */
+PEAK_EXEC_API int peak_test_fini_checkpoint_reader_wait_count(void);
+
+/** @return Nonzero after the bounded checkpoint-reader wait timed out. */
+PEAK_EXEC_API int peak_test_fini_checkpoint_reader_timeout_observed(void);
+
 /** Invokes the normal `peak_fini()` path for lifetime-gate testing. */
 PEAK_EXEC_API void peak_test_fini(void);
 

--- a/src/peak.c
+++ b/src/peak.c
@@ -139,6 +139,8 @@ static pthread_cond_t peak_exec_checkpoint_gate_cond;
 static pthread_once_t peak_exec_checkpoint_gate_cond_once = PTHREAD_ONCE_INIT;
 static _Atomic int peak_exec_checkpoint_gate_cond_ready = 0;
 static _Atomic int peak_exec_checkpoint_fini_skip_warning_emitted = 0;
+static _Atomic int peak_exec_checkpoint_gate_failure_warning_emitted = 0;
+static _Atomic int peak_fini_completion_wait_warning_emitted = 0;
 typedef enum {
     PEAK_FINI_NOT_STARTED = 0,
     PEAK_FINI_IN_PROGRESS = 1,
@@ -206,6 +208,7 @@ static _Atomic int peak_test_checkpoint_reader_released = 0;
 static _Atomic int peak_test_fini_waiting_for_reader = 0;
 static _Atomic int peak_test_fini_checkpoint_wait_count = 0;
 static _Atomic int peak_test_fini_checkpoint_timeout_observed = 0;
+static _Atomic int peak_test_fini_completion_wait_count_value = 0;
 static _Atomic int peak_test_activation_pause = 0;
 static _Atomic int peak_test_activation_held = 0;
 static _Atomic int peak_test_activation_released = 0;
@@ -243,6 +246,9 @@ peak_test_checkpoint_reader_pause_enable(void)
                           0,
                           memory_order_release);
     atomic_store_explicit(&peak_test_fini_checkpoint_timeout_observed,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_fini_completion_wait_count_value,
                           0,
                           memory_order_release);
     atomic_store_explicit(&peak_test_checkpoint_reader_pause,
@@ -283,6 +289,13 @@ PEAK_EXEC_API int
 peak_test_fini_checkpoint_reader_timeout_observed(void)
 {
     return atomic_load_explicit(&peak_test_fini_checkpoint_timeout_observed,
+                                memory_order_acquire);
+}
+
+PEAK_EXEC_API int
+peak_test_fini_completion_wait_count(void)
+{
+    return atomic_load_explicit(&peak_test_fini_completion_wait_count_value,
                                 memory_order_acquire);
 }
 
@@ -328,6 +341,7 @@ peak_test_checkpoint_reader_pause_after_acquire(void)
                           memory_order_release);
     while (atomic_load_explicit(&peak_test_checkpoint_reader_released,
                                 memory_order_acquire) == 0) {
+        pthread_testcancel();
         sched_yield();
     }
 }
@@ -370,8 +384,10 @@ peak_exec_checkpoint_gate_cond_initialize(void)
         status = pthread_cond_init(&peak_exec_checkpoint_gate_cond, &attr);
     }
     (void)pthread_condattr_destroy(&attr);
-#else
+#elif defined(__APPLE__)
     status = pthread_cond_init(&peak_exec_checkpoint_gate_cond, NULL);
+#else
+    return;
 #endif
     if (status == 0) {
         atomic_store_explicit(&peak_exec_checkpoint_gate_cond_ready,
@@ -383,10 +399,84 @@ peak_exec_checkpoint_gate_cond_initialize(void)
 static gboolean
 peak_exec_checkpoint_gate_cond_is_ready(void)
 {
-    (void)pthread_once(&peak_exec_checkpoint_gate_cond_once,
-                       peak_exec_checkpoint_gate_cond_initialize);
+    if (pthread_once(&peak_exec_checkpoint_gate_cond_once,
+                     peak_exec_checkpoint_gate_cond_initialize) != 0) {
+        return FALSE;
+    }
     return atomic_load_explicit(&peak_exec_checkpoint_gate_cond_ready,
                                 memory_order_acquire) != 0;
+}
+
+static gboolean
+peak_exec_checkpoint_deadline(struct timespec* deadline)
+{
+#if defined(__linux__) || defined(__APPLE__)
+    if (clock_gettime(
+            CLOCK_MONOTONIC,
+            deadline) != 0) {
+        return FALSE;
+    }
+    deadline->tv_sec += PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS / 1000L;
+    deadline->tv_nsec +=
+        (PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS % 1000L) * 1000000L;
+    if (deadline->tv_nsec >= 1000000000L) {
+        deadline->tv_sec++;
+        deadline->tv_nsec -= 1000000000L;
+    }
+    return TRUE;
+#else
+    (void)deadline;
+    return FALSE;
+#endif
+}
+
+static int
+peak_exec_checkpoint_cond_timedwait(const struct timespec* deadline)
+{
+#if defined(__linux__)
+    return pthread_cond_timedwait(&peak_exec_checkpoint_gate_cond,
+                                  &peak_exec_checkpoint_gate_mutex,
+                                  deadline);
+#elif defined(__APPLE__)
+    struct timespec now;
+    struct timespec remaining;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return EINVAL;
+    }
+    remaining.tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining.tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining.tv_nsec < 0) {
+        remaining.tv_sec--;
+        remaining.tv_nsec += 1000000000L;
+    }
+    if (remaining.tv_sec < 0 ||
+        (remaining.tv_sec == 0 && remaining.tv_nsec == 0)) {
+        return ETIMEDOUT;
+    }
+    return pthread_cond_timedwait_relative_np(&peak_exec_checkpoint_gate_cond,
+                                              &peak_exec_checkpoint_gate_mutex,
+                                              &remaining);
+#else
+    (void)deadline;
+    return ENOTSUP;
+#endif
+}
+
+static void
+peak_exec_checkpoint_warn_gate_failure(const char* operation)
+{
+    int expected = 0;
+
+    if (atomic_compare_exchange_strong_explicit(
+            &peak_exec_checkpoint_gate_failure_warning_emitted,
+            &expected,
+            1,
+            memory_order_acq_rel,
+            memory_order_acquire)) {
+        peak_log_warn("[peak] Exec checkpoint gate %s failed; skipping unsafe teardown\n",
+                      operation);
+    }
 }
 
 static void
@@ -409,7 +499,7 @@ peak_exec_checkpoint_warn_fini_skip(const char* reason)
 }
 
 static gboolean
-peak_exec_checkpoint_wait_for_readers(void)
+peak_exec_checkpoint_wait_for_readers(gboolean* gate_unlock_failed)
 {
     struct timespec deadline;
     gboolean drained = TRUE;
@@ -417,31 +507,22 @@ peak_exec_checkpoint_wait_for_readers(void)
     int wait_status = 0;
     const char* failure_reason = NULL;
 
+    *gate_unlock_failed = FALSE;
+
     if ((atomic_load_explicit(&peak_exec_checkpoint_gate,
                               memory_order_acquire) &
          PEAK_EXEC_CHECKPOINT_GATE_READERS) == 0) {
         return TRUE;
     }
     if (!peak_exec_checkpoint_gate_cond_is_ready() ||
-        clock_gettime(
-#if defined(__linux__)
-            CLOCK_MONOTONIC,
-#else
-            CLOCK_REALTIME,
-#endif
-            &deadline) != 0) {
+        !peak_exec_checkpoint_deadline(&deadline)) {
         peak_exec_checkpoint_warn_fini_skip("checkpoint wait unavailable");
         return FALSE;
     }
-    deadline.tv_sec += PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS / 1000L;
-    deadline.tv_nsec +=
-        (PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS % 1000L) * 1000000L;
-    if (deadline.tv_nsec >= 1000000000L) {
-        deadline.tv_sec++;
-        deadline.tv_nsec -= 1000000000L;
+    if (pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_fini_skip("checkpoint gate lock failed");
+        return FALSE;
     }
-
-    pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex);
     while ((atomic_load_explicit(&peak_exec_checkpoint_gate,
                                  memory_order_acquire) &
             PEAK_EXEC_CHECKPOINT_GATE_READERS) != 0) {
@@ -453,9 +534,7 @@ peak_exec_checkpoint_wait_for_readers(void)
                                   1,
                                   memory_order_release);
 #endif
-        wait_status = pthread_cond_timedwait(&peak_exec_checkpoint_gate_cond,
-                                             &peak_exec_checkpoint_gate_mutex,
-                                             &deadline);
+        wait_status = peak_exec_checkpoint_cond_timedwait(&deadline);
         if (wait_status != 0) {
             drained = FALSE;
             failure_reason = wait_status == ETIMEDOUT ?
@@ -463,7 +542,11 @@ peak_exec_checkpoint_wait_for_readers(void)
             break;
         }
     }
-    pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex);
+    if (pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        drained = FALSE;
+        failure_reason = "checkpoint gate unlock failed";
+        *gate_unlock_failed = TRUE;
+    }
 
     if (!drained) {
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -476,6 +559,103 @@ peak_exec_checkpoint_wait_for_readers(void)
         peak_exec_checkpoint_warn_fini_skip(failure_reason);
     }
     return drained;
+}
+
+static void
+peak_fini_publish_done_without_gate(void)
+{
+    atomic_store_explicit(&peak_fini_state,
+                          PEAK_FINI_DONE,
+                          memory_order_release);
+    peak_exec_checkpoint_warn_gate_failure("completion publication after unlock failure");
+}
+
+static void
+peak_fini_publish_done(void)
+{
+    if (!peak_exec_checkpoint_gate_cond_is_ready()) {
+        atomic_store_explicit(&peak_fini_state,
+                              PEAK_FINI_DONE,
+                              memory_order_release);
+        return;
+    }
+
+    if (pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        atomic_store_explicit(&peak_fini_state,
+                              PEAK_FINI_DONE,
+                              memory_order_release);
+        peak_exec_checkpoint_warn_gate_failure("completion publication lock");
+        return;
+    }
+    atomic_store_explicit(&peak_fini_state,
+                          PEAK_FINI_DONE,
+                          memory_order_release);
+    if (pthread_cond_broadcast(&peak_exec_checkpoint_gate_cond) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("completion broadcast");
+    }
+    if (pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("completion publication unlock");
+    }
+}
+
+static void
+peak_fini_wait_for_completion(void)
+{
+    struct timespec deadline;
+    int wait_status = 0;
+    gboolean still_in_progress;
+    int warning_expected = 0;
+
+    if (atomic_load_explicit(&peak_fini_state, memory_order_acquire) !=
+        PEAK_FINI_IN_PROGRESS) {
+        return;
+    }
+    if (!peak_exec_checkpoint_gate_cond_is_ready() ||
+        !peak_exec_checkpoint_deadline(&deadline)) {
+        if (atomic_compare_exchange_strong_explicit(
+                &peak_fini_completion_wait_warning_emitted,
+                &warning_expected,
+                1,
+                memory_order_acq_rel,
+                memory_order_acquire)) {
+            peak_log_warn("[peak] Finalization completion wait unavailable; returning without cleanup\n");
+        }
+        return;
+    }
+
+    if (pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("completion wait lock");
+        return;
+    }
+    while (atomic_load_explicit(&peak_fini_state, memory_order_acquire) ==
+           PEAK_FINI_IN_PROGRESS) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        atomic_fetch_add_explicit(&peak_test_fini_completion_wait_count_value,
+                                  1,
+                                  memory_order_release);
+#endif
+        wait_status = peak_exec_checkpoint_cond_timedwait(&deadline);
+        if (wait_status != 0) {
+            break;
+        }
+    }
+    still_in_progress =
+        atomic_load_explicit(&peak_fini_state, memory_order_acquire) ==
+        PEAK_FINI_IN_PROGRESS;
+    if (pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("completion wait unlock");
+        return;
+    }
+    if (wait_status != 0 && still_in_progress &&
+        atomic_compare_exchange_strong_explicit(
+            &peak_fini_completion_wait_warning_emitted,
+            &warning_expected,
+            1,
+            memory_order_acq_rel,
+            memory_order_acquire)) {
+        peak_log_warn("[peak] Finalization completion wait %s; returning without cleanup\n",
+                      wait_status == ETIMEDOUT ? "timed out" : "failed");
+    }
 }
 
 static int
@@ -512,12 +692,33 @@ peak_exec_checkpoint_reader_release(void)
         return;
     }
 
-    pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex);
+    if (pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("reader release lock");
+        return;
+    }
     atomic_fetch_sub_explicit(&peak_exec_checkpoint_gate,
                               1U,
                               memory_order_release);
-    pthread_cond_broadcast(&peak_exec_checkpoint_gate_cond);
-    pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex);
+    if (pthread_cond_broadcast(&peak_exec_checkpoint_gate_cond) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("reader release broadcast");
+    }
+    if (pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex) != 0) {
+        peak_exec_checkpoint_warn_gate_failure("reader release unlock");
+    }
+}
+
+static gboolean
+peak_fini_cancellation_disable(int* saved_state)
+{
+    return pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, saved_state) == 0;
+}
+
+static void
+peak_fini_cancellation_restore(int saved_state)
+{
+    if (pthread_setcancelstate(saved_state, NULL) != 0) {
+        peak_log_warn("[peak] Failed to restore finalizer cancellation state\n");
+    }
 }
 
 static gboolean
@@ -1509,6 +1710,8 @@ peak_fini_impl(void)
 void peak_fini()
 {
     int expected = PEAK_FINI_NOT_STARTED;
+    int saved_cancel_state;
+    gboolean checkpoint_gate_unlock_failed;
     PeakRuntimeActivationState activation_state;
 
     if (peak_runtime_is_fork_child()) {
@@ -1533,6 +1736,14 @@ void peak_fini()
         return;
     }
 
+    /* Initialize the shared completion protocol before any finalizer can
+     * publish IN_PROGRESS, so followers never fall back to polling. */
+    (void)peak_exec_checkpoint_gate_cond_is_ready();
+    if (!peak_fini_cancellation_disable(&saved_cancel_state)) {
+        peak_log_warn("[peak] Failed to protect finalization from cancellation; skipping PEAK teardown\n");
+        return;
+    }
+
     if (atomic_compare_exchange_strong_explicit(
             &peak_fini_state,
             &expected,
@@ -1542,23 +1753,24 @@ void peak_fini()
         atomic_fetch_or_explicit(&peak_exec_checkpoint_gate,
                                  PEAK_EXEC_CHECKPOINT_GATE_CLOSING,
                                  memory_order_acq_rel);
-        if (!peak_exec_checkpoint_wait_for_readers()) {
-            atomic_store_explicit(&peak_fini_state,
-                                  PEAK_FINI_DONE,
-                                  memory_order_release);
+        if (!peak_exec_checkpoint_wait_for_readers(
+                &checkpoint_gate_unlock_failed)) {
+            if (checkpoint_gate_unlock_failed) {
+                peak_fini_publish_done_without_gate();
+            } else {
+                peak_fini_publish_done();
+            }
+            peak_fini_cancellation_restore(saved_cancel_state);
             return;
         }
         peak_fini_impl();
-        atomic_store_explicit(&peak_fini_state,
-                              PEAK_FINI_DONE,
-                              memory_order_release);
+        peak_fini_publish_done();
+        peak_fini_cancellation_restore(saved_cancel_state);
         return;
     }
 
-    while (atomic_load_explicit(&peak_fini_state, memory_order_acquire) ==
-           PEAK_FINI_IN_PROGRESS) {
-        sched_yield();
-    }
+    peak_fini_wait_for_completion();
+    peak_fini_cancellation_restore(saved_cancel_state);
 }
 
 PEAK_EXEC_API int

--- a/src/peak.c
+++ b/src/peak.c
@@ -2,12 +2,14 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <limits.h>
+#include <pthread.h>
 #include <sched.h>
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #ifdef HAVE_MPI
 #include <mpi.h>
@@ -128,6 +130,15 @@ static _Atomic unsigned int peak_exec_checkpoint_gate = 0;
 #define PEAK_EXEC_CHECKPOINT_GATE_CLOSING (1U << 31)
 #define PEAK_EXEC_CHECKPOINT_GATE_READERS \
     (PEAK_EXEC_CHECKPOINT_GATE_CLOSING - 1U)
+/* Exec checkpoints are best-effort.  Do not let a canceled checkpoint reader
+ * delay the application's normal exit indefinitely. */
+#define PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS 5000L
+static pthread_mutex_t peak_exec_checkpoint_gate_mutex =
+    PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_exec_checkpoint_gate_cond;
+static pthread_once_t peak_exec_checkpoint_gate_cond_once = PTHREAD_ONCE_INIT;
+static _Atomic int peak_exec_checkpoint_gate_cond_ready = 0;
+static _Atomic int peak_exec_checkpoint_fini_skip_warning_emitted = 0;
 typedef enum {
     PEAK_FINI_NOT_STARTED = 0,
     PEAK_FINI_IN_PROGRESS = 1,
@@ -193,6 +204,8 @@ static _Atomic int peak_test_checkpoint_reader_pause = 0;
 static _Atomic int peak_test_checkpoint_reader_held = 0;
 static _Atomic int peak_test_checkpoint_reader_released = 0;
 static _Atomic int peak_test_fini_waiting_for_reader = 0;
+static _Atomic int peak_test_fini_checkpoint_wait_count = 0;
+static _Atomic int peak_test_fini_checkpoint_timeout_observed = 0;
 static _Atomic int peak_test_activation_pause = 0;
 static _Atomic int peak_test_activation_held = 0;
 static _Atomic int peak_test_activation_released = 0;
@@ -226,6 +239,12 @@ peak_test_checkpoint_reader_pause_enable(void)
     atomic_store_explicit(&peak_test_fini_waiting_for_reader,
                           0,
                           memory_order_release);
+    atomic_store_explicit(&peak_test_fini_checkpoint_wait_count,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_fini_checkpoint_timeout_observed,
+                          0,
+                          memory_order_release);
     atomic_store_explicit(&peak_test_checkpoint_reader_pause,
                           1,
                           memory_order_release);
@@ -250,6 +269,20 @@ PEAK_EXEC_API int
 peak_test_fini_waiting_for_checkpoint_reader(void)
 {
     return atomic_load_explicit(&peak_test_fini_waiting_for_reader,
+                                memory_order_acquire);
+}
+
+PEAK_EXEC_API int
+peak_test_fini_checkpoint_reader_wait_count(void)
+{
+    return atomic_load_explicit(&peak_test_fini_checkpoint_wait_count,
+                                memory_order_acquire);
+}
+
+PEAK_EXEC_API int
+peak_test_fini_checkpoint_reader_timeout_observed(void)
+{
+    return atomic_load_explicit(&peak_test_fini_checkpoint_timeout_observed,
                                 memory_order_acquire);
 }
 
@@ -320,6 +353,131 @@ peak_test_activation_pause_before_claim(void)
 }
 #endif
 
+static void
+peak_exec_checkpoint_gate_cond_initialize(void)
+{
+#if defined(__linux__)
+    pthread_condattr_t attr;
+#endif
+    int status;
+
+#if defined(__linux__)
+    if (pthread_condattr_init(&attr) != 0) {
+        return;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&peak_exec_checkpoint_gate_cond, &attr);
+    }
+    (void)pthread_condattr_destroy(&attr);
+#else
+    status = pthread_cond_init(&peak_exec_checkpoint_gate_cond, NULL);
+#endif
+    if (status == 0) {
+        atomic_store_explicit(&peak_exec_checkpoint_gate_cond_ready,
+                              1,
+                              memory_order_release);
+    }
+}
+
+static gboolean
+peak_exec_checkpoint_gate_cond_is_ready(void)
+{
+    (void)pthread_once(&peak_exec_checkpoint_gate_cond_once,
+                       peak_exec_checkpoint_gate_cond_initialize);
+    return atomic_load_explicit(&peak_exec_checkpoint_gate_cond_ready,
+                                memory_order_acquire) != 0;
+}
+
+static void
+peak_exec_checkpoint_warn_fini_skip(const char* reason)
+{
+    int expected = 0;
+
+    if (atomic_compare_exchange_strong_explicit(
+            &peak_exec_checkpoint_fini_skip_warning_emitted,
+            &expected,
+            1,
+            memory_order_acq_rel,
+            memory_order_acquire)) {
+        peak_log_warn(
+            "[peak] Exec checkpoint readers did not drain (%s); skipping "
+            "PEAK final report and teardown "
+            "so application exit can continue\n",
+            reason);
+    }
+}
+
+static gboolean
+peak_exec_checkpoint_wait_for_readers(void)
+{
+    struct timespec deadline;
+    gboolean drained = TRUE;
+
+    int wait_status = 0;
+    const char* failure_reason = NULL;
+
+    if ((atomic_load_explicit(&peak_exec_checkpoint_gate,
+                              memory_order_acquire) &
+         PEAK_EXEC_CHECKPOINT_GATE_READERS) == 0) {
+        return TRUE;
+    }
+    if (!peak_exec_checkpoint_gate_cond_is_ready() ||
+        clock_gettime(
+#if defined(__linux__)
+            CLOCK_MONOTONIC,
+#else
+            CLOCK_REALTIME,
+#endif
+            &deadline) != 0) {
+        peak_exec_checkpoint_warn_fini_skip("checkpoint wait unavailable");
+        return FALSE;
+    }
+    deadline.tv_sec += PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS / 1000L;
+    deadline.tv_nsec +=
+        (PEAK_EXEC_CHECKPOINT_FINI_WAIT_TIMEOUT_MS % 1000L) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+
+    pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex);
+    while ((atomic_load_explicit(&peak_exec_checkpoint_gate,
+                                 memory_order_acquire) &
+            PEAK_EXEC_CHECKPOINT_GATE_READERS) != 0) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        atomic_store_explicit(&peak_test_fini_waiting_for_reader,
+                              1,
+                              memory_order_release);
+        atomic_fetch_add_explicit(&peak_test_fini_checkpoint_wait_count,
+                                  1,
+                                  memory_order_release);
+#endif
+        wait_status = pthread_cond_timedwait(&peak_exec_checkpoint_gate_cond,
+                                             &peak_exec_checkpoint_gate_mutex,
+                                             &deadline);
+        if (wait_status != 0) {
+            drained = FALSE;
+            failure_reason = wait_status == ETIMEDOUT ?
+                "finalization deadline expired" : "checkpoint wait failed";
+            break;
+        }
+    }
+    pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex);
+
+    if (!drained) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (wait_status == ETIMEDOUT) {
+            atomic_store_explicit(&peak_test_fini_checkpoint_timeout_observed,
+                                  1,
+                                  memory_order_release);
+        }
+#endif
+        peak_exec_checkpoint_warn_fini_skip(failure_reason);
+    }
+    return drained;
+}
+
 static int
 peak_exec_checkpoint_reader_acquire(void)
 {
@@ -347,9 +505,19 @@ peak_exec_checkpoint_reader_acquire(void)
 static void
 peak_exec_checkpoint_reader_release(void)
 {
+    if (!peak_exec_checkpoint_gate_cond_is_ready()) {
+        atomic_fetch_sub_explicit(&peak_exec_checkpoint_gate,
+                                  1U,
+                                  memory_order_release);
+        return;
+    }
+
+    pthread_mutex_lock(&peak_exec_checkpoint_gate_mutex);
     atomic_fetch_sub_explicit(&peak_exec_checkpoint_gate,
                               1U,
                               memory_order_release);
+    pthread_cond_broadcast(&peak_exec_checkpoint_gate_cond);
+    pthread_mutex_unlock(&peak_exec_checkpoint_gate_mutex);
 }
 
 static gboolean
@@ -1374,15 +1542,11 @@ void peak_fini()
         atomic_fetch_or_explicit(&peak_exec_checkpoint_gate,
                                  PEAK_EXEC_CHECKPOINT_GATE_CLOSING,
                                  memory_order_acq_rel);
-        while ((atomic_load_explicit(&peak_exec_checkpoint_gate,
-                                     memory_order_acquire) &
-                PEAK_EXEC_CHECKPOINT_GATE_READERS) != 0) {
-#ifdef PEAK_ENABLE_TEST_HOOKS
-            atomic_store_explicit(&peak_test_fini_waiting_for_reader,
-                                  1,
+        if (!peak_exec_checkpoint_wait_for_readers()) {
+            atomic_store_explicit(&peak_fini_state,
+                                  PEAK_FINI_DONE,
                                   memory_order_release);
-#endif
-            sched_yield();
+            return;
         }
         peak_fini_impl();
         atomic_store_explicit(&peak_fini_state,

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -7,6 +7,15 @@ set_tests_properties(test_exec_chain_platform_contract
         PASS_REGULAR_EXPRESSION "exec_chain_platform_contract_ok"
         TIMEOUT 10)
 
+add_test(NAME test_peak_fini_wait_platform_contract
+    COMMAND ${CMAKE_COMMAND}
+            -DPEAK_SOURCE_ROOT=${PROJECT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/test_peak_fini_wait_platform_contract.cmake)
+set_tests_properties(test_peak_fini_wait_platform_contract
+    PROPERTIES
+        PASS_REGULAR_EXPRESSION "peak_fini_wait_platform_contract_ok"
+        TIMEOUT 10)
+
 add_test(NAME test_exec_chain_platform_selection_contract
     COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/run_exec_platform_selection_contract.py
@@ -275,7 +284,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawn_explicit_peak_env_preserved
         exec_checkpoint_concurrent_fini_callbacks
         exec_checkpoint_reader_wake_before_wait
+        exec_checkpoint_fini_completion_wake
         exec_checkpoint_reader_timeout
+        exec_checkpoint_fini_cancel_deferred
+        exec_checkpoint_reader_cancel_deferred
+        exec_checkpoint_reader_cancel_async
         exec_checkpoint_snapshot_lock_contention
         exec_checkpoint_statistics_snapshot_contention
         exec_checkpoint_statistics_shadow_invalidation

--- a/test/exec_chain/CMakeLists.txt
+++ b/test/exec_chain/CMakeLists.txt
@@ -274,6 +274,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         posix_spawnp_bad_argv_failure_non_destructive
         posix_spawn_explicit_peak_env_preserved
         exec_checkpoint_concurrent_fini_callbacks
+        exec_checkpoint_reader_wake_before_wait
+        exec_checkpoint_reader_timeout
         exec_checkpoint_snapshot_lock_contention
         exec_checkpoint_statistics_snapshot_contention
         exec_checkpoint_statistics_shadow_invalidation

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -180,7 +180,19 @@ MODE_TO_APP_ARG = {
     "exec_checkpoint_reader_wake_before_wait": (
         "exec-checkpoint-reader-wake-before-wait"
     ),
+    "exec_checkpoint_fini_completion_wake": (
+        "exec-checkpoint-fini-completion-wake"
+    ),
     "exec_checkpoint_reader_timeout": "exec-checkpoint-reader-timeout",
+    "exec_checkpoint_fini_cancel_deferred": (
+        "exec-checkpoint-fini-cancel-deferred"
+    ),
+    "exec_checkpoint_reader_cancel_deferred": (
+        "exec-checkpoint-reader-cancel-deferred"
+    ),
+    "exec_checkpoint_reader_cancel_async": (
+        "exec-checkpoint-reader-cancel-async"
+    ),
     "exec_checkpoint_snapshot_lock_contention": "exec-checkpoint-snapshot-lock-contention",
     "exec_checkpoint_statistics_snapshot_contention": (
         "exec-checkpoint-statistics-snapshot-contention"
@@ -228,7 +240,11 @@ NO_EXEC_CHECKPOINT_MODES = {
     "exec_checkpoint_disabled",
     "exec_checkpoint_direct_disabled",
     "exec_checkpoint_concurrent_fini_callbacks",
+    "exec_checkpoint_fini_completion_wake",
     "exec_checkpoint_reader_timeout",
+    "exec_checkpoint_fini_cancel_deferred",
+    "exec_checkpoint_reader_cancel_deferred",
+    "exec_checkpoint_reader_cancel_async",
     "exec_checkpoint_statistics_shadow_invalidation",
     "execve_child_checkpoint_disabled",
     "exec_bad_stats_path_nonfatal",
@@ -1280,22 +1296,83 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         require(len(exec_files) == 1,
                 f"wake-before-wait reader did not finish its checkpoint\n{output}")
 
+    if args.mode == "exec_checkpoint_fini_completion_wake":
+        match = re.search(
+            r"fini_completion_wake=1 completion_waits=(\d+) owner_done=(\d+) "
+            r"follower_done=(\d+)",
+            output,
+        )
+        require(match is not None and int(match.group(1)) > 0,
+                f"follower did not use the completion condition variable\n{output}")
+        require(match.group(2) == "1" and match.group(3) == "1",
+                f"finalizers did not both complete after the owner wake\n{output}")
+        require(len(final_files) == 1 and not exec_files,
+                f"normal completion produced unexpected artifacts: "
+                f"final={final_files} checkpoint={exec_files}\n{output}")
+
     if args.mode == "exec_checkpoint_reader_timeout":
         match = re.search(
             r"checkpoint_reader_timeout=1 reader_released_after_timeout=1 "
-            r"timeout_observed=1 fini_waits=(\d+) elapsed_ms=(\d+)",
+            r"timeout_observed=1 fini_waits=(\d+) completion_waits=(\d+) "
+            r"owner_done=(\d+) follower_done=(\d+) elapsed_ms=(\d+)",
             output,
         )
         require(match is not None,
                 f"checkpoint reader timeout/release was not proven\n{output}")
         require(int(match.group(1)) > 0,
                 f"finalizer did not block on the condition variable\n{output}")
-        require(4500 <= int(match.group(2)) < 7000,
+        require(int(match.group(2)) > 0,
+                f"follower did not block on finalization completion\n{output}")
+        require(match.group(3) == "1" and match.group(4) == "1",
+                f"finalizers did not finish after checkpoint timeout\n{output}")
+        require(4500 <= int(match.group(5)) < 7000,
                 f"checkpoint reader timeout was not bounded\n{output}")
         require("skipping PEAK final report and teardown" in output,
                 f"timeout warning did not identify the skipped PEAK work\n{output}")
         require(not final_files and not exec_files,
                 f"timed-out finalization emitted unsafe artifacts: "
+                f"final={final_files} checkpoint={exec_files}\n{output}")
+
+    if args.mode == "exec_checkpoint_fini_cancel_deferred":
+        match = re.search(
+            r"fini_cancellation=(\w+) timeout_observed=(\d+) "
+            r"owner_result=(\w+) owner_setup=(\d+) follower_done=(\d+) "
+            r"reader_released_after_timeout=1 elapsed_ms=(\d+)",
+            output,
+        )
+        require(match is not None and match.group(1) == "deferred",
+                f"missing cancellation finalizer evidence\n{output}")
+        require(match.group(2) == "1" and match.group(3) == "canceled" and
+                match.group(4) == "0" and match.group(5) == "1",
+                f"canceled owner did not publish safe finalization\n{output}")
+        require(4500 <= int(match.group(6)) < 7000,
+                f"canceled owner finalizer was not bounded\n{output}")
+        require("skipping PEAK final report and teardown" in output,
+                f"canceled owner did not take the fail-open timeout path\n{output}")
+        require(not final_files and not exec_files,
+                f"canceled finalization emitted unsafe artifacts: "
+                f"final={final_files} checkpoint={exec_files}\n{output}")
+
+    if args.mode in {"exec_checkpoint_reader_cancel_deferred",
+                     "exec_checkpoint_reader_cancel_async"}:
+        expected_type = "async" if args.mode.endswith("async") else "deferred"
+        match = re.search(
+            r"checkpoint_reader_cancellation=(\w+) reader_result=canceled "
+            r"timeout_observed=(\d+) owner_done=(\d+) follower_done=(\d+) "
+            r"elapsed_ms=(\d+)",
+            output,
+        )
+        require(match is not None and match.group(1) == expected_type,
+                f"missing canceled-reader finalizer evidence\n{output}")
+        require(match.group(2) == "1" and match.group(3) == "1" and
+                match.group(4) == "1",
+                f"canceled reader did not lead to bounded finalization\n{output}")
+        require(4500 <= int(match.group(5)) < 7000,
+                f"canceled-reader finalization was not bounded\n{output}")
+        require("skipping PEAK final report and teardown" in output,
+                f"canceled reader did not take the fail-open timeout path\n{output}")
+        require(not final_files and not exec_files,
+                f"canceled reader emitted unsafe artifacts: "
                 f"final={final_files} checkpoint={exec_files}\n{output}")
 
     if args.mode == "exec_checkpoint_fork_child_fini":

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -177,6 +177,10 @@ MODE_TO_APP_ARG = {
     "posix_spawnp_bad_argv_failure_non_destructive": "posix-spawnp-bad-argv",
     "posix_spawn_explicit_peak_env_preserved": "posix-spawn-explicit-peak-env",
     "exec_checkpoint_concurrent_fini_callbacks": "exec-concurrent-fini-callbacks",
+    "exec_checkpoint_reader_wake_before_wait": (
+        "exec-checkpoint-reader-wake-before-wait"
+    ),
+    "exec_checkpoint_reader_timeout": "exec-checkpoint-reader-timeout",
     "exec_checkpoint_snapshot_lock_contention": "exec-checkpoint-snapshot-lock-contention",
     "exec_checkpoint_statistics_snapshot_contention": (
         "exec-checkpoint-statistics-snapshot-contention"
@@ -224,6 +228,7 @@ NO_EXEC_CHECKPOINT_MODES = {
     "exec_checkpoint_disabled",
     "exec_checkpoint_direct_disabled",
     "exec_checkpoint_concurrent_fini_callbacks",
+    "exec_checkpoint_reader_timeout",
     "exec_checkpoint_statistics_shadow_invalidation",
     "execve_child_checkpoint_disabled",
     "exec_bad_stats_path_nonfatal",
@@ -1258,10 +1263,40 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
     exec_files, final_files = csv_files(tmpdir)
 
     if args.mode == "exec_checkpoint_concurrent_fini_callbacks":
-        require("checkpoint_reader_gate_held=1 fini_waiting=1" in output,
+        match = re.search(
+            r"checkpoint_reader_gate_held=1 fini_waiting=1 fini_waits=(\d+)",
+            output,
+        )
+        require(match is not None and int(match.group(1)) > 0,
                 f"checkpoint/fini lifetime-gate ordering was not proven\n{output}")
         require(final_files,
                 f"fini did not complete after releasing checkpoint reader\n{output}")
+
+    if args.mode == "exec_checkpoint_reader_wake_before_wait":
+        require("checkpoint_reader_wake_before_wait=1 fini_waits=0" in output,
+                f"wake-before-wait did not avoid a checkpoint wait\n{output}")
+        require(len(final_files) == 1,
+                f"wake-before-wait did not complete final reporting\n{output}")
+        require(len(exec_files) == 1,
+                f"wake-before-wait reader did not finish its checkpoint\n{output}")
+
+    if args.mode == "exec_checkpoint_reader_timeout":
+        match = re.search(
+            r"checkpoint_reader_timeout=1 reader_released_after_timeout=1 "
+            r"timeout_observed=1 fini_waits=(\d+) elapsed_ms=(\d+)",
+            output,
+        )
+        require(match is not None,
+                f"checkpoint reader timeout/release was not proven\n{output}")
+        require(int(match.group(1)) > 0,
+                f"finalizer did not block on the condition variable\n{output}")
+        require(4500 <= int(match.group(2)) < 7000,
+                f"checkpoint reader timeout was not bounded\n{output}")
+        require("skipping PEAK final report and teardown" in output,
+                f"timeout warning did not identify the skipped PEAK work\n{output}")
+        require(not final_files and not exec_files,
+                f"timed-out finalization emitted unsafe artifacts: "
+                f"final={final_files} checkpoint={exec_files}\n{output}")
 
     if args.mode == "exec_checkpoint_fork_child_fini":
         match = re.search(

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -3231,11 +3231,13 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
         RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
     PeakTestReadyFn fini_waiting = (PeakTestReadyFn)dlsym(
         RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    PeakTestReadyFn wait_count = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_wait_count");
     CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
 
     if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
         reader_is_held == NULL || reader_release == NULL ||
-        fini_waiting == NULL) {
+        fini_waiting == NULL || wait_count == NULL) {
         fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
         return 180;
     }
@@ -3275,7 +3277,8 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
         int fini_join = join_test_thread(fini_thread, "fini");
         return checkpoint_join == 0 && fini_join == 0 ? 184 : 185;
     }
-    printf("checkpoint_reader_gate_held=1 fini_waiting=1\n");
+    printf("checkpoint_reader_gate_held=1 fini_waiting=1 fini_waits=%d\n",
+           wait_count());
     fflush(stdout);
     reader_release();
     int checkpoint_join =
@@ -3289,6 +3292,136 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
     execv(self, argv);
     perror("exec-concurrent-fini-callbacks");
     return 186;
+}
+
+static long
+elapsed_milliseconds(const struct timespec* start, const struct timespec* end)
+{
+    return (end->tv_sec - start->tv_sec) * 1000L +
+           (end->tv_nsec - start->tv_nsec) / 1000000L;
+}
+
+static int
+run_exec_checkpoint_reader_wake_before_wait(const char* self)
+{
+    pthread_t checkpoint_thread;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    PeakTestReadyFn wait_count = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_wait_count");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    int rc;
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL || wait_count == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 187;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    rc = pthread_create(&checkpoint_thread,
+                        NULL,
+                        checkpoint_thread_main,
+                        &checkpoint_args);
+    if (rc != 0) {
+        fprintf(stderr, "pthread_create checkpoint reader failed: %s\n",
+                strerror(rc));
+        return 188;
+    }
+    if (wait_for_test_hook(reader_is_held,
+                           "checkpoint reader before wake-before-wait") != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   189 :
+                   190;
+    }
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "checkpoint reader") != 0) {
+        return 191;
+    }
+
+    fini();
+    printf("checkpoint_reader_wake_before_wait=1 fini_waits=%d\n",
+           wait_count());
+    return wait_count() == 0 ? 0 : 192;
+}
+
+static int
+run_exec_checkpoint_reader_timeout(const char* self)
+{
+    pthread_t checkpoint_thread;
+    struct timespec start;
+    struct timespec end;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    PeakTestReadyFn wait_count = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_wait_count");
+    PeakTestReadyFn timeout_observed = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_timeout_observed");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    int rc;
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL || wait_count == NULL ||
+        timeout_observed == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 191;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    rc = pthread_create(&checkpoint_thread,
+                        NULL,
+                        checkpoint_thread_main,
+                        &checkpoint_args);
+    if (rc != 0) {
+        fprintf(stderr, "pthread_create checkpoint reader failed: %s\n",
+                strerror(rc));
+        return 193;
+    }
+    if (wait_for_test_hook(reader_is_held, "stuck checkpoint reader") != 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   194 :
+                   195;
+    }
+    fini();
+    if (clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   196 :
+                   197;
+    }
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "released checkpoint reader") != 0) {
+        return 198;
+    }
+
+    long elapsed_ms = elapsed_milliseconds(&start, &end);
+    printf("checkpoint_reader_timeout=1 reader_released_after_timeout=1 "
+           "timeout_observed=%d fini_waits=%d elapsed_ms=%ld\n",
+           timeout_observed(), wait_count(), elapsed_ms);
+    return timeout_observed() && wait_count() > 0 &&
+                   checkpoint_args.result == -1 && elapsed_ms >= 4500L &&
+                   elapsed_ms < 7000L ?
+               0 :
+               199;
 }
 
 static int
@@ -4039,6 +4172,12 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[1], "exec-concurrent-fini-callbacks") == 0) {
         return run_exec_checkpoint_concurrent_fini_callbacks(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-reader-wake-before-wait") == 0) {
+        return run_exec_checkpoint_reader_wake_before_wait(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-reader-timeout") == 0) {
+        return run_exec_checkpoint_reader_timeout(argv[0]);
     }
     if (strcmp(argv[1], "exec-checkpoint-snapshot-lock-contention") == 0) {
         return run_exec_checkpoint_snapshot_lock_contention(argv[0]);

--- a/test/exec_chain/test_exec_chain.c
+++ b/test/exec_chain/test_exec_chain.c
@@ -3133,12 +3133,32 @@ typedef int (*PeakCheckpointFn)(const char*, char* const[]);
 typedef void (*PeakTestVoidFn)(void);
 typedef int (*PeakTestReadyFn)(void);
 
+typedef struct {
+    PeakFiniFn fini;
+    _Atomic int completed;
+    int set_cancellation_type;
+    int cancellation_type;
+    int cancellation_status;
+} FiniThreadArgs;
+
 static void*
 fini_thread_main(void* data)
 {
-    PeakFiniFn fini = data;
+    FiniThreadArgs* args = data;
 
-    fini();
+    if (args->set_cancellation_type) {
+        args->cancellation_status =
+            pthread_setcanceltype(args->cancellation_type, NULL);
+        if (args->cancellation_status != 0) {
+            return NULL;
+        }
+    }
+    args->fini();
+    if (args->set_cancellation_type &&
+        args->cancellation_type == PTHREAD_CANCEL_DEFERRED) {
+        pthread_testcancel();
+    }
+    atomic_store_explicit(&args->completed, 1, memory_order_release);
     return NULL;
 }
 
@@ -3146,6 +3166,9 @@ typedef struct {
     const char* self;
     PeakCheckpointFn checkpoint;
     int result;
+    int set_cancellation_type;
+    int cancellation_type;
+    int cancellation_status;
 } CheckpointThreadArgs;
 
 static void*
@@ -3154,6 +3177,13 @@ checkpoint_thread_main(void* data)
     CheckpointThreadArgs* args = data;
     char* const argv[] = {(char*)args->self, (char*)"child-basic", NULL};
 
+    if (args->set_cancellation_type) {
+        args->cancellation_status =
+            pthread_setcanceltype(args->cancellation_type, NULL);
+        if (args->cancellation_status != 0) {
+            return NULL;
+        }
+    }
     args->result = args->checkpoint(args->self, argv);
     return NULL;
 }
@@ -3233,6 +3263,7 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
         RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
     PeakTestReadyFn wait_count = (PeakTestReadyFn)dlsym(
         RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_wait_count");
+    FiniThreadArgs fini_args = {.fini = fini, .completed = 0};
     CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
 
     if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
@@ -3261,7 +3292,7 @@ run_exec_checkpoint_concurrent_fini_callbacks(const char* self)
                    182 :
                    185;
     }
-    rc = pthread_create(&fini_thread, NULL, fini_thread_main, (void*)fini);
+    rc = pthread_create(&fini_thread, NULL, fini_thread_main, &fini_args);
     if (rc != 0) {
         fprintf(stderr, "pthread_create fini failed: %s\n", strerror(rc));
         reader_release();
@@ -3355,9 +3386,103 @@ run_exec_checkpoint_reader_wake_before_wait(const char* self)
 }
 
 static int
+run_exec_checkpoint_fini_completion_wake(const char* self)
+{
+    pthread_t checkpoint_thread;
+    pthread_t owner_thread;
+    pthread_t follower_thread;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    PeakTestReadyFn owner_waiting = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    PeakTestReadyFn completion_wait_count = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_completion_wait_count");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    FiniThreadArgs owner_args = {.fini = fini, .completed = 0};
+    FiniThreadArgs follower_args = {.fini = fini, .completed = 0};
+    int rc;
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL ||
+        owner_waiting == NULL || completion_wait_count == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 200;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    rc = pthread_create(&checkpoint_thread, NULL, checkpoint_thread_main,
+                        &checkpoint_args);
+    if (rc != 0) {
+        fprintf(stderr, "pthread_create checkpoint reader failed: %s\n",
+                strerror(rc));
+        return 201;
+    }
+    if (wait_for_test_hook(reader_is_held, "checkpoint reader") != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   202 :
+                   203;
+    }
+    rc = pthread_create(&owner_thread, NULL, fini_thread_main, &owner_args);
+    if (rc != 0) {
+        reader_release();
+        return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
+                   204 :
+                   205;
+    }
+    if (wait_for_test_hook(owner_waiting, "owner finalizer") != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        (void)join_test_thread(owner_thread, "owner finalizer");
+        return 206;
+    }
+    rc = pthread_create(&follower_thread, NULL, fini_thread_main,
+                        &follower_args);
+    if (rc != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        (void)join_test_thread(owner_thread, "owner finalizer");
+        return 207;
+    }
+    if (wait_for_test_hook(completion_wait_count, "follower completion wait") !=
+            0 ||
+        atomic_load_explicit(&follower_args.completed, memory_order_acquire) !=
+            0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        (void)join_test_thread(owner_thread, "owner finalizer");
+        (void)join_test_thread(follower_thread, "follower finalizer");
+        return 208;
+    }
+
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "checkpoint reader") != 0 ||
+        join_test_thread(owner_thread, "owner finalizer") != 0 ||
+        join_test_thread(follower_thread, "follower finalizer") != 0) {
+        return 209;
+    }
+    printf("fini_completion_wake=1 completion_waits=%d owner_done=%d "
+           "follower_done=%d\n",
+           completion_wait_count(),
+           atomic_load_explicit(&owner_args.completed, memory_order_acquire),
+           atomic_load_explicit(&follower_args.completed, memory_order_acquire));
+    return checkpoint_args.result == -1 ? 0 : 210;
+}
+
+static int
 run_exec_checkpoint_reader_timeout(const char* self)
 {
     pthread_t checkpoint_thread;
+    pthread_t owner_thread;
+    pthread_t follower_thread;
     struct timespec start;
     struct timespec end;
     PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
@@ -3373,12 +3498,19 @@ run_exec_checkpoint_reader_timeout(const char* self)
         RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_wait_count");
     PeakTestReadyFn timeout_observed = (PeakTestReadyFn)dlsym(
         RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_timeout_observed");
+    PeakTestReadyFn fini_waiting = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    PeakTestReadyFn completion_wait_count = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_completion_wait_count");
     CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    FiniThreadArgs owner_args = {.fini = fini, .completed = 0};
+    FiniThreadArgs follower_args = {.fini = fini, .completed = 0};
     int rc;
 
     if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
         reader_is_held == NULL || reader_release == NULL || wait_count == NULL ||
-        timeout_observed == NULL) {
+        timeout_observed == NULL || fini_waiting == NULL ||
+        completion_wait_count == NULL) {
         fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
         return 191;
     }
@@ -3401,27 +3533,243 @@ run_exec_checkpoint_reader_timeout(const char* self)
                    194 :
                    195;
     }
-    fini();
+    rc = pthread_create(&owner_thread, NULL, fini_thread_main, &owner_args);
+    if (rc != 0 || wait_for_test_hook(fini_waiting, "owner finalizer") != 0) {
+        reader_release();
+        if (rc == 0) {
+            (void)join_test_thread(owner_thread, "owner finalizer");
+        }
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        return 196;
+    }
+    rc = pthread_create(&follower_thread, NULL, fini_thread_main,
+                        &follower_args);
+    if (rc != 0 ||
+        wait_for_test_hook(completion_wait_count,
+                           "follower completion wait") != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        (void)join_test_thread(owner_thread, "owner finalizer");
+        if (rc == 0) {
+            (void)join_test_thread(follower_thread, "follower finalizer");
+        }
+        return 197;
+    }
+    if (join_test_thread(owner_thread, "owner finalizer") != 0 ||
+        join_test_thread(follower_thread, "follower finalizer") != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        return 198;
+    }
     if (clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
         reader_release();
         return join_test_thread(checkpoint_thread, "checkpoint reader") == 0 ?
-                   196 :
-                   197;
+                   199 :
+                   200;
     }
     reader_release();
     if (join_test_thread(checkpoint_thread, "released checkpoint reader") != 0) {
-        return 198;
+        return 201;
     }
 
     long elapsed_ms = elapsed_milliseconds(&start, &end);
     printf("checkpoint_reader_timeout=1 reader_released_after_timeout=1 "
-           "timeout_observed=%d fini_waits=%d elapsed_ms=%ld\n",
-           timeout_observed(), wait_count(), elapsed_ms);
+           "timeout_observed=%d fini_waits=%d completion_waits=%d "
+           "owner_done=%d follower_done=%d elapsed_ms=%ld\n",
+           timeout_observed(), wait_count(), completion_wait_count(),
+           atomic_load_explicit(&owner_args.completed, memory_order_acquire),
+           atomic_load_explicit(&follower_args.completed, memory_order_acquire),
+           elapsed_ms);
     return timeout_observed() && wait_count() > 0 &&
+                   completion_wait_count() > 0 &&
+                   atomic_load_explicit(&owner_args.completed,
+                                        memory_order_acquire) != 0 &&
+                   atomic_load_explicit(&follower_args.completed,
+                                        memory_order_acquire) != 0 &&
                    checkpoint_args.result == -1 && elapsed_ms >= 4500L &&
                    elapsed_ms < 7000L ?
                0 :
-               199;
+               202;
+}
+
+static int
+run_exec_checkpoint_fini_cancellation(const char* self, int cancellation_type)
+{
+    pthread_t checkpoint_thread;
+    pthread_t owner_thread;
+    pthread_t follower_thread;
+    struct timespec start;
+    struct timespec end;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestVoidFn reader_release = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_release");
+    PeakTestReadyFn fini_waiting = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    PeakTestReadyFn timeout_observed = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_timeout_observed");
+    CheckpointThreadArgs checkpoint_args = {.self = self, .checkpoint = checkpoint};
+    FiniThreadArgs owner_args = {
+        .fini = fini,
+        .completed = 0,
+        .set_cancellation_type = 1,
+        .cancellation_type = cancellation_type,
+        .cancellation_status = 0,
+    };
+    FiniThreadArgs follower_args = {.fini = fini, .completed = 0};
+    void* owner_result = NULL;
+    int rc;
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || reader_release == NULL ||
+        fini_waiting == NULL || timeout_observed == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 211;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    rc = pthread_create(&checkpoint_thread, NULL, checkpoint_thread_main,
+                        &checkpoint_args);
+    if (rc != 0 ||
+        wait_for_test_hook(reader_is_held, "checkpoint reader") != 0) {
+        if (rc == 0) {
+            reader_release();
+            (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        }
+        return 212;
+    }
+    if (clock_gettime(CLOCK_MONOTONIC, &start) != 0 ||
+        pthread_create(&owner_thread, NULL, fini_thread_main, &owner_args) != 0 ||
+        wait_for_test_hook(fini_waiting, "cancelable owner finalizer") != 0 ||
+        pthread_cancel(owner_thread) != 0 ||
+        pthread_join(owner_thread, &owner_result) != 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        return 213;
+    }
+    rc = pthread_create(&follower_thread, NULL, fini_thread_main,
+                        &follower_args);
+    if (rc != 0 || join_test_thread(follower_thread, "second finalizer") != 0) {
+        reader_release();
+        (void)join_test_thread(checkpoint_thread, "checkpoint reader");
+        return 214;
+    }
+    reader_release();
+    if (join_test_thread(checkpoint_thread, "released checkpoint reader") != 0) {
+        return 215;
+    }
+
+    long elapsed_ms = elapsed_milliseconds(&start, &end);
+    printf("fini_cancellation=%s timeout_observed=%d owner_result=%s "
+           "owner_setup=%d follower_done=%d "
+           "reader_released_after_timeout=1 "
+           "elapsed_ms=%ld\n",
+           cancellation_type == PTHREAD_CANCEL_ASYNCHRONOUS ? "async" :
+                                                           "deferred",
+           timeout_observed(),
+           owner_result == PTHREAD_CANCELED ? "canceled" : "returned",
+           owner_args.cancellation_status,
+           atomic_load_explicit(&follower_args.completed, memory_order_acquire),
+           elapsed_ms);
+    return timeout_observed() && owner_args.cancellation_status == 0 &&
+                   atomic_load_explicit(&follower_args.completed,
+                                        memory_order_acquire) != 0 &&
+                   checkpoint_args.result == -1 && elapsed_ms >= 4500L &&
+                   elapsed_ms < 7000L ?
+               0 :
+               216;
+}
+
+static int
+run_exec_checkpoint_reader_cancellation(const char* self,
+                                        int cancellation_type)
+{
+    pthread_t checkpoint_thread;
+    pthread_t owner_thread;
+    pthread_t follower_thread;
+    struct timespec start;
+    struct timespec end;
+    PeakFiniFn fini = (PeakFiniFn)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakCheckpointFn checkpoint =
+        (PeakCheckpointFn)dlsym(RTLD_DEFAULT, "peak_checkpoint_for_exec");
+    PeakTestVoidFn pause_enable = (PeakTestVoidFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_pause_enable");
+    PeakTestReadyFn reader_is_held = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_checkpoint_reader_is_held");
+    PeakTestReadyFn fini_waiting = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_waiting_for_checkpoint_reader");
+    PeakTestReadyFn timeout_observed = (PeakTestReadyFn)dlsym(
+        RTLD_DEFAULT, "peak_test_fini_checkpoint_reader_timeout_observed");
+    CheckpointThreadArgs checkpoint_args = {
+        .self = self,
+        .checkpoint = checkpoint,
+        .result = 0,
+        .set_cancellation_type = 1,
+        .cancellation_type = cancellation_type,
+        .cancellation_status = 0,
+    };
+    FiniThreadArgs owner_args = {.fini = fini, .completed = 0};
+    FiniThreadArgs follower_args = {.fini = fini, .completed = 0};
+    void* reader_result = NULL;
+    int rc;
+
+    if (fini == NULL || checkpoint == NULL || pause_enable == NULL ||
+        reader_is_held == NULL || fini_waiting == NULL ||
+        timeout_observed == NULL) {
+        fprintf(stderr, "checkpoint/fini test hooks unavailable\n");
+        return 217;
+    }
+
+    call_hot_target(5);
+    pause_enable();
+    rc = pthread_create(&checkpoint_thread, NULL, checkpoint_thread_main,
+                        &checkpoint_args);
+    if (rc != 0 ||
+        wait_for_test_hook(reader_is_held, "cancelable checkpoint reader") !=
+            0 ||
+        pthread_cancel(checkpoint_thread) != 0 ||
+        pthread_join(checkpoint_thread, &reader_result) != 0 ||
+        checkpoint_args.cancellation_status != 0 ||
+        reader_result != PTHREAD_CANCELED ||
+        clock_gettime(CLOCK_MONOTONIC, &start) != 0 ||
+        pthread_create(&owner_thread, NULL, fini_thread_main, &owner_args) != 0 ||
+        wait_for_test_hook(fini_waiting, "owner after reader cancellation") !=
+            0 ||
+        join_test_thread(owner_thread, "owner finalizer") != 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
+        return 218;
+    }
+    rc = pthread_create(&follower_thread, NULL, fini_thread_main,
+                        &follower_args);
+    if (rc != 0 || join_test_thread(follower_thread, "second finalizer") != 0) {
+        return 219;
+    }
+
+    long elapsed_ms = elapsed_milliseconds(&start, &end);
+    printf("checkpoint_reader_cancellation=%s reader_result=canceled "
+           "timeout_observed=%d owner_done=%d follower_done=%d "
+           "elapsed_ms=%ld\n",
+           cancellation_type == PTHREAD_CANCEL_ASYNCHRONOUS ? "async" :
+                                                           "deferred",
+           timeout_observed(),
+           atomic_load_explicit(&owner_args.completed, memory_order_acquire),
+           atomic_load_explicit(&follower_args.completed, memory_order_acquire),
+           elapsed_ms);
+    return timeout_observed() &&
+                   atomic_load_explicit(&owner_args.completed,
+                                        memory_order_acquire) != 0 &&
+                   atomic_load_explicit(&follower_args.completed,
+                                        memory_order_acquire) != 0 &&
+                   elapsed_ms >= 4500L && elapsed_ms < 7000L ?
+               0 :
+               220;
 }
 
 static int
@@ -4176,8 +4524,23 @@ main(int argc, char** argv)
     if (strcmp(argv[1], "exec-checkpoint-reader-wake-before-wait") == 0) {
         return run_exec_checkpoint_reader_wake_before_wait(argv[0]);
     }
+    if (strcmp(argv[1], "exec-checkpoint-fini-completion-wake") == 0) {
+        return run_exec_checkpoint_fini_completion_wake(argv[0]);
+    }
     if (strcmp(argv[1], "exec-checkpoint-reader-timeout") == 0) {
         return run_exec_checkpoint_reader_timeout(argv[0]);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-fini-cancel-deferred") == 0) {
+        return run_exec_checkpoint_fini_cancellation(
+            argv[0], PTHREAD_CANCEL_DEFERRED);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-reader-cancel-deferred") == 0) {
+        return run_exec_checkpoint_reader_cancellation(
+            argv[0], PTHREAD_CANCEL_DEFERRED);
+    }
+    if (strcmp(argv[1], "exec-checkpoint-reader-cancel-async") == 0) {
+        return run_exec_checkpoint_reader_cancellation(
+            argv[0], PTHREAD_CANCEL_ASYNCHRONOUS);
     }
     if (strcmp(argv[1], "exec-checkpoint-snapshot-lock-contention") == 0) {
         return run_exec_checkpoint_snapshot_lock_contention(argv[0]);

--- a/test/exec_chain/test_peak_fini_wait_platform_contract.cmake
+++ b/test/exec_chain/test_peak_fini_wait_platform_contract.cmake
@@ -1,0 +1,21 @@
+if(NOT DEFINED PEAK_SOURCE_ROOT)
+    message(FATAL_ERROR "PEAK_SOURCE_ROOT is required")
+endif()
+
+file(READ "${PEAK_SOURCE_ROOT}/src/peak.c" peak_source)
+foreach(required_fragment
+        "pthread_cond_timedwait_relative_np"
+        "CLOCK_MONOTONIC"
+        "return ENOTSUP"
+        "PTHREAD_CANCEL_DISABLE")
+    string(FIND "${peak_source}" "${required_fragment}" fragment_offset)
+    if(fragment_offset EQUAL -1)
+        message(FATAL_ERROR "missing finalization wait contract: ${required_fragment}")
+    endif()
+endforeach()
+string(FIND "${peak_source}" "CLOCK_REALTIME" realtime_offset)
+if(NOT realtime_offset EQUAL -1)
+    message(FATAL_ERROR "finalization wait must not use CLOCK_REALTIME")
+endif()
+
+message("peak_fini_wait_platform_contract_ok")


### PR DESCRIPTION
## Summary

- replace the exec-checkpoint reader and concurrent-finalizer busy waits with a predicate-based condition-variable protocol
- bound checkpoint-reader finalization waits to 5 seconds, using a monotonic deadline on Linux and a relative monotonic wait on Darwin
- fail open on timeout or unsupported wait primitives by warning and skipping the unsafe final report/teardown portion so application exit can continue
- make finalization cancellation-safe: the owner publishes `DONE`, broadcasts, and unlocks before restoring cancellation
- cover normal wakeup, wake-before-wait, stuck/canceled readers, concurrent finalizers, cancellation, timeout diagnostics, and platform contracts

## Root cause

Finalization polled an active exec-checkpoint reader with `sched_yield()` and no deadline. A canceled or failed reader could leave the gate count nonzero forever. A concurrent non-owner finalizer also spun on `PEAK_FINI_IN_PROGRESS`, consuming a core while the owner was blocked.

## Review and local validation

- exact head: `311431def39c88402bcc9083dab976a2066cda9d`
- implementation: GPT-5.6 Terra High
- primary review: ACCEPT
- independent GPT-5.6 Sol High review: ACCEPT
- fresh focused tests: 16/16
- full exec-chain: 135/135 in the independent fresh archive; 155/155 in the implementation build
- normal/wake-before-wait/completion-wake repeats: 300/300
- timeout and cancellation repeats: 12/12
- non-owner finalizer CPU probe: 4/4 at 0 ms thread CPU over about 2.06 s wall; old code consumed about 2.0 s CPU
- ASan+UBSan writer path: 100/100
- `git diff --check`: clean

## State-machine redline

The six detach/reattach redline files are byte-for-byte unchanged from `main` (`5537cb69a90c97a20b1b0241195470d1bd50301d`):

- `src/detach_controller.c`
- `src/pthread_listener.c`
- `include/detach_controller.h`
- `include/general_listener.h`
- `src/unsafe_gum_prologue.c`
- `include/internal/unsafe_gum_prologue.h`

## GitHub CI

- 14/14 checks passed for exact head `311431def39c88402bcc9083dab976a2066cda9d`
- GCC and Clang CMake builds, MPICH/Open MPI/Intel MPI matrices, controlled dependencies, detach benchmarks, and TSan all passed

## HPC certification

### Exact Frontera MILC artifact

- build job: `7893865` (`small`, 1 node, exit `0:0`, 23 s)
- source product hash: `fcb374fd447190ee96e10b7668e629eb1d0d68ab0056726aab5b6eba0acb5f81` across 100 product files
- `libpeak.so`: `578df16ba2656b87d70dc4d69c7af1d7973a0879220bd5a5487ab5a807ae9d34`
- detach helper: `fe9f7939166c53cc5e9b9fbc1f08ea05bebd74370da2c477046007d6212458fb`
- provenance: `cbab3aa13006f3f57ea1a2a637d44d42cfbedfd6104c6f15e4f610066d2024e5`

### Frontera high-thread stress

- job: `7893864` (`development`, 1 node, exit `0:0`, 2m54s)
- 56 persistent workers + 8 transient-thread spawners, 6/6 strict signal-backend samples
- every sample observed detach, reattach, and redetach-after-reattach; trace diagnostics required
- 9/9 issue/FSM focused checks passed
- malloc/free pre-main rollback stress passed 100 repeats

### Vista high-thread stress

- job: `899027` (`gh-dev`, 1 node, exit `0:0`, 3m26s)
- 72 persistent workers + 8 transient-thread spawners, 6/6 strict signal-backend samples
- every sample observed detach, reattach, and redetach-after-reattach; trace diagnostics required
- 9/9 issue/FSM focused checks passed
- malloc/free pre-main rollback stress passed 100 repeats

### Frontera 1024-node MILC certification

- job: `7893872` (`large`, 1024 nodes, 4096 ranks, 12 CPUs/rank, 23m10s)
- excluded known suspect nodes with `--exclude=c122-123,c171-091`; case, gauge, arm order, cooldowns, thresholds, modules, and artifact were unchanged
- backend-repeat arms completed in order: B0/A1/S1/A2/S2/A3/S3/Bend
- B0 and Bend: launcher rc 0, exactly one `RUNNING COMPLETED`, no PEAK markers, no CSV, and no fatal/hang marker
- all six PEAK arms: exactly one `RUNNING COMPLETED`, aggregate report scope of 4096 MPI ranks, `normal_exit` exactly 4096 calls, exactly one PEAK completion, and exactly one 242-line CSV
- all six PEAK arms: `detached_targets=28`, `reattached_targets=27`, `revisited_targets=20`, failed control windows 0, `snapshot_valid=1`, and no fatal/hang marker
- A2/A3/S3 returned launcher rc 0; A1/S1/S2 returned the known bare TACC launcher rc 255 only after MILC and PEAK had fully completed. Their stdout contains only TACC startup, `MPI job exited with code: 255`, and clean shutdown; no product failure evidence is present
- the legacy matrix runner therefore returned exit 1 with three `launcher_rc=255` entries, but the user-approved application/report criterion passes all 8/8 arms; no rerun or 255 investigation was performed
- matrix provenance matches artifact job `7893865`: exact head, source hash, 100 product files, libpeak, helper, and provenance hashes all matched before launch

Closes #58
