### PR TITLE
Isolate report outputs and narrow socket reducer exposure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 project(peak LANGUAGES C CXX)
 
 include(GNUInstallDirs)
+include(CheckIncludeFile)
 
 option(PEAK_FETCH_DEPS
     "Allow CMake to download pinned dependencies when callers do not provide them"
@@ -10,6 +11,14 @@ option(PEAK_FETCH_DEPS
 option(PEAK_ENABLE_OTF2 "Enable OTF2 memory-trace export" OFF)
 option(PEAK_USE_SYSTEM_OTF2 "Find OTF2 in the system before fetching it" ON)
 option(PEAK_ENABLE_FORTRAN_TESTS "Build tests that require a Fortran compiler" OFF)
+
+check_include_file("sys/random.h" PEAK_HAVE_SYS_RANDOM_H)
+if(PEAK_HAVE_SYS_RANDOM_H)
+    add_compile_definitions(PEAK_HAVE_SYS_RANDOM_H=1)
+else()
+    add_compile_definitions(PEAK_HAVE_SYS_RANDOM_H=0)
+endif()
+message(STATUS "PEAK_HAVE_SYS_RANDOM_H = ${PEAK_HAVE_SYS_RANDOM_H}")
 
 # Set build type to Release by default if CMAKE_BUILD_TYPE is not given
 set(default_build_type "Release")

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ in detail.
 | `PEAK_PROFILE_INTERPRETERS` | Allow normally skipped interpreter processes to initialize PEAK. |
 | `PEAK_ENABLE_CXX_SYMBOL_SCAN` | Force the C++ symbol-map lookup path for target matching. |
 | `PEAK_STATSLOG_PATH` | CSV output prefix. Default: `./peak_statslog`. |
-| `PEAK_STATSLOG_TEMPLATE` | Complete statistics-CSV pathname template. Supports `{jobid}`, `{stepid}`, `{host}`, `{rank}`, `{pid}`, and `{session}`. Missing parent directories are created for an explicit template; the template itself supplies `.csv`. The default adds all identity fields plus `.csv` to the prefix. |
+| `PEAK_STATSLOG_TEMPLATE` | Complete statistics-CSV pathname template. Supports `{jobid}`, `{stepid}`, `{host}`, `{rank}`, `{pid}`, and `{session}`; for example `{jobid}/{stepid}/{host}/peak-{rank}-{pid}-{session}.csv`. Missing parent directories are created for an explicit template. A template without `.csv` is valid; an exec checkpoint appends `-execN.csv` to it, while the final report uses the literal rendered name. The default adds all identity fields plus `.csv` to the prefix. |
 | `PEAK_MEMLOG_TEMPLATE` | Complete memory-log CSV pathname template; it supports the same fields. |
 | `PEAK_OUTPUT_ALLOW_OVERWRITE` | Explicitly permit replacement of a completed statistics CSV. Default: disabled. |
 | `PEAK_TEXT_OUTPUT` | Force or suppress the human-readable stderr report. |
@@ -198,9 +198,10 @@ default because its hwloc teardown can crash after PEAK instrumentation; this
 compatibility path is non-conforming and must be validated with the target
 launcher. A gate error or timeout permanently disables later teardown MPI
 calls, even when `PEAK_MPI_REAL_FINALIZE=1` was requested.
-Aggregate CSVs retain `base-pPID.csv`; multi-rank local fallback files use
-`base-pPID-rRANK.csv` (or a sanitized hostname suffix when rank metadata is
-unavailable) to avoid cross-node PID collisions.
+CSV publication uses the same job/step/host/rank/PID/session identity as the
+default report name, including rank-local fallback. Completed outputs are
+published no-clobber by default; replacement requires the explicit
+`PEAK_OUTPUT_ALLOW_OVERWRITE` opt-in.
 In both CSV and text reports, `count` is the exact total call count,
 `per_thread` is the ceiling over active threads, and `per_rank`/`avg/rank` is
 the non-truncated arithmetic mean over all ranks represented by the report.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ in detail.
 | `PEAK_PROFILE_INTERPRETERS` | Allow normally skipped interpreter processes to initialize PEAK. |
 | `PEAK_ENABLE_CXX_SYMBOL_SCAN` | Force the C++ symbol-map lookup path for target matching. |
 | `PEAK_STATSLOG_PATH` | CSV output prefix. Default: `./peak_statslog`. |
+| `PEAK_STATSLOG_TEMPLATE` | Complete statistics-CSV pathname template. Supports `{jobid}`, `{stepid}`, `{host}`, `{rank}`, `{pid}`, and `{session}`. Missing parent directories are created for an explicit template; the template itself supplies `.csv`. The default adds all identity fields plus `.csv` to the prefix. |
+| `PEAK_MEMLOG_TEMPLATE` | Complete memory-log CSV pathname template; it supports the same fields. |
+| `PEAK_OUTPUT_ALLOW_OVERWRITE` | Explicitly permit replacement of a completed statistics CSV. Default: disabled. |
 | `PEAK_TEXT_OUTPUT` | Force or suppress the human-readable stderr report. |
 | `PEAK_VERBOSITY` | `silent`, `report`/`quiet`, `warn`, `info`, or `debug`; numeric levels `0` through `4` are also accepted. |
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
@@ -180,7 +183,9 @@ in detail.
 | `PEAK_OUTPUT_AGGREGATION_PORT` | Override the socket reducer port. |
 | `PEAK_OUTPUT_AGGREGATION_TIMEOUT_MS` | Socket no-progress timeout and root-release phase timeout. Default: `60000`. The absolute gather cap adds `5000` ms per 128-peer wave, with at most `300000` ms adaptive margin; explicit values are never shortened. |
 | `PEAK_OUTPUT_AGGREGATION_RELEASE_TIMEOUT_MS` | Peer-side end-to-end socket release budget spanning the absolute gather cap, report publication, and confirmed release. Default and minimum: gather hard cap plus two socket phase timeouts. |
-| `PEAK_OUTPUT_AGGREGATION_TOKEN` | Override the socket reducer session token. |
+| `PEAK_OUTPUT_AGGREGATION_TOKEN` | Override the deterministic socket peer-enrollment identifier for controlled tests. Root still issues an unpredictable per-report session nonce; neither value is authentication. |
+| `PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS` | Bind the socket reducer to this IPv4 node-local address. By default it binds only the resolved root-host address. |
+| `PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND` | Explicitly permit binding the reducer to all interfaces. Default: disabled. |
 | `PEAK_OUTPUT_AGGREGATION_SOCKET_FALLBACK` | Enable MPI-reducer-to-socket and socket-to-rank-local fallback paths. Default: enabled. |
 
 MPI finalization and aggregation are deliberately bounded and locally

--- a/docs/physical-detach-controller.md
+++ b/docs/physical-detach-controller.md
@@ -829,8 +829,11 @@ emits a bounded diagnostic, releases the peers it did receive, and by default
 falls back to rank-local output CSV files. Set
 `PEAK_OUTPUT_AGGREGATION_SOCKET_FALLBACK=0` (or `false`) to keep this from
 falling back and retain aggregate-disabled behavior instead.
-`PEAK_OUTPUT_AGGREGATION_TOKEN` can override the reducer token for controlled
-tests.
+`PEAK_OUTPUT_AGGREGATION_TOKEN` can override the deterministic peer-enrollment
+identifier for controlled tests. The root distributes a fresh unpredictable
+session nonce after registration; neither value is authentication. By default the reducer binds
+only the selected root-host address; `PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND`
+is the explicit opt-in for an all-interface bind.
 
 `peak_fini()` is process-single-entry: the first caller owns teardown and later
 callers wait for that teardown to finish without touching Gum, MPI, or

--- a/include/internal/general_listener/output_identity.h
+++ b/include/internal/general_listener/output_identity.h
@@ -1,0 +1,28 @@
+#ifndef PEAK_OUTPUT_IDENTITY_H
+#define PEAK_OUTPUT_IDENTITY_H
+
+/* Build a report filename from launcher metadata available before MPI init. */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Capture the process session before any MPI initialization can occur. */
+void peak_output_identity_initialize(void);
+
+/* Create missing parent directories for an explicitly selected template. */
+bool peak_output_identity_make_parent(const char* path);
+
+/* Render a cached statistics checkpoint pathname without consulting getenv. */
+/* 1=ready, 0=pre-init fallback allowed, -1=initialized but invalid. */
+int peak_output_identity_checkpoint_path(char* out,
+                                         size_t out_size,
+                                         unsigned long long checkpoint_index);
+
+bool peak_output_identity_path(char* out,
+                               size_t out_size,
+                               const char* base,
+                               const char* template_value,
+                               const char* extension,
+                               long rank);
+
+#endif /* PEAK_OUTPUT_IDENTITY_H */

--- a/include/internal/general_listener/output_identity.h
+++ b/include/internal/general_listener/output_identity.h
@@ -13,7 +13,13 @@ void peak_output_identity_initialize(void);
 bool peak_output_identity_make_parent(const char* path);
 
 /* Render a cached statistics checkpoint pathname without consulting getenv. */
-/* 1=ready, 0=pre-init fallback allowed, -1=initialized but invalid. */
+enum PeakOutputCheckpointPath {
+    PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE = -1,
+    PEAK_OUTPUT_CHECKPOINT_PREINIT = 0,
+    PEAK_OUTPUT_CHECKPOINT_READY = 1,
+};
+
+/* PREINIT permits the raw legacy fallback; UNAVAILABLE must be skipped. */
 int peak_output_identity_checkpoint_path(char* out,
                                          size_t out_size,
                                          unsigned long long checkpoint_index);

--- a/include/internal/general_listener/report_formatter.h
+++ b/include/internal/general_listener/report_formatter.h
@@ -51,10 +51,11 @@ bool peak_report_formatter_write_rank_local_csv(
     const PeakReportSnapshot* snapshot);
 
 /**
- * Write a strict rank-local CSV with a sanitized-host suffix.
+ * Write a strict rank-local CSV that always adds a sanitized-host suffix.
  *
  * This strict variant always appends a sanitized hostname as a
- * `-ranklocal-hHOST` suffix, including when launcher rank metadata is valid.
+ * `-ranklocal-hHOST` suffix, including when launcher rank metadata is valid;
+ * a valid rank suffix may also remain in the base name.
  * The suffix makes a rank-local root fallback distinct from an already
  * published aggregate. Component-bound names retain a hostname preview plus
  * a stable digest. It is the fail-closed fallback for an active MPI job whose

--- a/include/internal/general_listener/report_formatter.h
+++ b/include/internal/general_listener/report_formatter.h
@@ -54,8 +54,9 @@ bool peak_report_formatter_write_rank_local_csv(
  * Write a rank-local CSV with a rank or sanitized-host suffix.
  *
  * A consistent launcher pair uses `-rRANK`; missing or inconsistent metadata
- * uses a sanitized hostname. The host suffix reduces cross-node PID collision
- * risk but cannot guarantee uniqueness when host identity is unavailable or
+ * uses a sanitized hostname plus a `-ranklocal-hHOST` suffix. The host suffix
+ * reduces cross-node PID collision risk but cannot guarantee uniqueness when
+ * host identity is unavailable or
  * duplicated. This is the fail-closed fallback for an active MPI job whose
  * strict socket path cannot identify the world without MPI.
  */

--- a/include/internal/general_listener/report_formatter.h
+++ b/include/internal/general_listener/report_formatter.h
@@ -51,7 +51,7 @@ bool peak_report_formatter_write_rank_local_csv(
     const PeakReportSnapshot* snapshot);
 
 /**
- * Write a rank-local CSV with a rank or sanitized-host suffix.
+ * Write a strict rank-local CSV with a sanitized-host suffix.
  *
  * This strict variant always appends a sanitized hostname as a
  * `-ranklocal-hHOST` suffix, including when launcher rank metadata is valid.

--- a/include/internal/general_listener/report_formatter.h
+++ b/include/internal/general_listener/report_formatter.h
@@ -53,11 +53,11 @@ bool peak_report_formatter_write_rank_local_csv(
 /**
  * Write a rank-local CSV with a rank or sanitized-host suffix.
  *
- * A consistent launcher pair uses `-rRANK`; missing or inconsistent metadata
- * uses a sanitized hostname plus a `-ranklocal-hHOST` suffix. The host suffix
- * reduces cross-node PID collision risk but cannot guarantee uniqueness when
- * host identity is unavailable or
- * duplicated. This is the fail-closed fallback for an active MPI job whose
+ * This strict variant always appends a sanitized hostname as a
+ * `-ranklocal-hHOST` suffix, including when launcher rank metadata is valid.
+ * The suffix makes a rank-local root fallback distinct from an already
+ * published aggregate. Component-bound names retain a hostname preview plus
+ * a stable digest. It is the fail-closed fallback for an active MPI job whose
  * strict socket path cannot identify the world without MPI.
  */
 bool peak_report_formatter_write_rank_local_csv_host_disambiguated(

--- a/include/internal/general_listener/socket_report_transport.h
+++ b/include/internal/general_listener/socket_report_transport.h
@@ -3,7 +3,7 @@
 
 /**
  * @file socket_report_transport.h
- * @brief Aggregate immutable final-report snapshots through PEAK wire-v12.
+ * @brief Aggregate immutable final-report snapshots through PEAK wire-v13.
  */
 
 #include "internal/general_listener/report_snapshot.h"
@@ -48,7 +48,7 @@ typedef enum {
 typedef struct PeakSocketReportSession PeakSocketReportSession;
 
 /**
- * Gathers immutable report snapshots through the established wire-v12 socket
+ * Gathers immutable report snapshots through the established wire-v13 socket
  * protocol.
  *
  * Root advances a bounded set of nonblocking peer connections under both a
@@ -133,6 +133,7 @@ typedef struct {
     uint32_t root_max_active;
     uint32_t root_release_target_count;
     uint32_t root_release_confirmed_count;
+    uint64_t root_receipt_session_nonce;
     uint8_t root_release_decision;
     bool root_receipt_failure_injected;
     bool peer_receipt_received;
@@ -149,6 +150,9 @@ void peak_socket_report_test_telemetry_reset(void);
 /** Copies test-only socket gather observations to @p telemetry_out. */
 void peak_socket_report_test_telemetry_get(
     PeakSocketReportTestTelemetry* telemetry_out);
+
+/** Opens a reducer listener for binding-scope regression tests. */
+int peak_socket_report_test_bind_listener(int port);
 
 /** Configures a one-shot test-only barrier around root receipt transmission. */
 void peak_socket_report_test_receipt_barrier_set(int peer_wait_fd,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources_peak
     general_listener.c
     general_listener/attach_policy.c
     general_listener/exec_checkpoint_writer.c
+    general_listener/output_identity.c
     general_listener/report_formatter.c
     general_listener/report_maxima.c
     general_listener/report_model.c

--- a/src/general_listener/exec_checkpoint_writer.c
+++ b/src/general_listener/exec_checkpoint_writer.c
@@ -115,10 +115,10 @@ peak_exec_checkpoint_path(char* buffer,
     int identity_path = peak_output_identity_checkpoint_path(buffer,
                                                               buffer_size,
                                                               checkpoint_index);
-    if (identity_path > 0) {
+    if (identity_path == PEAK_OUTPUT_CHECKPOINT_READY) {
         return 0;
     }
-    if (identity_path < 0) {
+    if (identity_path == PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE) {
         errno = EINVAL;
         return -1;
     }

--- a/src/general_listener/exec_checkpoint_writer.c
+++ b/src/general_listener/exec_checkpoint_writer.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include "internal/general_listener/exec_checkpoint_writer.h"
+#include "internal/general_listener/output_identity.h"
 
 #include "internal/exec_raw_syscall.h"
 
@@ -103,7 +104,7 @@ peak_exec_checkpoint_path(char* buffer,
                           size_t buffer_size,
                           unsigned long long checkpoint_index)
 {
-    const char* base = getenv("PEAK_STATSLOG_PATH");
+    const char* base;
     size_t out = 0;
 
     if (buffer == NULL || buffer_size == 0) {
@@ -111,9 +112,18 @@ peak_exec_checkpoint_path(char* buffer,
         return -1;
     }
     buffer[0] = '\0';
-    if (base == NULL || base[0] == '\0') {
-        base = "./peak_statslog";
+    int identity_path = peak_output_identity_checkpoint_path(buffer,
+                                                              buffer_size,
+                                                              checkpoint_index);
+    if (identity_path > 0) {
+        return 0;
     }
+    if (identity_path < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    base = getenv("PEAK_STATSLOG_PATH");
+    if (base == NULL || base[0] == '\0') base = "./peak_statslog";
 
     if (!peak_exec_checkpoint_append_literal(buffer, buffer_size, &out, base) ||
         !peak_exec_checkpoint_append_literal(buffer, buffer_size, &out, "-p") ||

--- a/src/general_listener/output_identity.c
+++ b/src/general_listener/output_identity.c
@@ -35,8 +35,6 @@ static char peak_output_jobid[128];
 static char peak_output_stepid[128];
 static char peak_output_rank[32];
 static char peak_output_host[PEAK_OUTPUT_HOST_CAPACITY];
-static char peak_output_stats_base[PATH_MAX];
-static char peak_output_stats_template[PATH_MAX];
 static char peak_output_checkpoint_prefix[PATH_MAX];
 static _Atomic unsigned int peak_output_checkpoint_prefix_length;
 static _Atomic int peak_output_checkpoint_state;
@@ -147,14 +145,6 @@ peak_output_identity_session_once(void)
         peak_output_identity_metadata(peak_output_rank,
                                       sizeof(peak_output_rank), value);
     }
-    (void)snprintf(peak_output_stats_base, sizeof(peak_output_stats_base), "%s",
-                   getenv("PEAK_STATSLOG_PATH") != NULL &&
-                           getenv("PEAK_STATSLOG_PATH")[0] != '\0'
-                       ? getenv("PEAK_STATSLOG_PATH") : "./peak_statslog");
-    (void)snprintf(peak_output_stats_template,
-                   sizeof(peak_output_stats_template), "%s",
-                   getenv("PEAK_STATSLOG_TEMPLATE") != NULL ?
-                       getenv("PEAK_STATSLOG_TEMPLATE") : "");
     atomic_store_explicit(&peak_output_session_ready, 1,
                           memory_order_release);
 }
@@ -164,8 +154,7 @@ peak_output_identity_checkpoint_path(char* out,
                                      size_t out_size,
                                      unsigned long long checkpoint_index)
 {
-    unsigned int length = atomic_load_explicit(&peak_output_checkpoint_prefix_length,
-                                         memory_order_acquire);
+    unsigned int length;
     size_t output = 0;
     char digits[32];
     size_t count = 0;
@@ -177,6 +166,8 @@ peak_output_identity_checkpoint_path(char* out,
                    ? PEAK_OUTPUT_CHECKPOINT_PREINIT
                    : PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE;
     }
+    length = atomic_load_explicit(&peak_output_checkpoint_prefix_length,
+                                  memory_order_acquire);
     if (length == 0 || out == NULL || out_size == 0 || length >= out_size) {
         return PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE;
     }
@@ -201,6 +192,8 @@ static void
 peak_output_identity_checkpoint_once(void)
 {
     char final_path[PATH_MAX];
+    const char* base = getenv("PEAK_STATSLOG_PATH");
+    const char* template_value = getenv("PEAK_STATSLOG_TEMPLATE");
     size_t length;
 
     atomic_store_explicit(&peak_output_checkpoint_state,
@@ -212,9 +205,14 @@ peak_output_identity_checkpoint_once(void)
                               memory_order_release);
         return;
     }
-    if (!peak_output_identity_path(final_path, sizeof(final_path),
-                                   peak_output_stats_base,
-                                   peak_output_stats_template,
+    if (base == NULL || base[0] == '\0') {
+        base = "./peak_statslog";
+    }
+    if (template_value == NULL) {
+        template_value = "";
+    }
+    if (!peak_output_identity_path(final_path, sizeof(final_path), base,
+                                   template_value,
                                    ".csv", -1)) {
         atomic_store_explicit(&peak_output_checkpoint_state,
                               PEAK_OUTPUT_CHECKPOINT_INVALID, memory_order_release);

--- a/src/general_listener/output_identity.c
+++ b/src/general_listener/output_identity.c
@@ -1,0 +1,411 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "internal/general_listener/output_identity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <sys/random.h>
+#endif
+
+enum { PEAK_OUTPUT_HOST_CAPACITY = 256, PEAK_OUTPUT_SESSION_CAPACITY = 17 };
+
+static uint64_t peak_output_session;
+static _Atomic int peak_output_session_ready;
+static pthread_once_t peak_output_session_once = PTHREAD_ONCE_INIT;
+static char peak_output_jobid[128];
+static char peak_output_stepid[128];
+static char peak_output_rank[32];
+static char peak_output_host[PEAK_OUTPUT_HOST_CAPACITY];
+static char peak_output_stats_base[PATH_MAX];
+static char peak_output_stats_template[PATH_MAX];
+static char peak_output_checkpoint_prefix[PATH_MAX];
+static _Atomic unsigned int peak_output_checkpoint_prefix_length;
+static _Atomic int peak_output_checkpoint_state;
+_Static_assert(ATOMIC_INT_LOCK_FREE == 2,
+               "exec checkpoint state requires lock-free atomics");
+
+static void peak_output_identity_host(char out[PEAK_OUTPUT_HOST_CAPACITY]);
+static void peak_output_identity_metadata(char* out,
+                                          size_t out_size,
+                                          const char* value);
+
+static void
+peak_output_identity_session_once(void)
+{
+    unsigned char* cursor = (unsigned char*)&peak_output_session;
+    size_t remaining = sizeof(peak_output_session);
+
+#ifdef __linux__
+    while (remaining != 0) {
+        ssize_t read_bytes;
+
+        do {
+            read_bytes = getrandom(cursor, remaining, GRND_NONBLOCK);
+        } while (read_bytes < 0 && errno == EINTR);
+        if (read_bytes <= 0) {
+            break;
+        }
+        cursor += read_bytes;
+        remaining -= (size_t)read_bytes;
+    }
+#else
+    (void)cursor;
+#endif
+    if (remaining != 0) {
+        int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+
+        if (fd < 0) {
+            return;
+        }
+        while (remaining != 0) {
+            ssize_t read_bytes;
+
+            do {
+                read_bytes = read(fd, cursor, remaining);
+            } while (read_bytes < 0 && errno == EINTR);
+            if (read_bytes <= 0) {
+                (void)close(fd);
+                return;
+            }
+            cursor += read_bytes;
+            remaining -= (size_t)read_bytes;
+        }
+        (void)close(fd);
+    }
+    peak_output_identity_host(peak_output_host);
+    peak_output_identity_metadata(peak_output_jobid,
+                                  sizeof(peak_output_jobid),
+                                  getenv("SLURM_JOB_ID"));
+    peak_output_identity_metadata(peak_output_stepid,
+                                  sizeof(peak_output_stepid),
+                                  getenv("SLURM_STEP_ID") != NULL ?
+                                      getenv("SLURM_STEP_ID") :
+                                      getenv("SLURM_STEPID"));
+    {
+        static const char* const rank_names[] = {
+            "PMI_RANK", "PMIX_RANK", "OMPI_COMM_WORLD_RANK",
+            "MV2_COMM_WORLD_RANK", "I_MPI_RANK", "SLURM_PROCID", NULL,
+        };
+        const char* value = NULL;
+        for (size_t i = 0; rank_names[i] != NULL && value == NULL; i++) {
+            const char* candidate = getenv(rank_names[i]);
+            if (candidate != NULL && candidate[0] != '\0') {
+                value = candidate;
+            }
+        }
+        peak_output_identity_metadata(peak_output_rank,
+                                      sizeof(peak_output_rank), value);
+    }
+    (void)snprintf(peak_output_stats_base, sizeof(peak_output_stats_base), "%s",
+                   getenv("PEAK_STATSLOG_PATH") != NULL &&
+                           getenv("PEAK_STATSLOG_PATH")[0] != '\0'
+                       ? getenv("PEAK_STATSLOG_PATH") : "./peak_statslog");
+    (void)snprintf(peak_output_stats_template,
+                   sizeof(peak_output_stats_template), "%s",
+                   getenv("PEAK_STATSLOG_TEMPLATE") != NULL ?
+                       getenv("PEAK_STATSLOG_TEMPLATE") : "");
+    atomic_store_explicit(&peak_output_session_ready, 1,
+                          memory_order_release);
+}
+
+int
+peak_output_identity_checkpoint_path(char* out,
+                                     size_t out_size,
+                                     unsigned long long checkpoint_index)
+{
+    unsigned int length = atomic_load_explicit(&peak_output_checkpoint_prefix_length,
+                                         memory_order_acquire);
+    size_t output = 0;
+    char digits[32];
+    size_t count = 0;
+
+    int state = atomic_load_explicit(&peak_output_checkpoint_state,
+                                     memory_order_acquire);
+    if (state != 1) {
+        return state == 0 ? 0 : -1;
+    }
+    if (length == 0 || out == NULL || out_size == 0 || length >= out_size) {
+        return -1;
+    }
+    for (size_t i = 0; i < length; i++) out[i] = peak_output_checkpoint_prefix[i];
+    output = length;
+    do {
+        digits[count++] = (char)('0' + checkpoint_index % 10U);
+        checkpoint_index /= 10U;
+    } while (checkpoint_index != 0 && count < sizeof(digits));
+    if (output + 5 + count + 4 >= out_size) {
+        return -1;
+    }
+    out[output++] = '-'; out[output++] = 'e'; out[output++] = 'x';
+    out[output++] = 'e'; out[output++] = 'c';
+    while (count != 0) out[output++] = digits[--count];
+    out[output++] = '.'; out[output++] = 'c'; out[output++] = 's';
+    out[output++] = 'v'; out[output] = '\0';
+    return 1;
+}
+
+void
+peak_output_identity_initialize(void)
+{
+    char final_path[PATH_MAX];
+    size_t length;
+
+    {
+        int expected = 0;
+        if (!atomic_compare_exchange_strong_explicit(
+                &peak_output_checkpoint_state, &expected, 3,
+                memory_order_acq_rel, memory_order_acquire)) return;
+    }
+    (void)pthread_once(&peak_output_session_once,
+                       peak_output_identity_session_once);
+    if (!atomic_load_explicit(&peak_output_session_ready, memory_order_acquire)) {
+        atomic_store_explicit(&peak_output_checkpoint_state, 2,
+                              memory_order_release);
+        return;
+    }
+    if (!peak_output_identity_path(final_path, sizeof(final_path),
+                                   peak_output_stats_base,
+                                   peak_output_stats_template,
+                                   ".csv", -1)) {
+        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        return;
+    }
+    if (!peak_output_identity_make_parent(final_path)) {
+        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        return;
+    }
+    length = strlen(final_path);
+    if (length >= 4 && strcmp(final_path + length - 4, ".csv") == 0) length -= 4;
+    if (length == 0 || length >= sizeof(peak_output_checkpoint_prefix)) {
+        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        return;
+    }
+    memcpy(peak_output_checkpoint_prefix, final_path, length);
+    peak_output_checkpoint_prefix[length] = '\0';
+    atomic_store_explicit(&peak_output_checkpoint_prefix_length, (unsigned int)length,
+                          memory_order_release);
+    atomic_store_explicit(&peak_output_checkpoint_state, 1, memory_order_release);
+}
+
+bool
+peak_output_identity_make_parent(const char* path)
+{
+    char parent[PATH_MAX];
+    char* slash;
+
+    if (path == NULL || strlen(path) >= sizeof(parent)) {
+        return false;
+    }
+    (void)snprintf(parent, sizeof(parent), "%s", path);
+    slash = strrchr(parent, '/');
+    if (slash == NULL) {
+        return true;
+    }
+    *slash = '\0';
+    if (parent[0] == '\0') {
+        return true;
+    }
+    for (char* component = parent + (parent[0] == '/' ? 1 : 0);
+         ; ) {
+        char* next = strchr(component, '/');
+
+        if (next == NULL) {
+            break;
+        }
+        *next = '\0';
+        if (component[0] != '\0' && mkdir(parent, 0777) != 0 && errno != EEXIST) {
+            return false;
+        }
+        if (component[0] != '\0') {
+            struct stat status;
+            if (stat(parent, &status) != 0 || !S_ISDIR(status.st_mode)) {
+                return false;
+            }
+        }
+        *next = '/';
+        component = next + 1;
+    }
+    if (parent[0] != '\0' && mkdir(parent, 0777) != 0 && errno != EEXIST) {
+        return false;
+    }
+    if (parent[0] != '\0') {
+        struct stat status;
+        if (stat(parent, &status) != 0 || !S_ISDIR(status.st_mode)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool
+peak_output_identity_session(char out[PEAK_OUTPUT_SESSION_CAPACITY])
+{
+    if (!atomic_load_explicit(&peak_output_session_ready, memory_order_acquire)) {
+        peak_output_identity_initialize();
+    }
+    if (!atomic_load_explicit(&peak_output_session_ready, memory_order_acquire)) {
+        return false;
+    }
+    return snprintf(out, PEAK_OUTPUT_SESSION_CAPACITY,
+                    "%016llx", (unsigned long long)peak_output_session) ==
+           PEAK_OUTPUT_SESSION_CAPACITY - 1;
+}
+
+static void
+peak_output_identity_host(char out[PEAK_OUTPUT_HOST_CAPACITY])
+{
+    char raw[PEAK_OUTPUT_HOST_CAPACITY] = {0};
+    size_t used = 0;
+
+    if (gethostname(raw, sizeof(raw) - 1) != 0 || raw[0] == '\0') {
+        (void)snprintf(raw, sizeof(raw), "unknown");
+    }
+    for (size_t i = 0; raw[i] != '\0' && used + 1 < PEAK_OUTPUT_HOST_CAPACITY;
+         i++) {
+        unsigned char byte = (unsigned char)raw[i];
+
+        out[used++] = (byte >= 'a' && byte <= 'z') ||
+                            (byte >= 'A' && byte <= 'Z') ||
+                            (byte >= '0' && byte <= '9') ||
+                            byte == '-' || byte == '_' || byte == '.'
+                        ? (char)byte
+                        : '_';
+    }
+    if (used == 0) {
+        (void)snprintf(out, PEAK_OUTPUT_HOST_CAPACITY, "unknown");
+    } else {
+        out[used] = '\0';
+    }
+}
+
+static void
+peak_output_identity_sanitize(char* out, size_t out_size, const char* value)
+{
+    size_t used = 0;
+
+    if (value == NULL || value[0] == '\0') {
+        value = "none";
+    }
+    for (; *value != '\0' && used + 1 < out_size; value++) {
+        unsigned char byte = (unsigned char)*value;
+
+        out[used++] = (byte >= 'a' && byte <= 'z') ||
+                            (byte >= 'A' && byte <= 'Z') ||
+                            (byte >= '0' && byte <= '9') ||
+                            byte == '-' || byte == '_' || byte == '.'
+                        ? (char)byte
+                        : '_';
+    }
+    if (used == 0 && out_size != 0) {
+        (void)snprintf(out, out_size, "none");
+    } else if (out_size != 0) {
+        out[used] = '\0';
+    }
+}
+
+static void
+peak_output_identity_metadata(char* out, size_t out_size, const char* value)
+{
+    peak_output_identity_sanitize(out, out_size, value);
+    for (size_t i = 0; out[i] != '\0'; i++) {
+        if (out[i] == '.') {
+            out[i] = '_';
+        }
+    }
+}
+
+static bool
+peak_output_identity_append(char* out, size_t out_size, size_t* used,
+                            const char* text)
+{
+    size_t length = strlen(text);
+
+    if (*used > out_size || length >= out_size - *used) {
+        return false;
+    }
+    memcpy(out + *used, text, length);
+    *used += length;
+    out[*used] = '\0';
+    return true;
+}
+
+bool
+peak_output_identity_path(char* out,
+                          size_t out_size,
+                          const char* base,
+                          const char* template_value,
+                          const char* extension,
+                          long rank)
+{
+    char host[PEAK_OUTPUT_HOST_CAPACITY];
+    char pid[32];
+    char rank_text[32];
+    char session[PEAK_OUTPUT_SESSION_CAPACITY];
+    char jobid[128];
+    char stepid[128];
+    size_t used = 0;
+
+    if (out == NULL || out_size == 0 || base == NULL || extension == NULL ||
+        !peak_output_identity_session(session)) {
+        return false;
+    }
+    (void)snprintf(host, sizeof(host), "%s", peak_output_host);
+    (void)snprintf(jobid, sizeof(jobid), "%s", peak_output_jobid);
+    (void)snprintf(stepid, sizeof(stepid), "%s", peak_output_stepid);
+    if (rank < 0) {
+        (void)snprintf(rank_text, sizeof(rank_text), "%s", peak_output_rank);
+    } else {
+        (void)snprintf(rank_text, sizeof(rank_text), "%ld", rank);
+    }
+    (void)snprintf(pid, sizeof(pid), "%ld", (long)getpid());
+    out[0] = '\0';
+    if (template_value == NULL || template_value[0] == '\0') {
+        return peak_output_identity_append(out, out_size, &used, base) &&
+               peak_output_identity_append(out, out_size, &used, "-j") &&
+               peak_output_identity_append(out, out_size, &used, jobid) &&
+               peak_output_identity_append(out, out_size, &used, "-s") &&
+               peak_output_identity_append(out, out_size, &used, stepid) &&
+               peak_output_identity_append(out, out_size, &used, "-h") &&
+               peak_output_identity_append(out, out_size, &used, host) &&
+               peak_output_identity_append(out, out_size, &used, "-r") &&
+               peak_output_identity_append(out, out_size, &used, rank_text) &&
+               peak_output_identity_append(out, out_size, &used, "-p") &&
+               peak_output_identity_append(out, out_size, &used, pid) &&
+               peak_output_identity_append(out, out_size, &used, "-q") &&
+               peak_output_identity_append(out, out_size, &used, session) &&
+               peak_output_identity_append(out, out_size, &used, extension);
+    }
+    for (const char* cursor = template_value; *cursor != '\0';) {
+        const char* replacement = NULL;
+
+        if (*cursor != '{') {
+            char literal[2] = {*cursor++, '\0'};
+            if (!peak_output_identity_append(out, out_size, &used, literal)) {
+                return false;
+            }
+            continue;
+        }
+        if (strncmp(cursor, "{jobid}", 7) == 0) { replacement = jobid; cursor += 7; }
+        else if (strncmp(cursor, "{stepid}", 8) == 0) { replacement = stepid; cursor += 8; }
+        else if (strncmp(cursor, "{host}", 6) == 0) { replacement = host; cursor += 6; }
+        else if (strncmp(cursor, "{rank}", 6) == 0) { replacement = rank_text; cursor += 6; }
+        else if (strncmp(cursor, "{pid}", 5) == 0) { replacement = pid; cursor += 5; }
+        else if (strncmp(cursor, "{session}", 9) == 0) { replacement = session; cursor += 9; }
+        else { return false; }
+        if (!peak_output_identity_append(out, out_size, &used, replacement)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/general_listener/output_identity.c
+++ b/src/general_listener/output_identity.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifdef __linux__
@@ -19,8 +20,15 @@
 #endif
 
 enum { PEAK_OUTPUT_HOST_CAPACITY = 256, PEAK_OUTPUT_SESSION_CAPACITY = 17 };
+enum peak_output_checkpoint_state {
+    PEAK_OUTPUT_CHECKPOINT_UNINITIALIZED,
+    PEAK_OUTPUT_CHECKPOINT_READY_STATE,
+    PEAK_OUTPUT_CHECKPOINT_INVALID,
+    PEAK_OUTPUT_CHECKPOINT_INITIALIZING,
+};
 
 static uint64_t peak_output_session;
+static _Atomic unsigned long peak_output_fallback_counter;
 static _Atomic int peak_output_session_ready;
 static pthread_once_t peak_output_session_once = PTHREAD_ONCE_INIT;
 static char peak_output_jobid[128];
@@ -32,6 +40,7 @@ static char peak_output_stats_template[PATH_MAX];
 static char peak_output_checkpoint_prefix[PATH_MAX];
 static _Atomic unsigned int peak_output_checkpoint_prefix_length;
 static _Atomic int peak_output_checkpoint_state;
+static pthread_once_t peak_output_checkpoint_once = PTHREAD_ONCE_INIT;
 _Static_assert(ATOMIC_INT_LOCK_FREE == 2,
                "exec checkpoint state requires lock-free atomics");
 
@@ -41,11 +50,31 @@ static void peak_output_identity_metadata(char* out,
                                           const char* value);
 
 static void
+peak_output_identity_fallback_session(void)
+{
+    struct timespec now = {0};
+    uint64_t mix;
+
+    (void)clock_gettime(CLOCK_MONOTONIC, &now);
+    mix = ((uint64_t)(unsigned long)getpid() << 32) ^ (uint64_t)now.tv_nsec ^
+          ((uint64_t)now.tv_sec << 1) ^
+          (uint64_t)atomic_fetch_add_explicit(&peak_output_fallback_counter, 1UL,
+                                               memory_order_relaxed) ^
+          (uintptr_t)&peak_output_session;
+    peak_output_session = mix == 0 ? 1 : mix;
+}
+
+static void
 peak_output_identity_session_once(void)
 {
     unsigned char* cursor = (unsigned char*)&peak_output_session;
     size_t remaining = sizeof(peak_output_session);
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (getenv("PEAK_TEST_OUTPUT_IDENTITY_ENTROPY_FAIL") != NULL) {
+        remaining = sizeof(peak_output_session);
+    } else {
+#endif
 #ifdef __linux__
     while (remaining != 0) {
         ssize_t read_bytes;
@@ -62,26 +91,37 @@ peak_output_identity_session_once(void)
 #else
     (void)cursor;
 #endif
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    }
+#endif
     if (remaining != 0) {
-        int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+        int fd = -1;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (getenv("PEAK_TEST_OUTPUT_IDENTITY_ENTROPY_FAIL") == NULL)
+#endif
+            fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC | O_NONBLOCK);
 
         if (fd < 0) {
-            return;
-        }
-        while (remaining != 0) {
-            ssize_t read_bytes;
-
-            do {
-                read_bytes = read(fd, cursor, remaining);
-            } while (read_bytes < 0 && errno == EINTR);
-            if (read_bytes <= 0) {
-                (void)close(fd);
-                return;
+            peak_output_identity_fallback_session();
+            remaining = 0;
+        } else {
+            while (remaining != 0) {
+                ssize_t read_bytes;
+                do {
+                    read_bytes = read(fd, cursor, remaining);
+                } while (read_bytes < 0 && errno == EINTR);
+                if (read_bytes <= 0) {
+                    (void)close(fd);
+                    peak_output_identity_fallback_session();
+                    remaining = 0;
+                    break;
+                }
+                cursor += read_bytes;
+                remaining -= (size_t)read_bytes;
             }
-            cursor += read_bytes;
-            remaining -= (size_t)read_bytes;
+            (void)close(fd);
         }
-        (void)close(fd);
     }
     peak_output_identity_host(peak_output_host);
     peak_output_identity_metadata(peak_output_jobid,
@@ -132,11 +172,13 @@ peak_output_identity_checkpoint_path(char* out,
 
     int state = atomic_load_explicit(&peak_output_checkpoint_state,
                                      memory_order_acquire);
-    if (state != 1) {
-        return state == 0 ? 0 : -1;
+    if (state != PEAK_OUTPUT_CHECKPOINT_READY_STATE) {
+        return state == PEAK_OUTPUT_CHECKPOINT_UNINITIALIZED
+                   ? PEAK_OUTPUT_CHECKPOINT_PREINIT
+                   : PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE;
     }
     if (length == 0 || out == NULL || out_size == 0 || length >= out_size) {
-        return -1;
+        return PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE;
     }
     for (size_t i = 0; i < length; i++) out[i] = peak_output_checkpoint_prefix[i];
     output = length;
@@ -145,32 +187,28 @@ peak_output_identity_checkpoint_path(char* out,
         checkpoint_index /= 10U;
     } while (checkpoint_index != 0 && count < sizeof(digits));
     if (output + 5 + count + 4 >= out_size) {
-        return -1;
+        return PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE;
     }
     out[output++] = '-'; out[output++] = 'e'; out[output++] = 'x';
     out[output++] = 'e'; out[output++] = 'c';
     while (count != 0) out[output++] = digits[--count];
     out[output++] = '.'; out[output++] = 'c'; out[output++] = 's';
     out[output++] = 'v'; out[output] = '\0';
-    return 1;
+    return PEAK_OUTPUT_CHECKPOINT_READY;
 }
 
-void
-peak_output_identity_initialize(void)
+static void
+peak_output_identity_checkpoint_once(void)
 {
     char final_path[PATH_MAX];
     size_t length;
 
-    {
-        int expected = 0;
-        if (!atomic_compare_exchange_strong_explicit(
-                &peak_output_checkpoint_state, &expected, 3,
-                memory_order_acq_rel, memory_order_acquire)) return;
-    }
-    (void)pthread_once(&peak_output_session_once,
-                       peak_output_identity_session_once);
+    atomic_store_explicit(&peak_output_checkpoint_state,
+                          PEAK_OUTPUT_CHECKPOINT_INITIALIZING,
+                          memory_order_release);
     if (!atomic_load_explicit(&peak_output_session_ready, memory_order_acquire)) {
-        atomic_store_explicit(&peak_output_checkpoint_state, 2,
+        atomic_store_explicit(&peak_output_checkpoint_state,
+                              PEAK_OUTPUT_CHECKPOINT_INVALID,
                               memory_order_release);
         return;
     }
@@ -178,24 +216,43 @@ peak_output_identity_initialize(void)
                                    peak_output_stats_base,
                                    peak_output_stats_template,
                                    ".csv", -1)) {
-        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        atomic_store_explicit(&peak_output_checkpoint_state,
+                              PEAK_OUTPUT_CHECKPOINT_INVALID, memory_order_release);
         return;
     }
     if (!peak_output_identity_make_parent(final_path)) {
-        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        atomic_store_explicit(&peak_output_checkpoint_state,
+                              PEAK_OUTPUT_CHECKPOINT_INVALID, memory_order_release);
         return;
     }
     length = strlen(final_path);
     if (length >= 4 && strcmp(final_path + length - 4, ".csv") == 0) length -= 4;
     if (length == 0 || length >= sizeof(peak_output_checkpoint_prefix)) {
-        atomic_store_explicit(&peak_output_checkpoint_state, 2, memory_order_release);
+        atomic_store_explicit(&peak_output_checkpoint_state,
+                              PEAK_OUTPUT_CHECKPOINT_INVALID, memory_order_release);
         return;
     }
     memcpy(peak_output_checkpoint_prefix, final_path, length);
     peak_output_checkpoint_prefix[length] = '\0';
     atomic_store_explicit(&peak_output_checkpoint_prefix_length, (unsigned int)length,
                           memory_order_release);
-    atomic_store_explicit(&peak_output_checkpoint_state, 1, memory_order_release);
+    atomic_store_explicit(&peak_output_checkpoint_state,
+                          PEAK_OUTPUT_CHECKPOINT_READY_STATE, memory_order_release);
+}
+
+void
+peak_output_identity_initialize(void)
+{
+    int expected = PEAK_OUTPUT_CHECKPOINT_UNINITIALIZED;
+
+    (void)atomic_compare_exchange_strong_explicit(
+        &peak_output_checkpoint_state, &expected,
+        PEAK_OUTPUT_CHECKPOINT_INITIALIZING,
+        memory_order_release, memory_order_relaxed);
+    (void)pthread_once(&peak_output_session_once,
+                       peak_output_identity_session_once);
+    (void)pthread_once(&peak_output_checkpoint_once,
+                       peak_output_identity_checkpoint_once);
 }
 
 bool

--- a/src/general_listener/output_identity.c
+++ b/src/general_listener/output_identity.c
@@ -15,7 +15,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef __linux__
+#if PEAK_HAVE_SYS_RANDOM_H
 #include <sys/random.h>
 #endif
 
@@ -73,7 +73,7 @@ peak_output_identity_session_once(void)
         remaining = sizeof(peak_output_session);
     } else {
 #endif
-#ifdef __linux__
+#if PEAK_HAVE_SYS_RANDOM_H
     while (remaining != 0) {
         ssize_t read_bytes;
 

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -20,6 +20,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
+
 enum {
     PEAK_TEXT_REPORT_FUNCTION_WIDTH = 32,
     PEAK_TEXT_REPORT_COLUMN_WIDTH = 12,
@@ -27,9 +31,165 @@ enum {
         PEAK_TEXT_REPORT_FUNCTION_WIDTH +
         PEAK_TEXT_REPORT_COLUMN_WIDTH * 5 + 7,
     PEAK_REPORT_TEMP_CREATE_ATTEMPTS = 128,
+    PEAK_REPORT_HOST_CAPACITY = 256,
+    PEAK_REPORT_HOST_PREVIEW_LENGTH = 32,
+    PEAK_REPORT_SUMMARY_HEX_LENGTH = 16,
 };
 
 static _Atomic unsigned long peak_report_formatter_temp_counter;
+
+static void
+peak_report_formatter_sanitized_hostname(
+    char hostname[PEAK_REPORT_HOST_CAPACITY])
+{
+    char local_hostname[PEAK_REPORT_HOST_CAPACITY] = {0};
+    const char* source = local_hostname;
+    size_t host_length = 0;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    const char* override = getenv("PEAK_TEST_REPORT_HOSTNAME");
+
+    if (override != NULL && override[0] != '\0') {
+        source = override;
+    } else
+#endif
+    if (gethostname(local_hostname, sizeof(local_hostname) - 1) != 0 ||
+        local_hostname[0] == '\0') {
+        (void)snprintf(local_hostname, sizeof(local_hostname), "unknown");
+    }
+    for (size_t index = 0;
+         source[index] != '\0' && host_length + 1 < PEAK_REPORT_HOST_CAPACITY;
+         index++) {
+        unsigned char byte = (unsigned char)source[index];
+
+        hostname[host_length++] =
+            (byte >= 'a' && byte <= 'z') ||
+            (byte >= 'A' && byte <= 'Z') ||
+            (byte >= '0' && byte <= '9') || byte == '-' ||
+            byte == '_' || byte == '.' ? (char)byte : '_';
+    }
+    if (host_length == 0) {
+        (void)snprintf(hostname, PEAK_REPORT_HOST_CAPACITY, "unknown");
+    } else {
+        hostname[host_length] = '\0';
+    }
+}
+
+static uint64_t
+peak_report_formatter_summary_update(uint64_t summary, const char* text)
+{
+    for (; *text != '\0'; text++) {
+        summary ^= (unsigned char)*text;
+        summary *= UINT64_C(1099511628211);
+    }
+    summary ^= UINT64_C(0xff);
+    return summary * UINT64_C(1099511628211);
+}
+
+static bool
+peak_report_formatter_strict_rank_local_path(char out[PATH_MAX],
+                                             const char* path,
+                                             long world_rank)
+{
+    static const char marker[] = "-ranklocal-h";
+    const char* basename = strrchr(path, '/');
+    const char* extension;
+    char hostname[PEAK_REPORT_HOST_CAPACITY] = {0};
+    char rank_text[32];
+    char summary[PEAK_REPORT_SUMMARY_HEX_LENGTH + 1];
+    size_t directory_length;
+    size_t basename_length;
+    size_t stem_length;
+    size_t extension_length;
+    size_t component_limit;
+    size_t hostname_length;
+    size_t marker_length = sizeof(marker) - 1;
+    size_t final_component_length;
+    uint64_t hash = UINT64_C(1469598103934665603);
+
+    if (basename == NULL) {
+        basename = path;
+        directory_length = 0;
+    } else {
+        directory_length = (size_t)(basename - path) + 1;
+        basename++;
+    }
+    basename_length = strlen(basename);
+    if (basename_length == 0 || directory_length >= PATH_MAX) {
+        return false;
+    }
+    extension = basename_length >= 4 &&
+                        strcmp(basename + basename_length - 4, ".csv") == 0 ?
+                    ".csv" : "";
+    extension_length = strlen(extension);
+    stem_length = basename_length - extension_length;
+    component_limit = PATH_MAX - directory_length - 1;
+    if (component_limit > NAME_MAX) {
+        component_limit = NAME_MAX;
+    }
+    peak_report_formatter_sanitized_hostname(hostname);
+    hostname_length = strlen(hostname);
+    if (snprintf(rank_text, sizeof(rank_text), "%ld", world_rank) < 0) {
+        return false;
+    }
+    hash = peak_report_formatter_summary_update(hash, path);
+    hash = peak_report_formatter_summary_update(hash, hostname);
+    hash = peak_report_formatter_summary_update(hash, rank_text);
+    if (snprintf(summary, sizeof(summary), "%016llx",
+                 (unsigned long long)hash) !=
+        PEAK_REPORT_SUMMARY_HEX_LENGTH) {
+        return false;
+    }
+    final_component_length = stem_length + marker_length + hostname_length +
+                             extension_length;
+    if (final_component_length <= component_limit) {
+        memcpy(out, path, directory_length);
+        memcpy(out + directory_length, basename, stem_length);
+        memcpy(out + directory_length + stem_length, marker, marker_length);
+        memcpy(out + directory_length + stem_length + marker_length,
+               hostname,
+               hostname_length);
+        memcpy(out + directory_length + stem_length + marker_length +
+                   hostname_length,
+               extension,
+               extension_length + 1);
+        return true;
+    }
+
+    /* Preserve a bounded preview, but digest all omitted path/host/rank bytes. */
+    final_component_length = marker_length + 2 +
+                             PEAK_REPORT_SUMMARY_HEX_LENGTH + extension_length;
+    if (final_component_length > component_limit) {
+        return false;
+    }
+    hostname_length = hostname_length > PEAK_REPORT_HOST_PREVIEW_LENGTH ?
+                          PEAK_REPORT_HOST_PREVIEW_LENGTH : hostname_length;
+    if (hostname_length > component_limit - final_component_length) {
+        hostname_length = component_limit - final_component_length;
+    }
+    final_component_length += hostname_length;
+    stem_length = stem_length > component_limit - final_component_length ?
+                      component_limit - final_component_length : stem_length;
+    memcpy(out, path, directory_length);
+    memcpy(out + directory_length, basename, stem_length);
+    memcpy(out + directory_length + stem_length, marker, marker_length);
+    memcpy(out + directory_length + stem_length + marker_length,
+           hostname,
+           hostname_length);
+    memcpy(out + directory_length + stem_length + marker_length +
+               hostname_length,
+           "-q",
+           2);
+    memcpy(out + directory_length + stem_length + marker_length +
+               hostname_length + 2,
+           summary,
+           PEAK_REPORT_SUMMARY_HEX_LENGTH);
+    memcpy(out + directory_length + stem_length + marker_length +
+               hostname_length + 2 + PEAK_REPORT_SUMMARY_HEX_LENGTH,
+           extension,
+           extension_length + 1);
+    return true;
+}
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static void
@@ -203,41 +363,9 @@ peak_report_formatter_csv_path(bool rank_local,
         return NULL;
     }
     if (require_host_suffix) {
-        char hostname[256] = {0};
         char suffixed[PATH_MAX];
-        int suffix_length;
-        size_t host_length = 0;
-        size_t path_length = strlen(path);
-        size_t stem_length = path_length;
-
-        if (gethostname(hostname, sizeof(hostname) - 1) != 0 ||
-            hostname[0] == '\0') {
-            (void)snprintf(hostname, sizeof(hostname), "unknown");
-        }
-        for (size_t index = 0; hostname[index] != '\0'; index++) {
-            unsigned char byte = (unsigned char)hostname[index];
-
-            hostname[host_length++] =
-                (byte >= 'a' && byte <= 'z') ||
-                (byte >= 'A' && byte <= 'Z') ||
-                (byte >= '0' && byte <= '9') || byte == '-' ||
-                byte == '_' || byte == '.' ? (char)byte : '_';
-        }
-        hostname[host_length] = '\0';
-        if (host_length == 0) {
-            (void)snprintf(hostname, sizeof(hostname), "unknown");
-        }
-        if (path_length >= 4 && strcmp(path + path_length - 4, ".csv") == 0) {
-            stem_length -= 4;
-        }
-        suffix_length = snprintf(suffixed,
-                                 sizeof(suffixed),
-                                 "%.*s-ranklocal-h%s%s",
-                                 (int)stem_length,
-                                 path,
-                                 hostname,
-                                 path_length == stem_length ? "" : ".csv");
-        if (suffix_length < 0 || suffix_length >= (int)sizeof(suffixed)) {
+        if (!peak_report_formatter_strict_rank_local_path(
+                suffixed, path, world_rank)) {
             return NULL;
         }
         (void)snprintf(path, sizeof(path), "%s", suffixed);
@@ -253,7 +381,13 @@ static int
 peak_report_formatter_create_csv_temp(const char* out_csv,
                                       char** temp_path_out)
 {
+    const char* basename;
+    size_t directory_length;
+    size_t basename_length;
+    size_t normal_component_length;
+    bool compact_name;
     int length;
+    int normal_suffix_length;
     char* temp_path;
 
     if (out_csv == NULL || temp_path_out == NULL) {
@@ -261,12 +395,37 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
         return -1;
     }
     *temp_path_out = NULL;
-    length = snprintf(NULL,
-                      0,
-                      "%s.tmp.p%d.%lu",
-                      out_csv,
-                      (int)getpid(),
-                      ULONG_MAX);
+    basename = strrchr(out_csv, '/');
+    if (basename == NULL) {
+        basename = out_csv;
+        directory_length = 0;
+    } else {
+        directory_length = (size_t)(basename - out_csv) + 1;
+        basename++;
+    }
+    basename_length = strlen(basename);
+    normal_suffix_length =
+        snprintf(NULL, 0, ".tmp.p%d.%lu", (int)getpid(), ULONG_MAX);
+    if (normal_suffix_length < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    normal_component_length = basename_length + (size_t)normal_suffix_length;
+    compact_name = normal_component_length > NAME_MAX;
+    length = compact_name ?
+                 snprintf(NULL,
+                          0,
+                          "%.*s.peak-tmp.p%d.%lu",
+                          (int)directory_length,
+                          out_csv,
+                          (int)getpid(),
+                          ULONG_MAX) :
+                 snprintf(NULL,
+                          0,
+                          "%s.tmp.p%d.%lu",
+                          out_csv,
+                          (int)getpid(),
+                          ULONG_MAX);
     if (length < 0) {
         errno = EINVAL;
         return -1;
@@ -283,12 +442,22 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
             &peak_report_formatter_temp_counter, 1UL, memory_order_relaxed);
         int fd;
 
-        (void)snprintf(temp_path,
-                       (size_t)length + 1,
-                       "%s.tmp.p%d.%lu",
-                       out_csv,
-                       (int)getpid(),
-                       ticket);
+        if (compact_name) {
+            (void)snprintf(temp_path,
+                           (size_t)length + 1,
+                           "%.*s.peak-tmp.p%d.%lu",
+                           (int)directory_length,
+                           out_csv,
+                           (int)getpid(),
+                           ticket);
+        } else {
+            (void)snprintf(temp_path,
+                           (size_t)length + 1,
+                           "%s.tmp.p%d.%lu",
+                           out_csv,
+                           (int)getpid(),
+                           ticket);
+        }
         fd = open(temp_path, O_WRONLY | O_CREAT | O_EXCL, 0666);
         if (fd >= 0) {
             if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -2,6 +2,7 @@
 
 #include "internal/general_listener/report_formatter.h"
 
+#include "internal/general_listener/output_identity.h"
 #include "internal/general_listener/runtime_config.h"
 
 #include "logging.h"
@@ -25,7 +26,6 @@ enum {
     PEAK_TEXT_REPORT_ROW_WIDTH =
         PEAK_TEXT_REPORT_FUNCTION_WIDTH +
         PEAK_TEXT_REPORT_COLUMN_WIDTH * 5 + 7,
-    PEAK_REPORT_HOSTNAME_CAPACITY = 256,
     PEAK_REPORT_TEMP_CREATE_ATTEMPTS = 128,
 };
 
@@ -174,122 +174,40 @@ peak_report_formatter_calls_per_rank(unsigned long calls, int rank_count)
     return (long double)calls / (long double)effective_rank_count;
 }
 
-static void
-peak_report_formatter_sanitized_hostname(
-    char sanitized[PEAK_REPORT_HOSTNAME_CAPACITY])
-{
-    char hostname[PEAK_REPORT_HOSTNAME_CAPACITY] = {0};
-    size_t output_length = 0;
-
-    if (gethostname(hostname, sizeof(hostname) - 1) != 0 ||
-        hostname[0] == '\0') {
-        (void)snprintf(hostname, sizeof(hostname), "unknown");
-    }
-    hostname[sizeof(hostname) - 1] = '\0';
-
-    for (size_t i = 0;
-         hostname[i] != '\0' && output_length + 1 <
-                                      PEAK_REPORT_HOSTNAME_CAPACITY;
-         i++) {
-        const unsigned char byte = (unsigned char)hostname[i];
-
-        if ((byte >= (unsigned char)'a' && byte <= (unsigned char)'z') ||
-            (byte >= (unsigned char)'A' && byte <= (unsigned char)'Z') ||
-            (byte >= (unsigned char)'0' && byte <= (unsigned char)'9') ||
-            byte == (unsigned char)'-' || byte == (unsigned char)'_' ||
-            byte == (unsigned char)'.') {
-            sanitized[output_length++] = (char)byte;
-        } else {
-            sanitized[output_length++] = '_';
-        }
-    }
-    if (output_length == 0) {
-        (void)snprintf(sanitized,
-                       PEAK_REPORT_HOSTNAME_CAPACITY,
-                       "unknown");
-        return;
-    }
-    sanitized[output_length] = '\0';
-}
-
 static char*
 peak_report_formatter_csv_path(bool rank_local,
                                bool require_host_suffix)
 {
     const char* env_path = getenv("PEAK_STATSLOG_PATH");
+    const char* template_value = getenv("PEAK_STATSLOG_TEMPLATE");
     const char* base = env_path != NULL && env_path[0] != '\0' ?
                            env_path : "./peak_statslog";
     long world_size = -1;
     long world_rank = -1;
-    char hostname[PEAK_REPORT_HOSTNAME_CAPACITY] = {0};
-    enum {
-        PEAK_REPORT_SUFFIX_NONE = 0,
-        PEAK_REPORT_SUFFIX_RANK,
-        PEAK_REPORT_SUFFIX_HOSTNAME,
-    } suffix = PEAK_REPORT_SUFFIX_NONE;
-    int length;
-    char* path;
+    char path[PATH_MAX];
 
     if (rank_local) {
         bool have_pair = peak_general_listener_mpi_env_rank_size(
             &world_rank,
             &world_size);
-        if (have_pair && world_size > 1) {
-            suffix = PEAK_REPORT_SUFFIX_RANK;
-        } else if (!have_pair &&
-                   (require_host_suffix ||
-                    peak_general_listener_mpi_env_world_metadata_present())) {
-            peak_report_formatter_sanitized_hostname(hostname);
-            suffix = PEAK_REPORT_SUFFIX_HOSTNAME;
+        if (!have_pair || world_size <= 1) {
+            world_rank = -1;
         }
     }
-
-    if (suffix == PEAK_REPORT_SUFFIX_RANK) {
-        length = snprintf(NULL,
-                          0,
-                          "%s-p%d-r%ld.csv",
-                          base,
-                          (int)getpid(),
-                          world_rank);
-    } else if (suffix == PEAK_REPORT_SUFFIX_HOSTNAME) {
-        length = snprintf(NULL,
-                          0,
-                          "%s-p%d-h%s.csv",
-                          base,
-                          (int)getpid(),
-                          hostname);
-    } else {
-        length = snprintf(NULL, 0, "%s-p%d.csv", base, (int)getpid());
-    }
-    if (length < 0) {
+    (void)require_host_suffix;
+    if (!peak_output_identity_path(path,
+                                   sizeof(path),
+                                   base,
+                                   template_value,
+                                   ".csv",
+                                   world_rank)) {
         return NULL;
     }
-    path = malloc((size_t)length + 1);
-    if (path == NULL) {
+    if (template_value != NULL && template_value[0] != '\0' &&
+        !peak_output_identity_make_parent(path)) {
         return NULL;
     }
-    if (suffix == PEAK_REPORT_SUFFIX_RANK) {
-        (void)snprintf(path,
-                       (size_t)length + 1,
-                       "%s-p%d-r%ld.csv",
-                       base,
-                       (int)getpid(),
-                       world_rank);
-    } else if (suffix == PEAK_REPORT_SUFFIX_HOSTNAME) {
-        (void)snprintf(path,
-                       (size_t)length + 1,
-                       "%s-p%d-h%s.csv",
-                       base,
-                       (int)getpid(),
-                       hostname);
-    } else {
-        (void)snprintf(path,
-                       (size_t)length + 1,
-                       "%s-p%d.csv",
-                       base,
-                       (int)getpid());
-    }
-    return path;
+    return strdup(path);
 }
 
 static int
@@ -668,9 +586,15 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     }
 #endif
     if (success) {
-        if (rename(temp_csv, out_csv) != 0) {
+        bool allow_overwrite = peak_general_listener_env_value_truthy(
+            getenv("PEAK_OUTPUT_ALLOW_OVERWRITE"));
+
+        if ((allow_overwrite ? rename(temp_csv, out_csv) :
+                               link(temp_csv, out_csv)) != 0) {
             success = false;
             failure_errno = errno;
+        } else if (!allow_overwrite) {
+            (void)unlink(temp_csv);
         }
     }
 #ifdef PEAK_ENABLE_TEST_HOOKS

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -289,6 +289,19 @@ peak_report_formatter_test_signal_publication_phase(const char* phase)
     (void)fflush(stderr);
     (void)kill(getpid(), signal_number);
 }
+
+static int
+peak_report_formatter_unlink_published_temp(int dirfd, const char* name)
+{
+    const char* inject =
+        getenv("PEAK_TEST_REPORT_FAIL_POST_PUBLISH_TEMP_UNLINK");
+
+    if (inject != NULL && strcmp(inject, "1") == 0) {
+        errno = EIO;
+        return -1;
+    }
+    return unlinkat(dirfd, name, 0);
+}
 #endif
 
 typedef struct {
@@ -743,6 +756,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     PeakReportCsvDestination destination = {.dirfd = -1};
     FILE* csv;
     bool success;
+    bool final_published = false;
     int csv_fd;
     int failure_errno = 0;
     int rank_count;
@@ -860,8 +874,21 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
                         destination.dirfd, destination.final_name, 0)) != 0) {
             success = false;
             failure_errno = errno;
-        } else if (!allow_overwrite) {
-            (void)unlinkat(destination.dirfd, temp_csv, 0);
+        } else {
+            final_published = true;
+            if (!allow_overwrite) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+                int unlink_result = peak_report_formatter_unlink_published_temp(
+                    destination.dirfd, temp_csv);
+#else
+                int unlink_result = unlinkat(destination.dirfd, temp_csv, 0);
+#endif
+
+                if (unlink_result != 0) {
+                    success = false;
+                    failure_errno = errno;
+                }
+            }
         }
     }
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -871,11 +898,40 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     }
 #endif
     if (!success) {
-        (void)unlinkat(destination.dirfd, temp_csv, 0);
-        peak_log_warn("[peak] failed to publish complete stats csv '%s': %s; "
-                      "any existing completed csv was left unchanged\n",
-                      destination.rendered_path,
-                      strerror(failure_errno != 0 ? failure_errno : EIO));
+        int cleanup_errno = 0;
+
+        if (unlinkat(destination.dirfd, temp_csv, 0) != 0 && errno != ENOENT) {
+            cleanup_errno = errno;
+        }
+        if (final_published) {
+            if (cleanup_errno == 0) {
+                peak_log_warn("[peak] published complete stats csv '%s', but "
+                              "the initial temporary cleanup failed: %s; "
+                              "retry succeeded\n",
+                              destination.rendered_path,
+                              strerror(failure_errno != 0 ? failure_errno : EIO));
+            } else {
+                peak_log_warn("[peak] published complete stats csv '%s', but "
+                              "temporary cleanup failed: initial=%s retry=%s\n",
+                              destination.rendered_path,
+                              strerror(failure_errno != 0 ? failure_errno : EIO),
+                              strerror(cleanup_errno));
+            }
+        } else {
+            if (cleanup_errno == 0) {
+                peak_log_warn("[peak] failed to publish complete stats csv '%s': %s; "
+                              "any existing completed csv was left unchanged\n",
+                              destination.rendered_path,
+                              strerror(failure_errno != 0 ? failure_errno : EIO));
+            } else {
+                peak_log_warn("[peak] failed to publish complete stats csv '%s': %s; "
+                              "any existing completed csv was left unchanged; "
+                              "temporary cleanup also failed: %s\n",
+                              destination.rendered_path,
+                              strerror(failure_errno != 0 ? failure_errno : EIO),
+                              strerror(cleanup_errno));
+            }
+        }
     }
     free(temp_csv);
     peak_report_formatter_csv_destination_destroy(&destination);

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -58,32 +58,11 @@ peak_report_formatter_name_max(int dirfd)
 #endif
     errno = 0;
     limit = fpathconf(dirfd, _PC_NAME_MAX);
+    if (limit < 0 && errno == 0) {
+        /* An indeterminate limit cannot safely bound a generated name. */
+        errno = ENAMETOOLONG;
+    }
     return limit;
-}
-
-static size_t
-peak_report_formatter_path_name_max(const char* path)
-{
-    const char* basename = strrchr(path, '/');
-    char* directory = basename == NULL ? strdup(".") :
-        strndup(path, (size_t)(basename - path) + 1);
-    long limit;
-    int dirfd;
-
-    if (directory == NULL) {
-        return 0;
-    }
-    dirfd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    free(directory);
-    if (dirfd < 0) {
-        return 0;
-    }
-    limit = peak_report_formatter_name_max(dirfd);
-    (void)close(dirfd);
-    if (limit < 0) {
-        return 0;
-    }
-    return (size_t)limit;
 }
 
 static void
@@ -134,18 +113,17 @@ peak_report_formatter_summary_update(uint64_t summary, const char* text)
     return summary * UINT64_C(1099511628211);
 }
 
-static bool
-peak_report_formatter_strict_rank_local_path(char out[PATH_MAX],
-                                             const char* path,
-                                             long world_rank)
+static char*
+peak_report_formatter_strict_rank_local_name(const char* rendered_path,
+                                             long world_rank,
+                                             long name_max)
 {
     static const char marker[] = "-ranklocal-h";
-    const char* basename = strrchr(path, '/');
+    const char* basename;
     const char* extension;
     char hostname[PEAK_REPORT_HOST_CAPACITY] = {0};
     char rank_text[32];
     char summary[PEAK_REPORT_SUMMARY_HEX_LENGTH + 1];
-    size_t directory_length;
     size_t basename_length;
     size_t stem_length;
     size_t extension_length;
@@ -155,63 +133,53 @@ peak_report_formatter_strict_rank_local_path(char out[PATH_MAX],
     size_t final_component_length;
     uint64_t hash = UINT64_C(1469598103934665603);
 
-    if (basename == NULL) {
-        basename = path;
-        directory_length = 0;
-    } else {
-        directory_length = (size_t)(basename - path) + 1;
-        basename++;
-    }
+    char* result;
+
+    basename = strrchr(rendered_path, '/');
+    basename = basename == NULL ? rendered_path : basename + 1;
     basename_length = strlen(basename);
-    if (basename_length == 0 || directory_length >= PATH_MAX) {
-        return false;
+    if (basename_length == 0 || name_max <= 0) {
+        errno = ENAMETOOLONG;
+        return NULL;
     }
     extension = basename_length >= 4 &&
                         strcmp(basename + basename_length - 4, ".csv") == 0 ?
                     ".csv" : "";
     extension_length = strlen(extension);
     stem_length = basename_length - extension_length;
-    component_limit = peak_report_formatter_path_name_max(path);
-    if (component_limit == 0) {
-        return false;
-    }
-    if (component_limit > PATH_MAX - directory_length - 1) {
-        component_limit = PATH_MAX - directory_length - 1;
-    }
+    component_limit = (size_t)name_max;
     peak_report_formatter_sanitized_hostname(hostname);
     hostname_length = strlen(hostname);
     if (snprintf(rank_text, sizeof(rank_text), "%ld", world_rank) < 0) {
-        return false;
+        return NULL;
     }
-    hash = peak_report_formatter_summary_update(hash, path);
+    hash = peak_report_formatter_summary_update(hash, rendered_path);
     hash = peak_report_formatter_summary_update(hash, hostname);
     hash = peak_report_formatter_summary_update(hash, rank_text);
     if (snprintf(summary, sizeof(summary), "%016llx",
                  (unsigned long long)hash) !=
         PEAK_REPORT_SUMMARY_HEX_LENGTH) {
-        return false;
+        return NULL;
     }
     final_component_length = stem_length + marker_length + hostname_length +
                              extension_length;
     if (final_component_length <= component_limit) {
-        memcpy(out, path, directory_length);
-        memcpy(out + directory_length, basename, stem_length);
-        memcpy(out + directory_length + stem_length, marker, marker_length);
-        memcpy(out + directory_length + stem_length + marker_length,
-               hostname,
-               hostname_length);
-        memcpy(out + directory_length + stem_length + marker_length +
-                   hostname_length,
-               extension,
-               extension_length + 1);
-        return true;
+        result = malloc(final_component_length + 1);
+        if (result == NULL) return NULL;
+        memcpy(result, basename, stem_length);
+        memcpy(result + stem_length, marker, marker_length);
+        memcpy(result + stem_length + marker_length, hostname, hostname_length);
+        memcpy(result + stem_length + marker_length + hostname_length,
+               extension, extension_length + 1);
+        return result;
     }
 
     /* Preserve a bounded preview, but digest all omitted path/host/rank bytes. */
     final_component_length = marker_length + 2 +
                              PEAK_REPORT_SUMMARY_HEX_LENGTH + extension_length;
     if (final_component_length > component_limit) {
-        return false;
+        errno = ENAMETOOLONG;
+        return NULL;
     }
     hostname_length = hostname_length > PEAK_REPORT_HOST_PREVIEW_LENGTH ?
                           PEAK_REPORT_HOST_PREVIEW_LENGTH : hostname_length;
@@ -221,25 +189,18 @@ peak_report_formatter_strict_rank_local_path(char out[PATH_MAX],
     final_component_length += hostname_length;
     stem_length = stem_length > component_limit - final_component_length ?
                       component_limit - final_component_length : stem_length;
-    memcpy(out, path, directory_length);
-    memcpy(out + directory_length, basename, stem_length);
-    memcpy(out + directory_length + stem_length, marker, marker_length);
-    memcpy(out + directory_length + stem_length + marker_length,
-           hostname,
-           hostname_length);
-    memcpy(out + directory_length + stem_length + marker_length +
-               hostname_length,
-           "-q",
-           2);
-    memcpy(out + directory_length + stem_length + marker_length +
-               hostname_length + 2,
-           summary,
-           PEAK_REPORT_SUMMARY_HEX_LENGTH);
-    memcpy(out + directory_length + stem_length + marker_length +
-               hostname_length + 2 + PEAK_REPORT_SUMMARY_HEX_LENGTH,
-           extension,
-           extension_length + 1);
-    return true;
+    result = malloc(stem_length + marker_length + hostname_length + 2 +
+                    PEAK_REPORT_SUMMARY_HEX_LENGTH + extension_length + 1);
+    if (result == NULL) return NULL;
+    memcpy(result, basename, stem_length);
+    memcpy(result + stem_length, marker, marker_length);
+    memcpy(result + stem_length + marker_length, hostname, hostname_length);
+    memcpy(result + stem_length + marker_length + hostname_length, "-q", 2);
+    memcpy(result + stem_length + marker_length + hostname_length + 2,
+           summary, PEAK_REPORT_SUMMARY_HEX_LENGTH);
+    memcpy(result + stem_length + marker_length + hostname_length + 2 +
+               PEAK_REPORT_SUMMARY_HEX_LENGTH, extension, extension_length + 1);
+    return result;
 }
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -385,9 +346,28 @@ peak_report_formatter_calls_per_rank(unsigned long calls, int rank_count)
     return (long double)calls / (long double)effective_rank_count;
 }
 
-static char*
-peak_report_formatter_csv_path(bool rank_local,
-                               bool require_host_suffix)
+typedef struct {
+    int dirfd;
+    long name_max;
+    char* final_name;
+    char* rendered_path;
+} PeakReportCsvDestination;
+
+static void
+peak_report_formatter_csv_destination_destroy(PeakReportCsvDestination* destination)
+{
+    if (destination->dirfd >= 0) {
+        (void)close(destination->dirfd);
+    }
+    free(destination->final_name);
+    free(destination->rendered_path);
+    *destination = (PeakReportCsvDestination){.dirfd = -1};
+}
+
+static bool
+peak_report_formatter_csv_destination(bool rank_local,
+                                      bool require_host_suffix,
+                                      PeakReportCsvDestination* destination)
 {
     const char* env_path = getenv("PEAK_STATSLOG_PATH");
     const char* template_value = getenv("PEAK_STATSLOG_TEMPLATE");
@@ -396,7 +376,14 @@ peak_report_formatter_csv_path(bool rank_local,
     long world_size = -1;
     long world_rank = -1;
     char path[PATH_MAX];
+    const char* basename;
+    char* directory;
 
+    if (destination == NULL) {
+        errno = EINVAL;
+        return false;
+    }
+    *destination = (PeakReportCsvDestination){.dirfd = -1};
     if (rank_local) {
         bool have_pair = peak_general_listener_mpi_env_rank_size(
             &world_rank,
@@ -411,32 +398,64 @@ peak_report_formatter_csv_path(bool rank_local,
                                    template_value,
                                    ".csv",
                                    world_rank)) {
-        return NULL;
-    }
-    if (require_host_suffix) {
-        char suffixed[PATH_MAX];
-        if (!peak_report_formatter_strict_rank_local_path(
-                suffixed, path, world_rank)) {
-            return NULL;
-        }
-        (void)snprintf(path, sizeof(path), "%s", suffixed);
+        errno = EINVAL;
+        return false;
     }
     if (template_value != NULL && template_value[0] != '\0' &&
         !peak_output_identity_make_parent(path)) {
-        return NULL;
+        if (errno == 0) errno = EINVAL;
+        return false;
     }
-    return strdup(path);
+    basename = strrchr(path, '/');
+    directory = basename == NULL ? strdup(".") :
+        strndup(path, (size_t)(basename - path) + 1);
+    if (directory == NULL) {
+        return false;
+    }
+    destination->dirfd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    free(directory);
+    if (destination->dirfd < 0) {
+        return false;
+    }
+    destination->name_max = peak_report_formatter_name_max(destination->dirfd);
+    if (destination->name_max <= 0) {
+        int saved_errno = errno != 0 ? errno : ENAMETOOLONG;
+        peak_report_formatter_csv_destination_destroy(destination);
+        errno = saved_errno;
+        return false;
+    }
+    basename = basename == NULL ? path : basename + 1;
+    if (strlen(basename) == 0 || strlen(basename) > (size_t)destination->name_max) {
+        errno = ENAMETOOLONG;
+        peak_report_formatter_csv_destination_destroy(destination);
+        errno = ENAMETOOLONG;
+        return false;
+    }
+    destination->final_name = require_host_suffix ?
+        peak_report_formatter_strict_rank_local_name(path,
+                                                     world_rank,
+                                                     destination->name_max) :
+        strdup(basename);
+    if (destination->final_name == NULL) {
+        int saved_errno = errno;
+        peak_report_formatter_csv_destination_destroy(destination);
+        errno = saved_errno;
+        return false;
+    }
+    destination->rendered_path = strdup(path);
+    if (destination->rendered_path == NULL) {
+        int saved_errno = errno;
+        peak_report_formatter_csv_destination_destroy(destination);
+        errno = saved_errno;
+        return false;
+    }
+    return true;
 }
 
 static int
-peak_report_formatter_create_csv_temp(const char* out_csv,
-                                      int* dirfd_out,
-                                      char** final_name_out,
+peak_report_formatter_create_csv_temp(const PeakReportCsvDestination* destination,
                                       char** temp_name_out)
 {
-    const char* basename;
-    char* directory;
-    char* final_name;
     char* temp_name;
     size_t basename_length;
     long name_max;
@@ -444,42 +463,17 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
     int length;
     int normal_suffix_length;
 
-    if (out_csv == NULL || dirfd_out == NULL || final_name_out == NULL ||
-        temp_name_out == NULL) {
+    if (destination == NULL || destination->dirfd < 0 ||
+        destination->final_name == NULL || temp_name_out == NULL) {
         errno = EINVAL;
         return -1;
     }
-    *dirfd_out = -1;
-    *final_name_out = NULL;
     *temp_name_out = NULL;
-    basename = strrchr(out_csv, '/');
-    if (basename == NULL) {
-        basename = out_csv;
-        directory = strdup(".");
-    } else {
-        directory = strndup(out_csv, (size_t)(basename - out_csv) + 1);
-        basename++;
-    }
-    if (directory == NULL) {
-        return -1;
-    }
-    int dirfd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    free(directory);
-    if (dirfd < 0) {
-        return -1;
-    }
-    name_max = peak_report_formatter_name_max(dirfd);
-    if (name_max < 0) {
-        int saved_errno = errno;
-        (void)close(dirfd);
-        errno = saved_errno != 0 ? saved_errno : ENAMETOOLONG;
-        return -1;
-    }
-    basename_length = strlen(basename);
+    name_max = destination->name_max;
+    basename_length = strlen(destination->final_name);
     normal_suffix_length =
         snprintf(NULL, 0, ".tmp.p%d.%lu", (int)getpid(), ULONG_MAX);
     if (normal_suffix_length < 0) {
-        (void)close(dirfd);
         errno = EINVAL;
         return -1;
     }
@@ -494,20 +488,15 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
                  snprintf(NULL,
                           0,
                           "%s.tmp.p%d.%lu",
-                          basename,
+                          destination->final_name,
                           (int)getpid(),
                           ULONG_MAX);
     if (length < 0 || length > name_max) {
-        (void)close(dirfd);
         errno = EINVAL;
         return -1;
     }
-    final_name = strdup(basename);
     temp_name = malloc((size_t)length + 1);
-    if (final_name == NULL || temp_name == NULL) {
-        free(final_name);
-        free(temp_name);
-        (void)close(dirfd);
+    if (temp_name == NULL) {
         return -1;
     }
 
@@ -528,29 +517,24 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
             (void)snprintf(temp_name,
                            (size_t)length + 1,
                            "%s.tmp.p%d.%lu",
-                           basename,
+                           destination->final_name,
                            (int)getpid(),
                            ticket);
         }
-        fd = openat(dirfd, temp_name, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+        fd = openat(destination->dirfd, temp_name,
+                    O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
                     0666);
         if (fd >= 0) {
-            *dirfd_out = dirfd;
-            *final_name_out = final_name;
             *temp_name_out = temp_name;
             return fd;
         }
         if (errno != EEXIST) {
-            free(final_name);
             free(temp_name);
-            (void)close(dirfd);
             return -1;
         }
     }
 
-    free(final_name);
     free(temp_name);
-    (void)close(dirfd);
     errno = EEXIST;
     return -1;
 }
@@ -755,13 +739,11 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         "count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
         "dropped_calls,dropped_threads\n";
-    char* out_csv;
     char* temp_csv;
-    char* final_name;
+    PeakReportCsvDestination destination = {.dirfd = -1};
     FILE* csv;
     bool success;
     int csv_fd;
-    int dirfd;
     int failure_errno = 0;
     int rank_count;
 
@@ -784,36 +766,31 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     }
 #endif
 
-    out_csv = peak_report_formatter_csv_path(
-        rank_local,
-        require_host_suffix);
-    if (out_csv == NULL) {
-        peak_log_warn("[peak] failed to allocate stats csv path\n");
+    if (!peak_report_formatter_csv_destination(rank_local,
+                                               require_host_suffix,
+                                               &destination)) {
+        peak_log_warn("[peak] failed to prepare stats csv destination: %s\n",
+                      strerror(errno));
         return false;
     }
-    csv_fd = peak_report_formatter_create_csv_temp(out_csv,
-                                                    &dirfd,
-                                                    &final_name,
-                                                    &temp_csv);
+    csv_fd = peak_report_formatter_create_csv_temp(&destination, &temp_csv);
     if (csv_fd < 0) {
         peak_log_warn("[peak] failed to create temporary stats csv for '%s': %s\n",
-                      out_csv,
+                      destination.rendered_path,
                       strerror(errno));
-        free(out_csv);
+        peak_report_formatter_csv_destination_destroy(&destination);
         return false;
     }
     csv = fdopen(csv_fd, "w");
     if (csv == NULL) {
         failure_errno = errno;
         (void)close(csv_fd);
-        (void)unlinkat(dirfd, temp_csv, 0);
-        (void)close(dirfd);
+        (void)unlinkat(destination.dirfd, temp_csv, 0);
         peak_log_warn("[peak] failed to open temporary stats csv for '%s': %s\n",
-                      out_csv,
+                      destination.rendered_path,
                       strerror(failure_errno));
         free(temp_csv);
-        free(final_name);
-        free(out_csv);
+        peak_report_formatter_csv_destination_destroy(&destination);
         return false;
     }
 
@@ -876,12 +853,15 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         bool allow_overwrite = peak_general_listener_env_value_truthy(
             getenv("PEAK_OUTPUT_ALLOW_OVERWRITE"));
 
-        if ((allow_overwrite ? renameat(dirfd, temp_csv, dirfd, final_name) :
-                               linkat(dirfd, temp_csv, dirfd, final_name, 0)) != 0) {
+        if ((allow_overwrite ?
+                 renameat(destination.dirfd, temp_csv,
+                          destination.dirfd, destination.final_name) :
+                 linkat(destination.dirfd, temp_csv,
+                        destination.dirfd, destination.final_name, 0)) != 0) {
             success = false;
             failure_errno = errno;
         } else if (!allow_overwrite) {
-            (void)unlinkat(dirfd, temp_csv, 0);
+            (void)unlinkat(destination.dirfd, temp_csv, 0);
         }
     }
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -891,16 +871,14 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     }
 #endif
     if (!success) {
-        (void)unlinkat(dirfd, temp_csv, 0);
+        (void)unlinkat(destination.dirfd, temp_csv, 0);
         peak_log_warn("[peak] failed to publish complete stats csv '%s': %s; "
                       "any existing completed csv was left unchanged\n",
-                      out_csv,
+                      destination.rendered_path,
                       strerror(failure_errno != 0 ? failure_errno : EIO));
     }
     free(temp_csv);
-    free(final_name);
-    (void)close(dirfd);
-    free(out_csv);
+    peak_report_formatter_csv_destination_destroy(&destination);
     return success;
 }
 

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -38,6 +38,54 @@ enum {
 
 static _Atomic unsigned long peak_report_formatter_temp_counter;
 
+static long
+peak_report_formatter_name_max(int dirfd)
+{
+    long limit;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    const char* override = getenv("PEAK_TEST_REPORT_NAME_MAX");
+    char* end = NULL;
+
+    if (override != NULL && override[0] != '\0') {
+        errno = 0;
+        limit = strtol(override, &end, 10);
+        if (errno != 0 || end == override || *end != '\0' || limit <= 0) {
+            return -1;
+        }
+        return limit;
+    }
+#endif
+    errno = 0;
+    limit = fpathconf(dirfd, _PC_NAME_MAX);
+    return limit;
+}
+
+static size_t
+peak_report_formatter_path_name_max(const char* path)
+{
+    const char* basename = strrchr(path, '/');
+    char* directory = basename == NULL ? strdup(".") :
+        strndup(path, (size_t)(basename - path) + 1);
+    long limit;
+    int dirfd;
+
+    if (directory == NULL) {
+        return 0;
+    }
+    dirfd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    free(directory);
+    if (dirfd < 0) {
+        return 0;
+    }
+    limit = peak_report_formatter_name_max(dirfd);
+    (void)close(dirfd);
+    if (limit < 0) {
+        return 0;
+    }
+    return (size_t)limit;
+}
+
 static void
 peak_report_formatter_sanitized_hostname(
     char hostname[PEAK_REPORT_HOST_CAPACITY])
@@ -123,9 +171,12 @@ peak_report_formatter_strict_rank_local_path(char out[PATH_MAX],
                     ".csv" : "";
     extension_length = strlen(extension);
     stem_length = basename_length - extension_length;
-    component_limit = PATH_MAX - directory_length - 1;
-    if (component_limit > NAME_MAX) {
-        component_limit = NAME_MAX;
+    component_limit = peak_report_formatter_path_name_max(path);
+    if (component_limit == 0) {
+        return false;
+    }
+    if (component_limit > PATH_MAX - directory_length - 1) {
+        component_limit = PATH_MAX - directory_length - 1;
     }
     peak_report_formatter_sanitized_hostname(hostname);
     hostname_length = strlen(hostname);
@@ -379,59 +430,84 @@ peak_report_formatter_csv_path(bool rank_local,
 
 static int
 peak_report_formatter_create_csv_temp(const char* out_csv,
-                                      char** temp_path_out)
+                                      int* dirfd_out,
+                                      char** final_name_out,
+                                      char** temp_name_out)
 {
     const char* basename;
-    size_t directory_length;
+    char* directory;
+    char* final_name;
+    char* temp_name;
     size_t basename_length;
-    size_t normal_component_length;
+    long name_max;
     bool compact_name;
     int length;
     int normal_suffix_length;
-    char* temp_path;
 
-    if (out_csv == NULL || temp_path_out == NULL) {
+    if (out_csv == NULL || dirfd_out == NULL || final_name_out == NULL ||
+        temp_name_out == NULL) {
         errno = EINVAL;
         return -1;
     }
-    *temp_path_out = NULL;
+    *dirfd_out = -1;
+    *final_name_out = NULL;
+    *temp_name_out = NULL;
     basename = strrchr(out_csv, '/');
     if (basename == NULL) {
         basename = out_csv;
-        directory_length = 0;
+        directory = strdup(".");
     } else {
-        directory_length = (size_t)(basename - out_csv) + 1;
+        directory = strndup(out_csv, (size_t)(basename - out_csv) + 1);
         basename++;
+    }
+    if (directory == NULL) {
+        return -1;
+    }
+    int dirfd = open(directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    free(directory);
+    if (dirfd < 0) {
+        return -1;
+    }
+    name_max = peak_report_formatter_name_max(dirfd);
+    if (name_max < 0) {
+        int saved_errno = errno;
+        (void)close(dirfd);
+        errno = saved_errno != 0 ? saved_errno : ENAMETOOLONG;
+        return -1;
     }
     basename_length = strlen(basename);
     normal_suffix_length =
         snprintf(NULL, 0, ".tmp.p%d.%lu", (int)getpid(), ULONG_MAX);
     if (normal_suffix_length < 0) {
+        (void)close(dirfd);
         errno = EINVAL;
         return -1;
     }
-    normal_component_length = basename_length + (size_t)normal_suffix_length;
-    compact_name = normal_component_length > NAME_MAX;
+    compact_name = basename_length + (size_t)normal_suffix_length >
+                   (size_t)name_max;
     length = compact_name ?
                  snprintf(NULL,
                           0,
-                          "%.*s.peak-tmp.p%d.%lu",
-                          (int)directory_length,
-                          out_csv,
+                          ".peak-tmp.p%d.%lu",
                           (int)getpid(),
                           ULONG_MAX) :
                  snprintf(NULL,
                           0,
                           "%s.tmp.p%d.%lu",
-                          out_csv,
+                          basename,
                           (int)getpid(),
                           ULONG_MAX);
-    if (length < 0) {
+    if (length < 0 || length > name_max) {
+        (void)close(dirfd);
         errno = EINVAL;
         return -1;
     }
-    temp_path = malloc((size_t)length + 1);
-    if (temp_path == NULL) {
+    final_name = strdup(basename);
+    temp_name = malloc((size_t)length + 1);
+    if (final_name == NULL || temp_name == NULL) {
+        free(final_name);
+        free(temp_name);
+        (void)close(dirfd);
         return -1;
     }
 
@@ -443,42 +519,38 @@ peak_report_formatter_create_csv_temp(const char* out_csv,
         int fd;
 
         if (compact_name) {
-            (void)snprintf(temp_path,
+            (void)snprintf(temp_name,
                            (size_t)length + 1,
-                           "%.*s.peak-tmp.p%d.%lu",
-                           (int)directory_length,
-                           out_csv,
+                           ".peak-tmp.p%d.%lu",
                            (int)getpid(),
                            ticket);
         } else {
-            (void)snprintf(temp_path,
+            (void)snprintf(temp_name,
                            (size_t)length + 1,
                            "%s.tmp.p%d.%lu",
-                           out_csv,
+                           basename,
                            (int)getpid(),
                            ticket);
         }
-        fd = open(temp_path, O_WRONLY | O_CREAT | O_EXCL, 0666);
+        fd = openat(dirfd, temp_name, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC,
+                    0666);
         if (fd >= 0) {
-            if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) {
-                int saved_errno = errno;
-
-                (void)close(fd);
-                (void)unlink(temp_path);
-                free(temp_path);
-                errno = saved_errno;
-                return -1;
-            }
-            *temp_path_out = temp_path;
+            *dirfd_out = dirfd;
+            *final_name_out = final_name;
+            *temp_name_out = temp_name;
             return fd;
         }
         if (errno != EEXIST) {
-            free(temp_path);
+            free(final_name);
+            free(temp_name);
+            (void)close(dirfd);
             return -1;
         }
     }
 
-    free(temp_path);
+    free(final_name);
+    free(temp_name);
+    (void)close(dirfd);
     errno = EEXIST;
     return -1;
 }
@@ -685,9 +757,11 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         "dropped_calls,dropped_threads\n";
     char* out_csv;
     char* temp_csv;
+    char* final_name;
     FILE* csv;
     bool success;
     int csv_fd;
+    int dirfd;
     int failure_errno = 0;
     int rank_count;
 
@@ -717,7 +791,10 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         peak_log_warn("[peak] failed to allocate stats csv path\n");
         return false;
     }
-    csv_fd = peak_report_formatter_create_csv_temp(out_csv, &temp_csv);
+    csv_fd = peak_report_formatter_create_csv_temp(out_csv,
+                                                    &dirfd,
+                                                    &final_name,
+                                                    &temp_csv);
     if (csv_fd < 0) {
         peak_log_warn("[peak] failed to create temporary stats csv for '%s': %s\n",
                       out_csv,
@@ -729,11 +806,13 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     if (csv == NULL) {
         failure_errno = errno;
         (void)close(csv_fd);
-        (void)unlink(temp_csv);
+        (void)unlinkat(dirfd, temp_csv, 0);
+        (void)close(dirfd);
         peak_log_warn("[peak] failed to open temporary stats csv for '%s': %s\n",
                       out_csv,
                       strerror(failure_errno));
         free(temp_csv);
+        free(final_name);
         free(out_csv);
         return false;
     }
@@ -797,12 +876,12 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         bool allow_overwrite = peak_general_listener_env_value_truthy(
             getenv("PEAK_OUTPUT_ALLOW_OVERWRITE"));
 
-        if ((allow_overwrite ? rename(temp_csv, out_csv) :
-                               link(temp_csv, out_csv)) != 0) {
+        if ((allow_overwrite ? renameat(dirfd, temp_csv, dirfd, final_name) :
+                               linkat(dirfd, temp_csv, dirfd, final_name, 0)) != 0) {
             success = false;
             failure_errno = errno;
         } else if (!allow_overwrite) {
-            (void)unlink(temp_csv);
+            (void)unlinkat(dirfd, temp_csv, 0);
         }
     }
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -812,13 +891,15 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
     }
 #endif
     if (!success) {
-        (void)unlink(temp_csv);
+        (void)unlinkat(dirfd, temp_csv, 0);
         peak_log_warn("[peak] failed to publish complete stats csv '%s': %s; "
                       "any existing completed csv was left unchanged\n",
                       out_csv,
                       strerror(failure_errno != 0 ? failure_errno : EIO));
     }
     free(temp_csv);
+    free(final_name);
+    (void)close(dirfd);
     free(out_csv);
     return success;
 }

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -194,7 +194,6 @@ peak_report_formatter_csv_path(bool rank_local,
             world_rank = -1;
         }
     }
-    (void)require_host_suffix;
     if (!peak_output_identity_path(path,
                                    sizeof(path),
                                    base,
@@ -202,6 +201,46 @@ peak_report_formatter_csv_path(bool rank_local,
                                    ".csv",
                                    world_rank)) {
         return NULL;
+    }
+    if (require_host_suffix) {
+        char hostname[256] = {0};
+        char suffixed[PATH_MAX];
+        int suffix_length;
+        size_t host_length = 0;
+        size_t path_length = strlen(path);
+        size_t stem_length = path_length;
+
+        if (gethostname(hostname, sizeof(hostname) - 1) != 0 ||
+            hostname[0] == '\0') {
+            (void)snprintf(hostname, sizeof(hostname), "unknown");
+        }
+        for (size_t index = 0; hostname[index] != '\0'; index++) {
+            unsigned char byte = (unsigned char)hostname[index];
+
+            hostname[host_length++] =
+                (byte >= 'a' && byte <= 'z') ||
+                (byte >= 'A' && byte <= 'Z') ||
+                (byte >= '0' && byte <= '9') || byte == '-' ||
+                byte == '_' || byte == '.' ? (char)byte : '_';
+        }
+        hostname[host_length] = '\0';
+        if (host_length == 0) {
+            (void)snprintf(hostname, sizeof(hostname), "unknown");
+        }
+        if (path_length >= 4 && strcmp(path + path_length - 4, ".csv") == 0) {
+            stem_length -= 4;
+        }
+        suffix_length = snprintf(suffixed,
+                                 sizeof(suffixed),
+                                 "%.*s-ranklocal-h%s%s",
+                                 (int)stem_length,
+                                 path,
+                                 hostname,
+                                 path_length == stem_length ? "" : ".csv");
+        if (suffix_length < 0 || suffix_length >= (int)sizeof(suffixed)) {
+            return NULL;
+        }
+        (void)snprintf(path, sizeof(path), "%s", suffixed);
     }
     if (template_value != NULL && template_value[0] != '\0' &&
         !peak_output_identity_make_parent(path)) {

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <float.h>
 #include <fcntl.h>
+#include <arpa/inet.h>
 #include <limits.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -19,6 +20,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#ifdef __linux__
+#include <sys/random.h>
+#endif
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -32,6 +36,10 @@
 #define PEAK_OUTPUT_AGGREGATION_HOST_ENV "PEAK_OUTPUT_AGGREGATION_HOST"
 #define PEAK_OUTPUT_AGGREGATION_PORT_ENV "PEAK_OUTPUT_AGGREGATION_PORT"
 #define PEAK_OUTPUT_AGGREGATION_TOKEN_ENV "PEAK_OUTPUT_AGGREGATION_TOKEN"
+#define PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS_ENV \
+    "PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS"
+#define PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND_ENV \
+    "PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND"
 #define PEAK_TEST_OUTPUT_AGGREGATION_RELEASE_FAIL_ENV \
     "PEAK_TEST_OUTPUT_AGGREGATION_RELEASE_FAIL"
 #define PEAK_TEST_OUTPUT_AGGREGATION_RELEASE_DROP_ONCE_ENV \
@@ -70,7 +78,7 @@
     "PEAK_TEST_OUTPUT_AGGREGATION_SESSION_ALLOC_FAIL"
 
 #define PEAK_SOCKET_REDUCE_MAGIC 0x5045414b52454431ULL
-#define PEAK_SOCKET_REDUCE_VERSION 12U
+#define PEAK_SOCKET_REDUCE_VERSION 13U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT 0x41U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT_CONFIRM 0x42U
 #define PEAK_SOCKET_REDUCE_GATHER_REGISTERED 0x01U
@@ -147,19 +155,19 @@ typedef struct {
 } PeakSocketReduceRecord;
 
 /*
- * Wire-v12 intentionally targets a homogeneous job: every rank must use the
+ * Wire-v13 intentionally targets a homogeneous job: every rank must use the
  * same byte order, floating-point representation, and 64-bit Linux C ABI.
  * Lock the layouts so an accidental field or packing change cannot silently
  * corrupt a report without another wire-version bump.
  */
 _Static_assert(sizeof(PeakSocketReduceHeader) == 168,
-               "wire-v12 header layout changed");
+               "wire-v13 header layout changed");
 _Static_assert(sizeof(PeakSocketReduceReleaseFrame) == 40,
-               "wire-v12 control-frame layout changed");
+               "wire-v13 control-frame layout changed");
 _Static_assert(sizeof(PeakSocketReduceRecord) == 80,
-               "wire-v12 record layout changed");
+               "wire-v13 record layout changed");
 _Static_assert(sizeof(unsigned long) == sizeof(uint64_t),
-               "wire-v12 requires a 64-bit unsigned long");
+               "wire-v13 requires a 64-bit unsigned long");
 
 struct PeakSocketReportSession {
     bool* release_targets;
@@ -388,6 +396,50 @@ peak_socket_reduce_session_token(void)
         return hash;
     }
     return peak_socket_reduce_launcher_token();
+}
+
+static bool
+peak_socket_reduce_session_nonce(uint64_t* nonce_out)
+{
+    unsigned char* cursor = (unsigned char*)nonce_out;
+    size_t remaining = sizeof(*nonce_out);
+
+    if (nonce_out == NULL) {
+        return false;
+    }
+#ifdef __linux__
+    while (remaining != 0) {
+        ssize_t read_bytes;
+        do {
+            read_bytes = getrandom(cursor, remaining, GRND_NONBLOCK);
+        } while (read_bytes < 0 && errno == EINTR);
+        if (read_bytes <= 0) {
+            break;
+        }
+        cursor += read_bytes;
+        remaining -= (size_t)read_bytes;
+    }
+#endif
+    if (remaining != 0) {
+        int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+        if (fd < 0) {
+            return false;
+        }
+        while (remaining != 0) {
+            ssize_t read_bytes;
+            do {
+                read_bytes = read(fd, cursor, remaining);
+            } while (read_bytes < 0 && errno == EINTR);
+            if (read_bytes <= 0) {
+                close(fd);
+                return false;
+            }
+            cursor += read_bytes;
+            remaining -= (size_t)read_bytes;
+        }
+        close(fd);
+    }
+    return true;
 }
 
 static void
@@ -1282,6 +1334,8 @@ peak_socket_reduce_bind_listener(int port)
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     int one = 1;
     struct sockaddr_in address;
+    const char* bind_override;
+    char root_host[256];
 
     if (fd < 0) {
         return -1;
@@ -1290,7 +1344,69 @@ peak_socket_reduce_bind_listener(int port)
     (void)setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
     memset(&address, 0, sizeof(address));
     address.sin_family = AF_INET;
-    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    bind_override = getenv(PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS_ENV);
+    if (peak_general_listener_env_value_truthy(
+            getenv(PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND_ENV))) {
+        address.sin_addr.s_addr = htonl(INADDR_ANY);
+    } else if (bind_override != NULL && bind_override[0] != '\0') {
+        if (inet_pton(AF_INET, bind_override, &address.sin_addr) != 1 ||
+            address.sin_addr.s_addr == htonl(INADDR_ANY)) {
+            close(fd);
+            errno = EINVAL;
+            return -1;
+        }
+    } else {
+        struct addrinfo hints = {0};
+        struct addrinfo* result = NULL;
+        struct addrinfo* candidate;
+        int status;
+        int bind_errno = EADDRNOTAVAIL;
+        bool bound = false;
+
+        if (!peak_socket_reduce_root_host(root_host, sizeof(root_host))) {
+            close(fd);
+            errno = EADDRNOTAVAIL;
+            return -1;
+        }
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        status = getaddrinfo(root_host, NULL, &hints, &result);
+        if (status != 0 || result == NULL) {
+            if (result != NULL) {
+                freeaddrinfo(result);
+            }
+            close(fd);
+            errno = EADDRNOTAVAIL;
+            return -1;
+        }
+        for (candidate = result; candidate != NULL;
+             candidate = candidate->ai_next) {
+            const struct sockaddr_in* candidate_address;
+
+            if (candidate->ai_family != AF_INET ||
+                candidate->ai_addrlen != sizeof(*candidate_address)) {
+                continue;
+            }
+            candidate_address = (const struct sockaddr_in*)candidate->ai_addr;
+            if (candidate_address->sin_addr.s_addr == htonl(INADDR_ANY)) {
+                continue;
+            }
+            address.sin_addr = candidate_address->sin_addr;
+            address.sin_port = htons((uint16_t)port);
+            if (bind(fd, (struct sockaddr*)&address, sizeof(address)) == 0) {
+                bound = true;
+                break;
+            }
+            bind_errno = errno;
+        }
+        freeaddrinfo(result);
+        if (!bound) {
+            close(fd);
+            errno = bind_errno;
+            return -1;
+        }
+        return fd;
+    }
     address.sin_port = htons((uint16_t)port);
 
     if (bind(fd, (struct sockaddr*)&address, sizeof(address)) != 0) {
@@ -1302,6 +1418,14 @@ peak_socket_reduce_bind_listener(int port)
     }
     return fd;
 }
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+int
+peak_socket_report_test_bind_listener(int port)
+{
+    return peak_socket_reduce_bind_listener(port);
+}
+#endif
 
 static bool
 peak_socket_reduce_activate_listener(int fd, int expected_connections)
@@ -2163,6 +2287,7 @@ typedef struct {
     size_t record_bytes;
     int size;
     uint64_t session_token;
+    uint64_t receipt_session_token;
     bool* claimed_ranks;
     bool* release_targets;
     double* profile_seconds;
@@ -2245,8 +2370,11 @@ peak_socket_gather_prepare_receipt(
     connection->receipt.version = PEAK_SOCKET_REDUCE_VERSION;
     connection->receipt.rank = connection->header.rank;
     connection->receipt.hook_count = connection->header.hook_count;
-    connection->receipt.session_token =
-        connection->header.session_token;
+    connection->receipt.session_token = aggregate->receipt_session_token;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_socket_test_telemetry.root_receipt_session_nonce =
+        connection->receipt.session_token;
+#endif
     connection->receipt.type = PEAK_SOCKET_REDUCE_GATHER_RECEIPT;
     connection->receipt.decision =
         PEAK_SOCKET_REDUCE_GATHER_REGISTERED;
@@ -2445,7 +2573,7 @@ peak_socket_gather_read_ready(PeakSocketGatherConnection* connection,
                     confirmation->hook_count !=
                         connection->header.hook_count ||
                     confirmation->session_token !=
-                        connection->header.session_token ||
+                        connection->receipt.session_token ||
                     confirmation->type !=
                         PEAK_SOCKET_REDUCE_GATHER_RECEIPT_CONFIRM ||
                     confirmation->decision !=
@@ -3056,7 +3184,6 @@ peak_socket_report_peer_begin(const PeakReportSnapshot* local,
         receipt.version == header->version &&
         receipt.rank == header->rank &&
         receipt.hook_count == header->hook_count &&
-        receipt.session_token == header->session_token &&
         receipt.type == PEAK_SOCKET_REDUCE_GATHER_RECEIPT &&
         receipt.decision ==
             PEAK_SOCKET_REDUCE_GATHER_REGISTERED;
@@ -3087,10 +3214,14 @@ peak_socket_report_peer_begin(const PeakReportSnapshot* local,
                       rank);
     }
 
+    {
+    PeakSocketReduceHeader release_header = *header;
+    release_header.session_token = receipt.session_token;
     release = peak_socket_reduce_wait_for_release(root_addresses,
                                                   release_port,
-                                                  header,
+                                                  &release_header,
                                                   release_wait_timeout_ms);
+    }
     freeaddrinfo(root_addresses);
     if (release == PEAK_SOCKET_RELEASE_FALLBACK) {
         peak_log_info("[peak] Socket aggregation root requested rank-local fallback for rank %d\n",
@@ -3125,6 +3256,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     int startup_grace_ms;
 #endif
     uint64_t session_token;
+    uint64_t session_nonce = 0;
     PeakSocketReduceRecord* local_records = NULL;
     PeakSocketReduceHeader header;
     PeakReportRankTuple local_report_tuple;
@@ -3170,6 +3302,20 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
                       rank,
                       size);
         return PEAK_SOCKET_REPORT_FAILED;
+    }
+    if (rank == 0) {
+        unsigned int attempts = 0;
+
+        do {
+            if (!peak_socket_reduce_session_nonce(&session_nonce)) {
+                peak_log_warn("[peak] Socket aggregation could not create a session nonce; skipping aggregate output\n");
+                return PEAK_SOCKET_REPORT_FAILED;
+            }
+        } while (session_nonce == 0 && ++attempts < 3);
+        if (session_nonce == 0) {
+            peak_log_warn("[peak] Socket aggregation received an invalid session nonce; skipping aggregate output\n");
+            return PEAK_SOCKET_REPORT_FAILED;
+        }
     }
     timeout_budget =
         peak_general_listener_report_timeout_budget_for_rank_count(
@@ -3334,6 +3480,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     gather_aggregate.record_bytes = record_bytes;
     gather_aggregate.size = size;
     gather_aggregate.session_token = session_token;
+    gather_aggregate.receipt_session_token = session_nonce;
     gather_aggregate.claimed_ranks = claimed_ranks;
     gather_aggregate.release_targets = release_targets;
     gather_aggregate.profile_seconds = &socket_profile_seconds;
@@ -3396,7 +3543,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
             release_targets,
             size,
             (uint64_t)local->hook_count,
-            session_token,
+            session_nonce,
             timeout_ms,
             PEAK_SOCKET_REDUCE_RELEASE_FALLBACK);
         free(release_targets);
@@ -3413,7 +3560,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
             release_targets,
             size,
             (uint64_t)local->hook_count,
-            session_token,
+            session_nonce,
             timeout_ms,
             PEAK_SOCKET_REDUCE_RELEASE_FALLBACK);
         free(release_targets);
@@ -3440,7 +3587,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
         release_listener,
         timeout_ms,
         (uint64_t)local->hook_count,
-        session_token);
+        session_nonce);
     if (session == NULL) {
         peak_report_snapshot_destroy(aggregate);
         (void)peak_socket_reduce_release_peers(
@@ -3448,7 +3595,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
             release_targets,
             size,
             (uint64_t)local->hook_count,
-            session_token,
+            session_nonce,
             timeout_ms,
             PEAK_SOCKET_REDUCE_RELEASE_FALLBACK);
         free(release_targets);

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-#ifdef __linux__
+#if PEAK_HAVE_SYS_RANDOM_H
 #include <sys/random.h>
 #endif
 #include <sys/resource.h>
@@ -412,7 +412,7 @@ peak_socket_reduce_session_nonce(uint64_t* nonce_out)
         return false;
     }
 #endif
-#ifdef __linux__
+#if PEAK_HAVE_SYS_RANDOM_H
     while (remaining != 0) {
         ssize_t read_bytes;
         do {

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -407,6 +407,11 @@ peak_socket_reduce_session_nonce(uint64_t* nonce_out)
     if (nonce_out == NULL) {
         return false;
     }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (getenv("PEAK_TEST_OUTPUT_AGGREGATION_NONCE_FAIL") != NULL) {
+        return false;
+    }
+#endif
 #ifdef __linux__
     while (remaining != 0) {
         ssize_t read_bytes;
@@ -3303,20 +3308,6 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
                       size);
         return PEAK_SOCKET_REPORT_FAILED;
     }
-    if (rank == 0) {
-        unsigned int attempts = 0;
-
-        do {
-            if (!peak_socket_reduce_session_nonce(&session_nonce)) {
-                peak_log_warn("[peak] Socket aggregation could not create a session nonce; skipping aggregate output\n");
-                return PEAK_SOCKET_REPORT_FAILED;
-            }
-        } while (session_nonce == 0 && ++attempts < 3);
-        if (session_nonce == 0) {
-            peak_log_warn("[peak] Socket aggregation received an invalid session nonce; skipping aggregate output\n");
-            return PEAK_SOCKET_REPORT_FAILED;
-        }
-    }
     timeout_budget =
         peak_general_listener_report_timeout_budget_for_rank_count(
             (unsigned int)size);
@@ -3375,6 +3366,20 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
         single->rank_count = 1;
         *aggregate_out = single;
         return PEAK_SOCKET_REPORT_SINGLE_READY;
+    }
+    if (rank == 0) {
+        unsigned int attempts = 0;
+
+        do {
+            if (!peak_socket_reduce_session_nonce(&session_nonce)) {
+                peak_log_warn("[peak] Socket aggregation could not create a session nonce; skipping aggregate output\n");
+                return PEAK_SOCKET_REPORT_FAILED;
+            }
+        } while (session_nonce == 0 && ++attempts < 3);
+        if (session_nonce == 0) {
+            peak_log_warn("[peak] Socket aggregation received an invalid session nonce; skipping aggregate output\n");
+            return PEAK_SOCKET_REPORT_FAILED;
+        }
     }
     if (!peak_socket_positive_finite(local->overhead.elapsed_seconds)) {
         peak_log_warn("[peak] Socket aggregation observed an invalid local elapsed time; skipping aggregate output\n");

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "malloc_interceptor.h"
 #include "malloc_otf2.h"
+#include "internal/general_listener/output_identity.h"
 #include "logging.h"
 #include "utils/env_parser.h"
 #include <sched.h>
@@ -264,29 +265,21 @@ static int peak_log_backtrace_malloc() {
 =========================*/
 
 static void build_paths(char out_tmp[512], char out_csv[512], char out_otf2[512]) {
-    char base[256] = {0};
     const char *env_path = getenv("PEAK_MEMLOG_PATH");
-    if (env_path && *env_path) {
-        size_t n = strlen(env_path);
-        if (n >= sizeof(base)) n = sizeof(base) - 1;
-        memcpy(base, env_path, n);
-        base[n] = '\0';
-    } else {
-        snprintf(base, sizeof(base), "./peak_memlog");
-    }
-
     int rank = -1;
-    get_mpi_rank(&rank);
+    const char* base = env_path != NULL && env_path[0] != '\0' ?
+                           env_path : "./peak_memlog";
+    const char* template_value = getenv("PEAK_MEMLOG_TEMPLATE");
 
-    int pid = (int) getpid();
-    if (rank == -1) {
-        snprintf(out_tmp, 512, "%s-p%d.tmp", base, pid);
-        snprintf(out_csv, 512, "%s-p%d.csv", base, pid);
-        snprintf(out_otf2, 512, "p%d", pid);
-    } else {
-        snprintf(out_tmp, 512, "%s-r%d-p%d.tmp", base, rank, pid);
-        snprintf(out_csv, 512, "%s-r%d-p%d.csv", base, rank, pid);
-        snprintf(out_otf2, 512, "r%d-p%d", rank, pid);
+    get_mpi_rank(&rank);
+    if (!peak_output_identity_path(out_csv, 512, base, template_value,
+                                   ".csv", rank) ||
+        snprintf(out_tmp, 512, "%s.tmp", out_csv) >= 512 ||
+        !peak_output_identity_path(out_otf2, 512, "peak_memlog",
+                                   NULL, "", rank)) {
+        out_tmp[0] = '\0';
+        out_csv[0] = '\0';
+        out_otf2[0] = '\0';
     }
 }
 
@@ -442,6 +435,7 @@ static void peak_memlog_open(void) {
     int fd = -1;
     void* base = MAP_FAILED;
     const char* env_capacity;
+    const char* output_template;
 
     if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) !=
         PEAK_MEMLOG_UNINITIALIZED) return;
@@ -477,6 +471,18 @@ static void peak_memlog_open(void) {
     }
 
     build_paths(g_memlog.tmp_path, g_memlog.csv_path, g_memlog.otf2_prefix);
+    if (g_memlog.tmp_path[0] == '\0') {
+        peak_log_warn("[peak] memlog: output path is invalid; disabling log\n");
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
+        return;
+    }
+    output_template = getenv("PEAK_MEMLOG_TEMPLATE");
+    if (output_template != NULL && output_template[0] != '\0' &&
+        !peak_output_identity_make_parent(g_memlog.csv_path)) {
+        peak_log_warn("[peak] memlog: output directory is invalid; disabling log\n");
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED, memory_order_release);
+        return;
+    }
 #ifdef PEAK_ENABLE_TEST_HOOKS
     if (atomic_load_explicit(&g_memlog_test_failure, memory_order_acquire) ==
         PEAK_MEMLOG_TEST_FAIL_CREATE) {
@@ -484,7 +490,7 @@ static void peak_memlog_open(void) {
     } else
 #endif
     {
-        fd = open(g_memlog.tmp_path, O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0644);
+        fd = open(g_memlog.tmp_path, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0644);
     }
     if (fd < 0) {
         peak_log_warn("[peak] memlog: open(%s) failed: %s\n", g_memlog.tmp_path, strerror(errno));
@@ -551,13 +557,13 @@ static void peak_memlog_open(void) {
 }
 
 /* small helper to keep CSV emit identical but clearer */
-static inline void peak_csv_emit_line(int fd_csv, const PeakMemEvent *e) {
-    dprintf(fd_csv, "%llu,%lld,%llu,%u,%u\n",
-            (unsigned long long) e->ts_ns,
-            (long long)          e->delta,
-            (unsigned long long) e->current,
-            (unsigned)           e->tid,
-            (unsigned)           e->op);
+static inline int peak_csv_emit_line(int fd_csv, const PeakMemEvent *e) {
+    return dprintf(fd_csv, "%llu,%lld,%llu,%u,%u\n",
+                   (unsigned long long) e->ts_ns,
+                   (long long)          e->delta,
+                   (unsigned long long) e->current,
+                   (unsigned)           e->tid,
+                   (unsigned)           e->op) >= 0;
 }
 
 /* Convert the mmapped binary buffer to a CSV file (and remove the temp backing file). */
@@ -608,24 +614,55 @@ static void peak_memlog_finalize(void) {
     /* 1) OTF2 export */
     peak_memlog_export_otf2(g_memlog.otf2_prefix, base_chunk, events);
 
-    /* 2) CSV export (exactly as before) */
-    int fd_csv = open(g_memlog.csv_path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
+    /* 2) CSV export: publish the complete file without replacing a prior run. */
+    char csv_temp[sizeof(g_memlog.csv_path) + 16];
+    int fd_csv;
+
+    if (snprintf(csv_temp, sizeof(csv_temp), "%s.export", g_memlog.csv_path) >=
+        (int)sizeof(csv_temp)) {
+        csv_temp[0] = '\0';
+    }
+    fd_csv = csv_temp[0] == '\0' ? -1 :
+        open(csv_temp, O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0644);
+    bool csv_written = false;
     if (fd_csv < 0) {
         peak_log_warn("[peak] memlog: open CSV %s failed: %s\n", g_memlog.csv_path, strerror(errno));
     } else {
-        dprintf(fd_csv, "ts_ns,delta,current,tid,op\n");
+        int write_failed = dprintf(fd_csv, "ts_ns,delta,current,tid,op\n") < 0;
+        int failure_errno = write_failed ? errno : 0;
 
         uint8_t *base = (uint8_t *) g_memlog.map + g_memlog.header_bytes;
         for (size_t i = 0; i < events; i++) {
             PeakMemEvent *e = (PeakMemEvent *) (base + i * sizeof(PeakMemEvent));
-            peak_csv_emit_line(fd_csv, e);
+            if (!write_failed && !peak_csv_emit_line(fd_csv, e)) {
+                write_failed = 1;
+                failure_errno = errno;
+            }
         }
-        close(fd_csv);
+        if (close(fd_csv) != 0) {
+            write_failed = 1;
+            failure_errno = errno;
+        }
+        if (!write_failed && link(csv_temp, g_memlog.csv_path) != 0) {
+            write_failed = 1;
+            failure_errno = errno;
+        }
+        if (write_failed) {
+            peak_log_warn("[peak] memlog: publish CSV %s failed: %s\n",
+                          g_memlog.csv_path,
+                          strerror(failure_errno != 0 ? failure_errno : EIO));
+        }
+        else {
+            csv_written = true;
+        }
+        (void)unlink(csv_temp);
     }
-    peak_log_report("[peak] memlog CSV written: %s (events=%zu dropped=%zu)\n",
-                    g_memlog.csv_path,
-                    events,
-                    atomic_load_explicit(&g_memlog.dropped, memory_order_acquire));
+    if (csv_written) {
+        peak_log_report("[peak] memlog CSV written: %s (events=%zu dropped=%zu)\n",
+                        g_memlog.csv_path,
+                        events,
+                        atomic_load_explicit(&g_memlog.dropped, memory_order_acquire));
+    }
 
     munmap(g_memlog.map, g_memlog.map_bytes);
     close(g_memlog.fd);

--- a/src/peak.c
+++ b/src/peak.c
@@ -28,6 +28,7 @@
 #include "internal/general_listener_internal.h"
 #include "internal/general_listener/report_snapshot.h"
 #include "internal/general_listener/runtime_config.h"
+#include "internal/general_listener/output_identity.h"
 #include "internal/jit_provider.h"
 #include "logging.h"
 #include "pthread_listener.h"
@@ -1160,6 +1161,7 @@ peak_test_parse_max_num_threads(void)
 
 void peak_init()
 {
+    peak_output_identity_initialize();
     PeakRuntimeNumericConfig numeric_config;
 
     peak_log_configure();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -197,6 +197,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/utils)
     target_compile_options(test_report_formatter PRIVATE -UNDEBUG)
+    target_compile_definitions(test_report_formatter PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
     target_link_libraries(test_report_formatter PRIVATE Threads::Threads ${RT_LIBRARY})
     add_test(NAME test_report_formatter COMMAND test_report_formatter)
     set_tests_properties(test_report_formatter

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,6 +186,7 @@ if(BUILD_TESTING)
 
     add_executable(test_report_formatter
         report/test_report_formatter.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_formatter.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
@@ -237,6 +238,7 @@ if(BUILD_TESTING)
     add_executable(test_mpi_report_request_lifetime
         report/test_mpi_report_request_lifetime.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/mpi_report_transport.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_formatter.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c
@@ -439,6 +441,7 @@ if(BUILD_TESTING)
 
     add_executable(test_exec_checkpoint_writer
         report/test_exec_checkpoint_writer.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
         ${PROJECT_SOURCE_DIR}/src/general_listener/exec_checkpoint_writer.c)
     if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
        CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
@@ -3372,7 +3375,7 @@ if(BUILD_TESTING)
 
     # Add test of memory allocation intercepting
     add_subdirectory(memory)
-    foreach(memlog_case create sizing mapping overflow capacity stalled stress allocation realloc)
+    foreach(memlog_case create sizing mapping overflow capacity stalled stress no-clobber allocation realloc)
         add_test(NAME test_memlog_${memlog_case}
             COMMAND test_memlog_safety ${memlog_case})
         set_tests_properties(test_memlog_${memlog_case}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,7 +472,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_output_identity PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
     target_compile_options(test_output_identity PRIVATE -UNDEBUG)
     target_link_libraries(test_output_identity PRIVATE Threads::Threads ${RT_LIBRARY})
-    foreach(_output_identity_case IN ITEMS preinit default template-csv template-bare invalid template-overlong template-expanded-overlong concurrent snapshot entropy-fallback)
+    foreach(_output_identity_case IN ITEMS preinit default template-csv template-bare invalid template-overlong template-expanded-overlong template-raw-overlong-renderable concurrent snapshot entropy-fallback)
         add_test(NAME test_output_identity_${_output_identity_case}
             COMMAND test_output_identity ${_output_identity_case})
         set_tests_properties(test_output_identity_${_output_identity_case}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -197,7 +197,7 @@ if(BUILD_TESTING)
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/utils)
     target_compile_options(test_report_formatter PRIVATE -UNDEBUG)
-    target_link_libraries(test_report_formatter PRIVATE Threads::Threads)
+    target_link_libraries(test_report_formatter PRIVATE Threads::Threads ${RT_LIBRARY})
     add_test(NAME test_report_formatter COMMAND test_report_formatter)
     set_tests_properties(test_report_formatter
         PROPERTIES
@@ -450,6 +450,8 @@ if(BUILD_TESTING)
     endif()
     target_include_directories(test_exec_checkpoint_writer PRIVATE
         ${PROJECT_SOURCE_DIR}/include)
+    target_link_libraries(test_exec_checkpoint_writer PRIVATE
+        Threads::Threads ${RT_LIBRARY})
     add_test(NAME test_exec_checkpoint_writer
         COMMAND test_exec_checkpoint_writer)
     set_tests_properties(test_exec_checkpoint_writer
@@ -470,7 +472,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_output_identity PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
     target_compile_options(test_output_identity PRIVATE -UNDEBUG)
     target_link_libraries(test_output_identity PRIVATE Threads::Threads ${RT_LIBRARY})
-    foreach(_output_identity_case IN ITEMS preinit default template-csv template-bare invalid concurrent snapshot entropy-fallback)
+    foreach(_output_identity_case IN ITEMS preinit default template-csv template-bare invalid template-overlong template-expanded-overlong concurrent snapshot entropy-fallback)
         add_test(NAME test_output_identity_${_output_identity_case}
             COMMAND test_output_identity ${_output_identity_case})
         set_tests_properties(test_output_identity_${_output_identity_case}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -456,6 +456,34 @@ if(BUILD_TESTING)
         PROPERTIES
             PASS_REGULAR_EXPRESSION "exec_checkpoint_writer_test_ok")
 
+    add_executable(test_output_identity
+        report/test_output_identity.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
+        ${PROJECT_SOURCE_DIR}/src/general_listener/exec_checkpoint_writer.c)
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+        target_sources(test_output_identity PRIVATE
+            ${PROJECT_SOURCE_DIR}/cmake/peak-gum/peak_aarch64_raw_syscall.S)
+    endif()
+    target_include_directories(test_output_identity PRIVATE
+        ${PROJECT_SOURCE_DIR}/include)
+    target_compile_definitions(test_output_identity PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
+    target_compile_options(test_output_identity PRIVATE -UNDEBUG)
+    target_link_libraries(test_output_identity PRIVATE Threads::Threads ${RT_LIBRARY})
+    foreach(_output_identity_case IN ITEMS preinit default template-csv template-bare invalid concurrent snapshot entropy-fallback)
+        add_test(NAME test_output_identity_${_output_identity_case}
+            COMMAND test_output_identity ${_output_identity_case})
+        set_tests_properties(test_output_identity_${_output_identity_case}
+            PROPERTIES PASS_REGULAR_EXPRESSION "output_identity_test_ok")
+    endforeach()
+
+    add_test(NAME test_exec_checkpoint_output_contract
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/static_checks/check_exec_checkpoint_output_contract.py
+                ${PROJECT_SOURCE_DIR})
+    set_tests_properties(test_exec_checkpoint_output_contract
+        PROPERTIES PASS_REGULAR_EXPRESSION "exec_checkpoint_output_contract_ok")
+
     add_test(NAME test_general_listener_layout
         COMMAND ${Python3_EXECUTABLE}
                 ${PROJECT_SOURCE_DIR}/test/static_checks/check_general_listener_layout.py
@@ -767,7 +795,7 @@ if(BUILD_TESTING)
             COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
         set_tests_properties(test_fastpath_thread_exit_checkpoint_exact_once
             PROPERTIES
-                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_TEST_CHECKPOINT_EXACT=1;PEAK_EXEC_CHECKPOINT=1;PEAK_STATSLOG_PATH=${PROJECT_BINARY_DIR}/test/detach_runtime/fastpath-checkpoint;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
+                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_TEST_CHECKPOINT_EXACT=1;PEAK_EXEC_CHECKPOINT=1;PEAK_STATSLOG_PATH=${PROJECT_BINARY_DIR}/test/detach_runtime/fastpath-checkpoint;PEAK_STATSLOG_TEMPLATE=${PROJECT_BINARY_DIR}/test/detach_runtime/fastpath-checkpoint-{pid}-{session}.csv;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
                 PASS_REGULAR_EXPRESSION "fastpath_thread_exit_ok"
                 FAIL_REGULAR_EXPRESSION "fatal|checkpoint .* mismatch|capture failed|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)

--- a/test/detach_controller/CMakeLists.txt
+++ b/test/detach_controller/CMakeLists.txt
@@ -14,6 +14,7 @@ if(PEAK_GUM_PEAK_PC_API_AVAILABLE AND PEAK_DETACH_HELPER_SUPPORTED)
     ${PROJECT_SOURCE_DIR}/src/general_listener.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/attach_policy.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/exec_checkpoint_writer.c
+    ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_formatter.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_maxima.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c

--- a/test/detach_controller/test_detach_listener_shutdown.c
+++ b/test/detach_controller/test_detach_listener_shutdown.c
@@ -305,6 +305,57 @@ print_with_stderr_capture(char** output_out)
     return print_with_stderr_capture_for_mpi_policy(FALSE, output_out);
 }
 
+static gboolean
+print_rank_local_mpi_fixture_report(gboolean active_mpi_job,
+                                    char** output_out)
+{
+    char template_path[] = "/tmp/peak_rank_local_mpi_fixture_XXXXXX";
+    char hostname[256] = {0};
+    char strict_path[PATH_MAX];
+    size_t hostname_length = 0;
+    int strict_path_length;
+    int template_fd;
+    gboolean result;
+
+    template_fd = mkstemp(template_path);
+    if (template_fd < 0) {
+        return FALSE;
+    }
+    close(template_fd);
+    (void)unlink(template_path);
+    if (setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) != 0) {
+        return FALSE;
+    }
+    result = print_with_stderr_capture_for_mpi_policy(active_mpi_job,
+                                                      output_out);
+    (void)unlink(template_path);
+    if (gethostname(hostname, sizeof(hostname) - 1) != 0 ||
+        hostname[0] == '\0') {
+        (void)snprintf(hostname, sizeof(hostname), "unknown");
+    }
+    for (size_t index = 0; hostname[index] != '\0'; index++) {
+        unsigned char byte = (unsigned char)hostname[index];
+
+        hostname[hostname_length++] =
+            (byte >= 'a' && byte <= 'z') ||
+            (byte >= 'A' && byte <= 'Z') ||
+            (byte >= '0' && byte <= '9') || byte == '-' ||
+            byte == '_' || byte == '.' ? (char)byte : '_';
+    }
+    hostname[hostname_length] = '\0';
+    strict_path_length = snprintf(strict_path,
+                                  sizeof(strict_path),
+                                  "%s-ranklocal-h%s",
+                                  template_path,
+                                  hostname_length > 0 ? hostname : "unknown");
+    if (strict_path_length >= 0 &&
+        strict_path_length < (int)sizeof(strict_path)) {
+        (void)unlink(strict_path);
+    }
+    (void)unsetenv("PEAK_STATSLOG_TEMPLATE");
+    return result;
+}
+
 static void
 cleanup_public_listener_globals(void)
 {
@@ -685,7 +736,7 @@ run_rank_local_mpi_text_default(void)
     peak_general_listener_freeze_final_report_snapshot();
 
     check_true("rank-local MPI report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    TRUE, &report_log) == TRUE);
     check_not_contains("rank-local MPI default suppresses text",
                        report_log,
@@ -697,7 +748,7 @@ run_rank_local_mpi_text_default(void)
     (void)setenv("I_MPI_RANK", "0", 1);
     (void)setenv("I_MPI_SIZE", "1", 1);
     check_true("singleton MPI report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    TRUE, &report_log) == TRUE);
     check_contains("singleton MPI default keeps text",
                    report_log,
@@ -707,7 +758,7 @@ run_rank_local_mpi_text_default(void)
 
     clear_mpi_launcher_environment();
     check_true("missing metadata report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    TRUE, &report_log) == TRUE);
     check_contains("missing metadata fails open for text",
                    report_log,
@@ -719,7 +770,7 @@ run_rank_local_mpi_text_default(void)
     (void)setenv("I_MPI_RANK", "17", 1);
     (void)setenv("I_MPI_SIZE", "4096", 1);
     check_true("inactive MPI policy report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    FALSE, &report_log) == TRUE);
     check_contains("inactive policy ignores launcher metadata",
                    report_log,
@@ -729,7 +780,7 @@ run_rank_local_mpi_text_default(void)
 
     (void)setenv("PEAK_TEXT_OUTPUT", "1", 1);
     check_true("rank-local MPI text override report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    TRUE, &report_log) == TRUE);
     check_contains("rank-local MPI text override keeps text",
                    report_log,
@@ -739,7 +790,7 @@ run_rank_local_mpi_text_default(void)
 
     (void)setenv("PEAK_TEXT_OUTPUT", "0", 1);
     check_true("explicit text disable report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    FALSE, &report_log) == TRUE);
     check_not_contains("explicit text disable suppresses text",
                        report_log,
@@ -754,7 +805,7 @@ run_rank_local_mpi_text_default(void)
     (void)setenv("I_MPI_RANK", "1", 1);
     (void)setenv("I_MPI_SIZE", "4", 1);
     check_true("contradictory metadata report write succeeded",
-               print_with_stderr_capture_for_mpi_policy(
+               print_rank_local_mpi_fixture_report(
                    TRUE, &report_log) == TRUE);
     check_contains("contradictory metadata fails open for text",
                    report_log,

--- a/test/detach_runtime/run_detach_milc_like_ab_check.py
+++ b/test/detach_runtime/run_detach_milc_like_ab_check.py
@@ -30,6 +30,10 @@ STATS_CSV_FIELDS = (
     "dropped_calls",
     "dropped_threads",
 )
+PEAK_STATS_NAME_RE = re.compile(
+    r"^milc-like-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+    r"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p\d+-q[0-9a-f]{16}\.csv$"
+)
 STATS_CSV_METRIC_FIELDS = STATS_CSV_FIELDS[4:11]
 STATS_CSV_DIAGNOSTIC_FIELDS = STATS_CSV_FIELDS[11:]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
@@ -330,7 +334,7 @@ def progress_gate_required(args):
 
 
 def reset_peak_artifacts(args):
-    for path in args.work_dir.glob("milc-like-stats-p*.csv"):
+    for path in args.work_dir.glob("milc-like-stats-*.csv"):
         path.unlink()
 
 
@@ -1006,7 +1010,11 @@ def validated_profiled_stats_rows(handle, allowed_targets, rank_count=1):
 
 
 def read_profiled_stats(args):
-    paths = sorted(args.work_dir.glob("milc-like-stats-p*.csv"))
+    candidates = sorted(args.work_dir.glob("milc-like-stats-*.csv"))
+    paths = [path for path in candidates if PEAK_STATS_NAME_RE.fullmatch(path.name)]
+    unexpected = [path for path in candidates if path not in paths]
+    if unexpected:
+        raise AssertionError(f"unexpected PEAK stats CSV artifacts: {unexpected}")
     if not paths:
         raise AssertionError("missing PEAK stats CSV for profiled call coverage")
     if len(paths) != 1:

--- a/test/detach_runtime/test_fastpath_thread_exit.c
+++ b/test/detach_runtime/test_fastpath_thread_exit.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include <pthread.h>
+#include <dirent.h>
 #include <dlfcn.h>
 #include <sched.h>
 #include <stdatomic.h>
@@ -618,12 +619,45 @@ main(void)
             RTLD_DEFAULT, "peak_checkpoint_for_exec");
         const char* base = getenv("PEAK_STATSLOG_PATH");
         char path[1024];
+        char directory[1024];
+        char* slash;
+        DIR* stream;
+        struct dirent* entry;
+        int matches = 0;
         char* argv[] = { (char*)"checkpoint-test", NULL };
         if (checkpoint == NULL || base == NULL ||
             checkpoint("checkpoint-test", argv) != 0 ||
-            snprintf(path, sizeof(path), "%s-p%ld-exec1.csv", base,
-                     (long)getpid()) >= (int)sizeof(path)) {
+            snprintf(directory, sizeof(directory), "%s", base) >=
+                (int)sizeof(directory) ||
+            (slash = strrchr(directory, '/')) == NULL) {
             fputs("checkpoint capture failed\n", stderr);
+            return 1;
+        }
+        *slash = '\0';
+        stream = opendir(directory);
+        if (stream == NULL) {
+            fputs("checkpoint directory unavailable\n", stderr);
+            return 1;
+        }
+        while ((entry = readdir(stream)) != NULL) {
+            size_t name_length = strlen(entry->d_name);
+            static const char checkpoint_suffix[] = "-exec1.csv";
+
+            if (strncmp(entry->d_name, "fastpath-checkpoint-", 20) == 0 &&
+                name_length >= sizeof(checkpoint_suffix) - 1 &&
+                strcmp(entry->d_name + name_length - (sizeof(checkpoint_suffix) - 1),
+                       checkpoint_suffix) == 0) {
+                if (snprintf(path, sizeof(path), "%s/%s", directory,
+                             entry->d_name) >= (int)sizeof(path)) {
+                    (void)closedir(stream);
+                    return 1;
+                }
+                matches++;
+            }
+        }
+        (void)closedir(stream);
+        if (matches != 1) {
+            fputs("checkpoint output identity mismatch\n", stderr);
             return 1;
         }
         FILE* checkpoint_csv = fopen(path, "r");

--- a/test/detach_runtime/test_fastpath_thread_exit.c
+++ b/test/detach_runtime/test_fastpath_thread_exit.c
@@ -34,6 +34,27 @@ static atomic_int aba_worker_ready;
 static atomic_int aba_worker_release;
 typedef unsigned long (*CountFunction)(size_t);
 typedef uint64_t (*DroppedFunction)(void);
+
+static int
+checkpoint_name_matches(const char* name, long pid)
+{
+    char prefix[64];
+    const char* session;
+
+    if (snprintf(prefix, sizeof(prefix), "fastpath-checkpoint-%ld-", pid) >=
+            (int)sizeof(prefix) ||
+        strncmp(name, prefix, strlen(prefix)) != 0) {
+        return 0;
+    }
+    session = name + strlen(prefix);
+    for (size_t index = 0; index < 16; index++) {
+        if (!((session[index] >= '0' && session[index] <= '9') ||
+              (session[index] >= 'a' && session[index] <= 'f'))) {
+            return 0;
+        }
+    }
+    return strcmp(session + 16, "-exec1.csv") == 0;
+}
 typedef void (*MarkNextHelperFunction)(void);
 typedef int (*StaleGenerationRemoveFunction)(pthread_t);
 typedef int (*RemoveAmbiguousMappingFunction)(pthread_t);
@@ -639,14 +660,14 @@ main(void)
             fputs("checkpoint directory unavailable\n", stderr);
             return 1;
         }
+        if (!checkpoint_name_matches(
+                "fastpath-checkpoint-1-0123456789abcdef-exec1.csv", 1) ||
+            checkpoint_name_matches("fastpath-checkpoint-p1-exec1.csv", 1)) {
+            fputs("checkpoint name contract mismatch\n", stderr);
+            return 1;
+        }
         while ((entry = readdir(stream)) != NULL) {
-            size_t name_length = strlen(entry->d_name);
-            static const char checkpoint_suffix[] = "-exec1.csv";
-
-            if (strncmp(entry->d_name, "fastpath-checkpoint-", 20) == 0 &&
-                name_length >= sizeof(checkpoint_suffix) - 1 &&
-                strcmp(entry->d_name + name_length - (sizeof(checkpoint_suffix) - 1),
-                       checkpoint_suffix) == 0) {
+            if (checkpoint_name_matches(entry->d_name, (long)getpid())) {
                 if (snprintf(path, sizeof(path), "%s/%s", directory,
                              entry->d_name) >= (int)sizeof(path)) {
                     (void)closedir(stream);

--- a/test/dgemm_mpi/CMakeLists.txt
+++ b/test/dgemm_mpi/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(test_mpi_report_reduction test_mpi_report_reduction.c)
 add_executable(test_mpi_report_transport
     test_mpi_report_transport.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/mpi_report_transport.c
+    ${PROJECT_SOURCE_DIR}/src/general_listener/output_identity.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_formatter.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c
     ${PROJECT_SOURCE_DIR}/src/general_listener/report_model.c

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -1339,7 +1339,11 @@ def main():
         for name, evidence in stats_file_evidence.items():
             require_complete_stats_evidence(name, evidence)
         for path in temporary_stats_files:
-            rank_match = re.search(r"-r(\d+)\.csv\.tmp\.", path.name)
+            rank_match = re.fullmatch(
+                r"peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+                r"h[A-Za-z0-9_.-]+-r(\d+)-p\d+-q[0-9a-f]{16}\.csv\.tmp\..+",
+                path.name,
+            )
             if rank_match is None or int(rank_match.group(1)) == 0:
                 raise AssertionError(
                     "subset-finalize handoff left an unexpected temporary CSV: "

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -104,6 +104,9 @@ SOCKET_TRANSPORT_FALLBACK_MODES = {
     "finalize-clean-output-mpi-reducer-fail",
 }
 ALLOCATED_SOCKET_TEST_PORT_BASES = set()
+WRITER_DESTINATION_FAILURE_DIAGNOSTIC = (
+    "failed to prepare stats csv destination"
+)
 STATS_CSV_NAME_RE = re.compile(
     r"^peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
     r"h[A-Za-z0-9_.-]+-r(?P<rank>[A-Za-z0-9_-]+)-p\d+-"
@@ -146,6 +149,11 @@ def require_socket_release_fallback_layout(stats_names, nprocs):
             "socket release failure fallback ranks must contain each rank "
             f"exactly once: got {sorted(fallback_ranks)}"
         )
+
+
+def writer_destination_failure_observed(output):
+    """The dirfd writer rejects a non-directory parent before temp creation."""
+    return WRITER_DESTINATION_FAILURE_DIAGNOSTIC in output
 
 
 def compact_temporary_stats_files(stats_dir):
@@ -850,7 +858,7 @@ def main():
         env.pop("PEAK_MPI_FINALIZE_POLICY", None)
         env.pop("PEAK_TEST_MPI_LIBRARY_VERSION", None)
         app_args.append("finalize-then-exit0")
-        expected = "failed to create temporary stats csv"
+        expected = WRITER_DESTINATION_FAILURE_DIAGNOSTIC
         expected_extra.append(
             "All-rank report publication release completed: "
             "all_reports_succeeded=0"

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -104,6 +104,11 @@ SOCKET_TRANSPORT_FALLBACK_MODES = {
     "finalize-clean-output-mpi-reducer-fail",
 }
 ALLOCATED_SOCKET_TEST_PORT_BASES = set()
+STATS_CSV_NAME_RE = re.compile(
+    r"^peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+    r"h[A-Za-z0-9_.-]+-r(?P<rank>[A-Za-z0-9_-]+)-p\d+-"
+    r"q[0-9a-f]{16}(?:-ranklocal-h[A-Za-z0-9_.-]+)?\.csv$"
+)
 
 
 def require_valid_accounting_diagnostics(name, rows):
@@ -1126,11 +1131,7 @@ def main():
             env=env,
             timeout=args.timeout,
         )
-        stats_name = re.compile(
-            r"^peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
-            r"h[A-Za-z0-9_.-]+-r(?P<rank>[A-Za-z0-9_-]+)-p\d+-"
-            r"q[0-9a-f]{16}\.csv$"
-        )
+        stats_name = STATS_CSV_NAME_RE
         stats_files = sorted(
             path for path in Path(stats_dir).glob("peak-stats-*.csv")
             if stats_name.fullmatch(path.name)

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -148,6 +148,18 @@ def require_socket_release_fallback_layout(stats_names, nprocs):
         )
 
 
+def compact_temporary_stats_files(stats_dir):
+    return sorted(Path(stats_dir).glob(".peak-tmp.p*.*"))
+
+
+def reject_compact_temporary_stats_files(paths):
+    if paths:
+        raise AssertionError(
+            "PEAK compact CSV temporary file remained after launcher return: "
+            + ", ".join(path.name for path in paths)
+        )
+
+
 def require_valid_accounting_diagnostics(name, rows):
     diagnostics = [
         row for row in rows
@@ -1183,6 +1195,8 @@ def main():
         temporary_stats_files = sorted(
             Path(stats_dir).glob("peak-stats-*.csv.tmp.*")
         )
+        compact_temporary_files = compact_temporary_stats_files(stats_dir)
+        reject_compact_temporary_stats_files(compact_temporary_files)
         finalize_enter_markers = sorted(
             Path(stats_dir).glob("finalize-enter-r*.txt")
         )

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -1126,9 +1126,24 @@ def main():
             env=env,
             timeout=args.timeout,
         )
-        stats_files = sorted(Path(stats_dir).glob("peak-stats-p*.csv"))
+        stats_name = re.compile(
+            r"^peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+            r"h[A-Za-z0-9_.-]+-r(?P<rank>[A-Za-z0-9_-]+)-p\d+-"
+            r"q[0-9a-f]{16}\.csv$"
+        )
+        stats_files = sorted(
+            path for path in Path(stats_dir).glob("peak-stats-*.csv")
+            if stats_name.fullmatch(path.name)
+        )
+        unexpected_stats_files = [
+            path for path in Path(stats_dir).glob("peak-stats-*.csv")
+            if not stats_name.fullmatch(path.name)
+        ]
+        if unexpected_stats_files:
+            raise AssertionError(
+                f"unexpected PEAK stats CSV artifacts: {unexpected_stats_files}")
         temporary_stats_files = sorted(
-            Path(stats_dir).glob("peak-stats-p*.csv.tmp.*")
+            Path(stats_dir).glob("peak-stats-*.csv.tmp.*")
         )
         finalize_enter_markers = sorted(
             Path(stats_dir).glob("finalize-enter-r*.txt")
@@ -1162,19 +1177,14 @@ def main():
                 stats_rows.extend(rows)
         for name, evidence in stats_file_evidence.items():
             require_valid_accounting_diagnostics(name, evidence["rows"])
-        selected_stats_pattern = (
-            "peak-stats-p*-r0.csv" if nprocs > 1 else "peak-stats-p*.csv"
-        )
-        selected_temporary_stats_pattern = (
-            "peak-stats-p*-r0.csv.tmp.*" if nprocs > 1 else
-            "peak-stats-p*.csv.tmp.*"
-        )
-        selected_stats_files = sorted(
-            Path(stats_dir).glob(selected_stats_pattern)
-        )
-        selected_temporary_stats_files = sorted(
-            Path(stats_dir).glob(selected_temporary_stats_pattern)
-        )
+        selected_stats_files = [
+            path for path in stats_files
+            if nprocs == 1 or stats_name.fullmatch(path.name)["rank"] == "0"
+        ]
+        selected_temporary_stats_files = [
+            path for path in temporary_stats_files
+            if nprocs == 1 or "-r0-" in path.name
+        ]
         selected_stats_rows = []
         selected_stats_fields = None
         if len(selected_stats_files) == 1:

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -107,8 +107,45 @@ ALLOCATED_SOCKET_TEST_PORT_BASES = set()
 STATS_CSV_NAME_RE = re.compile(
     r"^peak-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
     r"h[A-Za-z0-9_.-]+-r(?P<rank>[A-Za-z0-9_-]+)-p\d+-"
-    r"q[0-9a-f]{16}(?:-ranklocal-h[A-Za-z0-9_.-]+)?\.csv$"
+    r"q[0-9a-f]{16}(?P<fallback>-ranklocal-h[A-Za-z0-9_.-]+)?\.csv$"
 )
+
+
+def require_socket_release_fallback_layout(stats_names, nprocs):
+    aggregates = []
+    fallback_ranks = []
+
+    for name in stats_names:
+        match = STATS_CSV_NAME_RE.fullmatch(name)
+        if match is None:
+            raise AssertionError(f"unexpected PEAK stats CSV artifact: {name}")
+        if match["fallback"] is None:
+            aggregates.append(name)
+            continue
+        try:
+            fallback_ranks.append(int(match["rank"]))
+        except ValueError as exc:
+            raise AssertionError(
+                f"rank-local fallback has a non-numeric rank: {name}"
+            ) from exc
+
+    if len(aggregates) != 1:
+        raise AssertionError(
+            f"socket release failure requires exactly one aggregate CSV, got "
+            f"{len(aggregates)}"
+        )
+    if len(fallback_ranks) != nprocs:
+        raise AssertionError(
+            f"socket release failure requires exactly {nprocs} rank-local "
+            f"fallback CSVs, got {len(fallback_ranks)}"
+        )
+    expected_ranks = set(range(nprocs))
+    if set(fallback_ranks) != expected_ranks or \
+            len(set(fallback_ranks)) != len(fallback_ranks):
+        raise AssertionError(
+            "socket release failure fallback ranks must contain each rank "
+            f"exactly once: got {sorted(fallback_ranks)}"
+        )
 
 
 def require_valid_accounting_diagnostics(name, rows):
@@ -1316,6 +1353,10 @@ def main():
         raise AssertionError(
             f"expected at most {expected_max_peak_tables} PEAK output table(s), "
             f"got {peak_table_count}"
+        )
+    if args.mode == "finalize-clean-output-socket-release-fail":
+        require_socket_release_fallback_layout(
+            [path.name for path in stats_files], nprocs
         )
     if expected_stats_files is not None and len(stats_files) != expected_stats_files:
         raise AssertionError(

--- a/test/dgemm_mpi/test_mpi_exit_before_finalize.c
+++ b/test/dgemm_mpi/test_mpi_exit_before_finalize.c
@@ -91,7 +91,9 @@ peak_mpi_exit_aggregate_csv_is_published(void)
     if (stats_prefix == NULL || stats_prefix[0] == '\0') {
         return 0;
     }
-    length = snprintf(NULL, 0, "%s-p*.csv", stats_prefix);
+    length = snprintf(NULL, 0,
+                      "%s-j*-s*-h*-r*-p*-q????????????????.csv",
+                      stats_prefix);
     if (length < 0) {
         return 0;
     }
@@ -100,7 +102,8 @@ peak_mpi_exit_aggregate_csv_is_published(void)
         return 0;
     }
     (void)snprintf(pattern, (size_t)length + 1,
-                   "%s-p*.csv", stats_prefix);
+                   "%s-j*-s*-h*-r*-p*-q????????????????.csv",
+                   stats_prefix);
 
     if (glob(pattern, 0, NULL, &matches) == 0) {
         for (size_t i = 0; i < matches.gl_pathc; i++) {

--- a/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
+++ b/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -316,6 +317,17 @@ class StatsArtifactNameTest(unittest.TestCase):
             CHECKER.require_socket_release_fallback_layout(missing, 4)
         with self.assertRaisesRegex(AssertionError, "each rank exactly once"):
             CHECKER.require_socket_release_fallback_layout(duplicate, 4)
+
+    def test_compact_temporary_artifact_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(CHECKER.compact_temporary_stats_files(directory), [])
+            artifact = Path(directory) / ".peak-tmp.p123.4"
+            artifact.touch()
+            artifacts = CHECKER.compact_temporary_stats_files(directory)
+
+            self.assertEqual(artifacts, [artifact])
+            with self.assertRaisesRegex(AssertionError, "compact CSV temporary"):
+                CHECKER.reject_compact_temporary_stats_files(artifacts)
 
 
 if __name__ == "__main__":

--- a/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
+++ b/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
@@ -282,6 +282,41 @@ class StatsArtifactNameTest(unittest.TestCase):
             "peak-stats-j42-s7-hnode0-r0-p123.csv"
         ))
 
+    @staticmethod
+    def release_name(rank: int, fallback: bool = False) -> str:
+        suffix = "-ranklocal-hnode0" if fallback else ""
+        return (
+            f"peak-stats-j42-s7-hnode0-r{rank}-p{rank + 100}-"
+            f"q{rank:016x}{suffix}.csv"
+        )
+
+    def test_socket_release_layout_requires_one_aggregate_and_every_rank(self) -> None:
+        names = [self.release_name(0)] + [
+            self.release_name(rank, fallback=True) for rank in range(4)
+        ]
+
+        CHECKER.require_socket_release_fallback_layout(names, 4)
+
+    def test_socket_release_layout_rejects_extra_aggregate(self) -> None:
+        names = [self.release_name(0), self.release_name(1), self.release_name(2)]
+        names.extend(self.release_name(rank, fallback=True) for rank in range(4))
+
+        with self.assertRaisesRegex(AssertionError, "exactly one aggregate"):
+            CHECKER.require_socket_release_fallback_layout(names, 4)
+
+    def test_socket_release_layout_rejects_missing_or_duplicate_rank(self) -> None:
+        missing = [self.release_name(0)] + [
+            self.release_name(rank, fallback=True) for rank in (0, 1, 3)
+        ]
+        duplicate = [self.release_name(0)] + [
+            self.release_name(rank, fallback=True) for rank in (0, 1, 1, 3)
+        ]
+
+        with self.assertRaisesRegex(AssertionError, "exactly 4 rank-local"):
+            CHECKER.require_socket_release_fallback_layout(missing, 4)
+        with self.assertRaisesRegex(AssertionError, "each rank exactly once"):
+            CHECKER.require_socket_release_fallback_layout(duplicate, 4)
+
 
 if __name__ == "__main__":
     result = unittest.main(exit=False)

--- a/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
+++ b/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
@@ -135,6 +135,18 @@ class ReportInterruptionPolicyTest(unittest.TestCase):
         self.assertFalse(CHECKER.report_release_was_interrupted(output))
 
 
+class WriterFailureDiagnosticPolicyTest(unittest.TestCase):
+    def test_dirfd_parent_failure_is_the_writer_failure_diagnostic(self) -> None:
+        output = "[peak] failed to prepare stats csv destination: Not a directory\n"
+
+        self.assertTrue(CHECKER.writer_destination_failure_observed(output))
+
+    def test_temp_creation_diagnostic_is_not_the_dirfd_parent_failure(self) -> None:
+        output = "[peak] failed to create temporary stats csv: Not a directory\n"
+
+        self.assertFalse(CHECKER.writer_destination_failure_observed(output))
+
+
 class SocketPortIsolationTest(unittest.TestCase):
     def test_busy_port_in_either_contiguous_pair_slot_retries(self) -> None:
         first_base = 21000

--- a/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
+++ b/test/dgemm_mpi/test_mpi_lifecycle_checker_policy.py
@@ -262,6 +262,27 @@ class SocketPortIsolationTest(unittest.TestCase):
         ))
 
 
+class StatsArtifactNameTest(unittest.TestCase):
+    def test_strict_rank_local_fallback_is_a_valid_identity_artifact(self) -> None:
+        aggregate = (
+            "peak-stats-j42-s7-hnode0-r0-p123-q0123456789abcdef.csv"
+        )
+        fallback = (
+            "peak-stats-j42-s7-hnode0-r0-p123-q0123456789abcdef-"
+            "ranklocal-hnode0.csv"
+        )
+
+        self.assertEqual(
+            CHECKER.STATS_CSV_NAME_RE.fullmatch(aggregate)["rank"], "0"
+        )
+        self.assertEqual(
+            CHECKER.STATS_CSV_NAME_RE.fullmatch(fallback)["rank"], "0"
+        )
+        self.assertIsNone(CHECKER.STATS_CSV_NAME_RE.fullmatch(
+            "peak-stats-j42-s7-hnode0-r0-p123.csv"
+        ))
+
+
 if __name__ == "__main__":
     result = unittest.main(exit=False)
     if result.result.wasSuccessful():

--- a/test/dgemm_mpi/test_mpi_report_transport.c
+++ b/test/dgemm_mpi/test_mpi_report_transport.c
@@ -56,14 +56,13 @@ validate_root_formatting(PeakReportSnapshot* aggregate)
                                  (long)getpid());
     stats_path_length = snprintf(stats_path,
                                  sizeof(stats_path),
-                                 "%s-p%ld.csv",
-                                 stats_base,
-                                 (long)getpid());
+                                 "%s.csv", stats_base);
     if (stats_base_length < 0 ||
         (size_t)stats_base_length >= sizeof(stats_base) ||
         stats_path_length < 0 ||
         (size_t)stats_path_length >= sizeof(stats_path) ||
-        setenv("PEAK_STATSLOG_PATH", stats_base, 1) != 0) {
+        setenv("PEAK_STATSLOG_PATH", stats_base, 1) != 0 ||
+        setenv("PEAK_STATSLOG_TEMPLATE", stats_path, 1) != 0) {
         return 1;
     }
 
@@ -82,6 +81,9 @@ validate_root_formatting(PeakReportSnapshot* aggregate)
         failures++;
     }
     if (unlink(stats_path) != 0) {
+        failures++;
+    }
+    if (unsetenv("PEAK_STATSLOG_TEMPLATE") != 0) {
         failures++;
     }
 

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -1169,6 +1169,14 @@ def run_checkpoint_contract_self_test():
         else:
             raise AssertionError(
                 "active-controller malformed checkpoint was accepted")
+        final_with_exec_metadata = (
+            workdir / "peak_stats-jjob-exec-sstep-hhost-exec-r0-p1-"
+            "q0123456789abcdef.csv"
+        )
+        final_with_exec_metadata.write_text("function,count\n", encoding="utf-8")
+        _, final_files = csv_files(workdir)
+        require(final_with_exec_metadata in final_files,
+                "identity metadata containing -exec was misclassified as checkpoint")
     print("exec_chain_checkpoint_contract_ok")
 
 
@@ -1595,11 +1603,13 @@ def check_common(args, proc, tmpdir: Path, native_observation=None):
         parent_pid = match.group(5)
         parent_exec_files = [
             path for path in exec_files
-            if f"-p{parent_pid}-exec" in path.name
+            if re.search(rf"-p{re.escape(parent_pid)}-q[0-9a-f]{{16}}-exec\d+\.csv$",
+                         path.name)
         ]
         parent_final_files = [
             path for path in final_files
-            if f"-p{parent_pid}.csv" in path.name
+            if re.search(rf"-p{re.escape(parent_pid)}-q[0-9a-f]{{16}}\.csv$",
+                         path.name)
         ]
         require(parent_exec_files,
                 f"clone parent wrote no exec checkpoint: {exec_files}")

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -1102,7 +1102,10 @@ def run_fixture(args, tmpdir: Path, preload=True):
 
 def csv_files(tmpdir: Path):
     stats_name = re.compile(
-        r"^(?:peak_stats|peak_statslog)-p\d+(?P<checkpoint>-exec\d+)?\.csv$"
+        r"^(?:(?:peak_stats|peak_statslog)-p\d+|"
+        r"(?:peak_stats|peak_statslog)-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+        r"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p\d+-q[0-9a-f]{16})"
+        r"(?P<checkpoint>-exec\d+)?\.csv$"
     )
     all_csv = sorted(tmpdir.glob("*.csv"))
     matched_csv = [(path, stats_name.fullmatch(path.name)) for path in all_csv]

--- a/test/exec_chain/run_exec_chain_check.py
+++ b/test/exec_chain/run_exec_chain_check.py
@@ -1101,19 +1101,29 @@ def run_fixture(args, tmpdir: Path, preload=True):
 
 
 def csv_files(tmpdir: Path):
-    stats_name = re.compile(
-        r"^(?:(?:peak_stats|peak_statslog)-p\d+|"
-        r"(?:peak_stats|peak_statslog)-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
-        r"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p\d+-q[0-9a-f]{16})"
+    identity_name = re.compile(
+        r"^(?:peak_stats|peak_statslog)-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+        r"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p\d+-q[0-9a-f]{16}"
         r"(?P<checkpoint>-exec\d+)?\.csv$"
     )
+    legacy_checkpoint = re.compile(
+        r"^(?:peak_stats|peak_statslog)-p\d+-exec\d+\.csv$"
+    )
     all_csv = sorted(tmpdir.glob("*.csv"))
-    matched_csv = [(path, stats_name.fullmatch(path.name)) for path in all_csv]
-    unexpected_csv = [path for path, match in matched_csv if match is None]
+    matched_csv = [(path, identity_name.fullmatch(path.name)) for path in all_csv]
+    unexpected_csv = [
+        path for path, match in matched_csv
+        if match is None and legacy_checkpoint.fullmatch(path.name) is None
+    ]
     require(not unexpected_csv,
             f"unexpected CSV artifacts in {tmpdir}: {unexpected_csv}")
-    exec_files = [path for path, match in matched_csv if match["checkpoint"]]
-    final_files = [path for path, match in matched_csv if not match["checkpoint"]]
+    exec_files = [
+        path for path, match in matched_csv
+        if (match is not None and match["checkpoint"]) or
+        legacy_checkpoint.fullmatch(path.name) is not None
+    ]
+    final_files = [path for path, match in matched_csv
+                   if match is not None and not match["checkpoint"]]
     return exec_files, final_files
 
 
@@ -1177,6 +1187,14 @@ def run_checkpoint_contract_self_test():
         _, final_files = csv_files(workdir)
         require(final_with_exec_metadata in final_files,
                 "identity metadata containing -exec was misclassified as checkpoint")
+        legacy_final = workdir / "peak_stats-p1.csv"
+        legacy_final.write_text("function,count\n", encoding="utf-8")
+        try:
+            csv_files(workdir)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("legacy PID-only final was accepted")
     print("exec_chain_checkpoint_contract_ok")
 
 

--- a/test/exec_chain/test_exec_chain_check_contracts.py
+++ b/test/exec_chain/test_exec_chain_check_contracts.py
@@ -74,6 +74,20 @@ class ExecChainCheckContractsTest(unittest.TestCase):
             self.assertEqual(finals, [final])
             self.assertEqual(checkpoints, [checkpoint])
 
+    def test_legacy_pid_only_final_is_rejected_but_checkpoint_is_allowed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            checkpoint = workdir / "peak_stats-p1-exec1.csv"
+            checkpoint.write_text("function,count\n", encoding="utf-8")
+            checkpoints, finals = checker.csv_files(workdir)
+            self.assertEqual(checkpoints, [checkpoint])
+            self.assertEqual(finals, [])
+            (workdir / "peak_stats-p1.csv").write_text(
+                "function,count\n", encoding="utf-8"
+            )
+            with self.assertRaises(AssertionError):
+                checker.csv_files(workdir)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/exec_chain/test_exec_chain_check_contracts.py
+++ b/test/exec_chain/test_exec_chain_check_contracts.py
@@ -57,6 +57,23 @@ class ExecChainCheckContractsTest(unittest.TestCase):
             )
             self.check_mode("execv_success_checkpoint", output, workdir)
 
+    def test_identity_exec_text_is_not_a_checkpoint_suffix(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            final = workdir / (
+                "peak_stats-jjob-exec-sstep-hhost-exec-r0-p1-"
+                "q0123456789abcdef.csv"
+            )
+            checkpoint = workdir / (
+                "peak_stats-jjob-exec-sstep-hhost-exec-r0-p1-"
+                "q0123456789abcdef-exec7.csv"
+            )
+            final.write_text("function,count\n", encoding="utf-8")
+            checkpoint.write_text("function,count\n", encoding="utf-8")
+            checkpoints, finals = checker.csv_files(workdir)
+            self.assertEqual(finals, [final])
+            self.assertEqual(checkpoints, [checkpoint])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/jit/run_jit_framework_metadata_check.py
+++ b/test/jit/run_jit_framework_metadata_check.py
@@ -31,10 +31,18 @@ def merge_preload(libpeak):
 
 
 def find_stats_csv(stats_prefix, pid):
-    candidates = sorted(glob.glob(f"{stats_prefix}-j*-s*-h*-r*-p{pid}-q????????????????.csv"))
-    if len(candidates) == 1:
-        return candidates[0]
-    return None
+    expression = re.compile(
+        rf"^{re.escape(stats_prefix)}-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+        rf"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p{pid}-q[0-9a-f]{{16}}\.csv$"
+    )
+    artifacts = sorted(glob.glob(f"{stats_prefix}-*.csv"))
+    unexpected = [path for path in artifacts if expression.fullmatch(path) is None]
+    if unexpected:
+        raise AssertionError(f"unexpected statistics CSV artifacts: {unexpected}")
+    candidates = [path for path in artifacts if expression.fullmatch(path)]
+    if len(candidates) != 1:
+        raise AssertionError(f"expected exactly one statistics CSV, got {candidates}")
+    return candidates[0]
 
 
 def symbol_count(rows, symbol):

--- a/test/jit/run_jit_framework_metadata_check.py
+++ b/test/jit/run_jit_framework_metadata_check.py
@@ -31,11 +31,7 @@ def merge_preload(libpeak):
 
 
 def find_stats_csv(stats_prefix, pid):
-    expected = f"{stats_prefix}-p{pid}.csv"
-    if os.path.exists(expected):
-        return expected
-
-    candidates = sorted(glob.glob(f"{stats_prefix}-p*.csv"))
+    candidates = sorted(glob.glob(f"{stats_prefix}-j*-s*-h*-r*-p{pid}-q????????????????.csv"))
     if len(candidates) == 1:
         return candidates[0]
     return None

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -157,11 +157,7 @@ def expected_attached_records(mode):
 
 
 def find_stats_csv(stats_prefix, pid):
-    expected = f"{stats_prefix}-p{pid}.csv"
-    if os.path.exists(expected):
-        return expected
-
-    candidates = sorted(glob.glob(f"{stats_prefix}-p*.csv"))
+    candidates = sorted(glob.glob(f"{stats_prefix}-j*-s*-h*-r*-p{pid}-q????????????????.csv"))
     if len(candidates) == 1:
         return candidates[0]
     return None

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -157,10 +157,20 @@ def expected_attached_records(mode):
 
 
 def find_stats_csv(stats_prefix, pid):
-    candidates = sorted(glob.glob(f"{stats_prefix}-j*-s*-h*-r*-p{pid}-q????????????????.csv"))
-    if len(candidates) == 1:
-        return candidates[0]
-    return None
+    expression = re.compile(
+        rf"^{re.escape(stats_prefix)}-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
+        rf"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p{pid}-q[0-9a-f]{{16}}\.csv$"
+    )
+    artifacts = sorted(glob.glob(f"{stats_prefix}-*.csv"))
+    unexpected = [path for path in artifacts if expression.fullmatch(path) is None]
+    if unexpected:
+        raise AssertionError(f"unexpected statistics CSV artifacts: {unexpected}")
+    candidates = [path for path in artifacts if expression.fullmatch(path)]
+    if not candidates:
+        return None
+    if len(candidates) != 1:
+        raise AssertionError(f"expected exactly one statistics CSV, got {candidates}")
+    return candidates[0]
 
 
 def parse_stats_csv(path):

--- a/test/memory/test_memlog_safety.c
+++ b/test/memory/test_memlog_safety.c
@@ -168,6 +168,37 @@ static int run_multithread_stress(void)
                    "export did not use only the fully committed records");
 }
 
+static int run_output_no_clobber(void)
+{
+    char path[256];
+    FILE* file;
+    char contents[32] = {0};
+
+    if (snprintf(path, sizeof(path), "/tmp/peak-memlog-no-clobber-%ld.csv",
+                 (long)getpid()) >= (int)sizeof(path)) return 1;
+    file = fopen(path, "w");
+    if (!expect(file != NULL, "could not create preserved CSV")) return 1;
+    if (!expect(fputs("preserved\n", file) >= 0, "could not seed preserved CSV") ||
+        !expect(fclose(file) == 0, "could not close preserved CSV")) return 1;
+    if (!expect(setenv("PEAK_MEMLOG_TEMPLATE", path, 1) == 0,
+                "could not set memlog template")) return 1;
+    if (!expect(peak_memlog_test_open(4), "memlog did not open")) return 1;
+    peak_memlog_test_log_event(2, 1, 1, 1);
+    peak_memlog_test_finalize();
+    file = fopen(path, "r");
+    if (!expect(file != NULL, "preserved CSV disappeared")) return 1;
+    if (!expect(fgets(contents, sizeof(contents), file) != NULL &&
+                strcmp(contents, "preserved\n") == 0,
+                "memlog replaced an existing CSV")) {
+        fclose(file);
+        return 1;
+    }
+    fclose(file);
+    unlink(path);
+    unsetenv("PEAK_MEMLOG_TEMPLATE");
+    return 0;
+}
+
 int main(int argc, char** argv)
 {
     if (argc != 2) return 2;
@@ -178,6 +209,7 @@ int main(int argc, char** argv)
     if (strcmp(argv[1], "capacity") == 0) return run_capacity();
     if (strcmp(argv[1], "stalled") == 0) return run_stalled_writer();
     if (strcmp(argv[1], "stress") == 0) return run_multithread_stress();
+    if (strcmp(argv[1], "no-clobber") == 0) return run_output_no_clobber();
     if (strcmp(argv[1], "realloc") == 0) {
         gum_init_embedded();
         int result = !peak_malloc_test_failed_realloc_preserves_accounting();

--- a/test/report/test_output_identity.c
+++ b/test/report/test_output_identity.c
@@ -170,6 +170,43 @@ run_template_overlong(const char *directory, int expanded)
 }
 
 static int
+run_template_raw_overlong_but_renderable(const char *directory)
+{
+    char base[PATH_MAX];
+    char template_path[PATH_MAX + 128];
+    char final_path[PATH_MAX];
+    char checkpoint_path[PATH_MAX];
+    char expected_checkpoint[PATH_MAX];
+    size_t used;
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    assert(snprintf(template_path, sizeof(template_path), "%s/", directory) <
+           (int)sizeof(template_path));
+    used = strlen(template_path);
+    while (used + sizeof("{jobid}/") < sizeof(template_path)) {
+        memcpy(template_path + used, "{jobid}/", sizeof("{jobid}/") - 1);
+        used += sizeof("{jobid}/") - 1;
+    }
+    memcpy(template_path + used, "report", sizeof("report"));
+    assert(used > PATH_MAX);
+    set_common(base);
+    assert(setenv("SLURM_JOB_ID", "x", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) == 0);
+    peak_output_identity_initialize();
+    if (!peak_output_identity_path(final_path, sizeof(final_path), base,
+                                   template_path, ".csv", -1)) {
+        return 1;
+    }
+    if (checkpoint(checkpoint_path) != PEAK_OUTPUT_CHECKPOINT_READY ||
+        snprintf(expected_checkpoint, sizeof(expected_checkpoint), "%s-exec7.csv",
+                 final_path) >= (int)sizeof(expected_checkpoint) ||
+        strcmp(checkpoint_path, expected_checkpoint) != 0) {
+        return 1;
+    }
+    return write_cached_checkpoint();
+}
+
+static int
 run_concurrent(const char *directory)
 {
     char base[PATH_MAX];
@@ -259,6 +296,8 @@ main(int argc, char **argv)
             rc = run_template_overlong(directory, 0);
         else if (strcmp(argv[1], "template-expanded-overlong") == 0)
             rc = run_template_overlong(directory, 1);
+        else if (strcmp(argv[1], "template-raw-overlong-renderable") == 0)
+            rc = run_template_raw_overlong_but_renderable(directory);
         else if (strcmp(argv[1], "concurrent") == 0) rc = run_concurrent(directory);
         else if (strcmp(argv[1], "snapshot") == 0) rc = run_snapshot(directory);
         else if (strcmp(argv[1], "entropy-fallback") == 0) rc = run_entropy_fallback(directory);

--- a/test/report/test_output_identity.c
+++ b/test/report/test_output_identity.c
@@ -1,0 +1,241 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "internal/general_listener/output_identity.h"
+#include "internal/general_listener/exec_checkpoint_writer.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+enum { THREADS = 12 };
+
+struct identity_thread {
+    char path[PATH_MAX];
+    int ok;
+};
+
+static void *
+render_identity(void *opaque)
+{
+    struct identity_thread *thread = opaque;
+
+    thread->ok = peak_output_identity_path(thread->path, sizeof(thread->path),
+                                           getenv("PEAK_STATSLOG_PATH"),
+                                           getenv("PEAK_STATSLOG_TEMPLATE"),
+                                           ".csv", -1);
+    return NULL;
+}
+
+static int
+checkpoint(char path[PATH_MAX])
+{
+    return peak_output_identity_checkpoint_path(path, PATH_MAX, 7);
+}
+
+static int
+write_cached_checkpoint(void)
+{
+    PeakExecCheckpointRow row = {
+        .name = "identity",
+        .num_calls = 1,
+        .threads_seen = 1,
+        .total_time = 1.0,
+        .max_total_time = 1.0,
+        .min_total_time = 1.0,
+        .exclusive_time = 1.0,
+        .max_time = 1.0f,
+        .min_time = 1.0f,
+    };
+    char path[PATH_MAX];
+
+    if (peak_output_identity_checkpoint_path(path, sizeof(path), 0) != PEAK_OUTPUT_CHECKPOINT_READY ||
+        !peak_exec_checkpoint_write_rows(0, &row, 1, 0.0)) {
+        return 1;
+    }
+    return access(path, F_OK) == 0 ? 0 : 1;
+}
+
+static void
+set_common(const char *base)
+{
+    assert(setenv("PEAK_STATSLOG_PATH", base, 1) == 0);
+    assert(setenv("SLURM_JOB_ID", "job-exec", 1) == 0);
+    assert(setenv("SLURM_STEP_ID", "step", 1) == 0);
+    assert(setenv("PMI_RANK", "3", 1) == 0);
+}
+
+static int
+run_preinit(void)
+{
+    char path[PATH_MAX];
+
+    return checkpoint(path) == PEAK_OUTPUT_CHECKPOINT_PREINIT ? 0 : 1;
+}
+
+static int
+run_default(const char *directory)
+{
+    char base[PATH_MAX];
+    char path[PATH_MAX];
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    set_common(base);
+    peak_output_identity_initialize();
+    if (checkpoint(path) != PEAK_OUTPUT_CHECKPOINT_READY || strstr(path, "-jjob-exec-sstep-") == NULL ||
+        strstr(path, "-r3-p") == NULL || strstr(path, "-exec7.csv") == NULL) {
+        return 1;
+    }
+    return write_cached_checkpoint();
+}
+
+static int
+run_template(const char *directory, int with_extension)
+{
+    char base[PATH_MAX];
+    char template_path[PATH_MAX];
+    char path[PATH_MAX];
+    char parent[PATH_MAX];
+    char *slash;
+    struct stat status;
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    assert(snprintf(template_path, sizeof(template_path),
+                    "%s/nested/{jobid}/report%s", directory,
+                    with_extension ? ".csv" : "") < (int)sizeof(template_path));
+    set_common(base);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) == 0);
+    peak_output_identity_initialize();
+    if (checkpoint(path) != PEAK_OUTPUT_CHECKPOINT_READY ||
+        strstr(path, "/nested/job-exec/report-exec7.csv") == NULL) {
+        return 1;
+    }
+    assert(snprintf(parent, sizeof(parent), "%s", path) < (int)sizeof(parent));
+    slash = strrchr(parent, '/');
+    assert(slash != NULL);
+    *slash = '\0';
+    if (stat(parent, &status) != 0 || !S_ISDIR(status.st_mode)) return 1;
+    return write_cached_checkpoint();
+}
+
+static int
+run_invalid(const char *directory)
+{
+    char base[PATH_MAX];
+    char path[PATH_MAX];
+    char legacy[PATH_MAX];
+    PeakExecCheckpointRow row = {.name = "identity", .threads_seen = 1};
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    set_common(base);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", "/dev/null/no-cwd-leak.csv", 1) == 0);
+    peak_output_identity_initialize();
+    if (checkpoint(path) != PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE) return 1;
+    errno = 0;
+    if (peak_exec_checkpoint_write_rows(0, &row, 1, 0.0) || errno != EINVAL) return 1;
+    assert(snprintf(legacy, sizeof(legacy), "%s-p%ld-exec0.csv", base,
+                    (long)getpid()) < (int)sizeof(legacy));
+    return access(legacy, F_OK) != 0 ? 0 : 1;
+}
+
+static int
+run_concurrent(const char *directory)
+{
+    char base[PATH_MAX];
+    pthread_t threads[THREADS];
+    struct identity_thread results[THREADS] = {{0}};
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    set_common(base);
+    for (int i = 0; i < THREADS; i++)
+        assert(pthread_create(&threads[i], NULL, render_identity, &results[i]) == 0);
+    for (int i = 0; i < THREADS; i++) {
+        assert(pthread_join(threads[i], NULL) == 0);
+        if (!results[i].ok || strcmp(results[0].path, results[i].path) != 0) return 1;
+    }
+    return 0;
+}
+
+static int
+run_snapshot(const char *directory)
+{
+    char base[PATH_MAX];
+    char path[PATH_MAX];
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    set_common(base);
+    peak_output_identity_initialize();
+    assert(setenv("SLURM_JOB_ID", "mutated", 1) == 0);
+    assert(unsetenv("PMI_RANK") == 0);
+    return peak_output_identity_path(path, sizeof(path), base, NULL, ".csv", -1) &&
+                   strstr(path, "-jjob-exec-") != NULL && strstr(path, "-r3-") != NULL
+               ? 0 : 1;
+}
+
+static int
+run_entropy_fallback(const char *directory)
+{
+    char base[PATH_MAX];
+    int pipes[2][2];
+    char paths[2][PATH_MAX] = {{0}};
+
+    assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
+    set_common(base);
+    assert(setenv("PEAK_TEST_OUTPUT_IDENTITY_ENTROPY_FAIL", "1", 1) == 0);
+    for (int index = 0; index < 2; index++) {
+        pid_t child;
+
+        assert(pipe(pipes[index]) == 0);
+        child = fork();
+        assert(child >= 0);
+        if (child == 0) {
+            char path[PATH_MAX];
+            (void)close(pipes[index][0]);
+            peak_output_identity_initialize();
+            if (checkpoint(path) != PEAK_OUTPUT_CHECKPOINT_READY ||
+                write(pipes[index][1], path, sizeof(path)) != (ssize_t)sizeof(path)) {
+                _exit(1);
+            }
+            _exit(0);
+        }
+        (void)close(pipes[index][1]);
+        if (read(pipes[index][0], paths[index], sizeof(paths[index])) !=
+            (ssize_t)sizeof(paths[index]) || waitpid(child, NULL, 0) != child) {
+            return 1;
+        }
+        (void)close(pipes[index][0]);
+    }
+    return strstr(paths[0], "-q0000000000000000") == NULL &&
+                   strcmp(paths[0], paths[1]) != 0
+               ? 0 : 1;
+}
+
+int
+main(int argc, char **argv)
+{
+    char directory[] = "/tmp/peak-output-identity-XXXXXX";
+    int rc;
+
+    if (argc != 2) return 2;
+    if (strcmp(argv[1], "preinit") == 0) rc = run_preinit();
+    else {
+        if (mkdtemp(directory) == NULL) return 2;
+        if (strcmp(argv[1], "default") == 0) rc = run_default(directory);
+        else if (strcmp(argv[1], "template-csv") == 0) rc = run_template(directory, 1);
+        else if (strcmp(argv[1], "template-bare") == 0) rc = run_template(directory, 0);
+        else if (strcmp(argv[1], "invalid") == 0) rc = run_invalid(directory);
+        else if (strcmp(argv[1], "concurrent") == 0) rc = run_concurrent(directory);
+        else if (strcmp(argv[1], "snapshot") == 0) rc = run_snapshot(directory);
+        else if (strcmp(argv[1], "entropy-fallback") == 0) rc = run_entropy_fallback(directory);
+        else return 2;
+    }
+    if (rc != 0) return rc;
+    puts("output_identity_test_ok");
+    return 0;
+}

--- a/test/report/test_output_identity.c
+++ b/test/report/test_output_identity.c
@@ -125,7 +125,7 @@ run_template(const char *directory, int with_extension)
 }
 
 static int
-run_invalid(const char *directory)
+run_invalid_template(const char *directory, const char *template_path)
 {
     char base[PATH_MAX];
     char path[PATH_MAX];
@@ -134,7 +134,7 @@ run_invalid(const char *directory)
 
     assert(snprintf(base, sizeof(base), "%s/stats", directory) < (int)sizeof(base));
     set_common(base);
-    assert(setenv("PEAK_STATSLOG_TEMPLATE", "/dev/null/no-cwd-leak.csv", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) == 0);
     peak_output_identity_initialize();
     if (checkpoint(path) != PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE) return 1;
     errno = 0;
@@ -142,6 +142,31 @@ run_invalid(const char *directory)
     assert(snprintf(legacy, sizeof(legacy), "%s-p%ld-exec0.csv", base,
                     (long)getpid()) < (int)sizeof(legacy));
     return access(legacy, F_OK) != 0 ? 0 : 1;
+}
+
+static int
+run_invalid(const char *directory)
+{
+    return run_invalid_template(directory, "/dev/null/no-cwd-leak.csv");
+}
+
+static int
+run_template_overlong(const char *directory, int expanded)
+{
+    char template_path[PATH_MAX + 32];
+    size_t used = 0;
+
+    if (!expanded) {
+        memset(template_path, 'x', sizeof(template_path) - 1);
+        template_path[sizeof(template_path) - 1] = '\0';
+    } else {
+        while (used + sizeof("{session}") < sizeof(template_path) - 1) {
+            memcpy(template_path + used, "{session}", sizeof("{session}") - 1);
+            used += sizeof("{session}") - 1;
+        }
+        template_path[used] = '\0';
+    }
+    return run_invalid_template(directory, template_path);
 }
 
 static int
@@ -230,6 +255,10 @@ main(int argc, char **argv)
         else if (strcmp(argv[1], "template-csv") == 0) rc = run_template(directory, 1);
         else if (strcmp(argv[1], "template-bare") == 0) rc = run_template(directory, 0);
         else if (strcmp(argv[1], "invalid") == 0) rc = run_invalid(directory);
+        else if (strcmp(argv[1], "template-overlong") == 0)
+            rc = run_template_overlong(directory, 0);
+        else if (strcmp(argv[1], "template-expanded-overlong") == 0)
+            rc = run_template_overlong(directory, 1);
         else if (strcmp(argv[1], "concurrent") == 0) rc = run_concurrent(directory);
         else if (strcmp(argv[1], "snapshot") == 0) rc = run_snapshot(directory);
         else if (strcmp(argv[1], "entropy-fallback") == 0) rc = run_entropy_fallback(directory);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -301,6 +301,7 @@ check_rank_local_csv_names(const char* stats_base,
     char rank_path[768];
     char hostname[TEST_HOSTNAME_CAPACITY] = {0};
     char hostname_path[1024];
+    char strict_hostname_path[1024];
     PeakReportSnapshot* snapshot = create_fixture("rank-local");
 
     clear_launcher_environment();
@@ -350,10 +351,15 @@ check_rank_local_csv_names(const char* stats_base,
 
     /* Strict MPI fallback naming reduces cross-node PID collision risk. */
     clear_launcher_environment();
+    assert(snprintf(strict_hostname_path, sizeof(strict_hostname_path),
+                    "%.*s-ranklocal-h%s.csv",
+                    (int)(strlen(hostname_path) - 4), hostname_path,
+                    hostname) > 0);
     assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
         snapshot));
-    assert(access(hostname_path, F_OK) == 0);
-    assert(unlink(hostname_path) == 0);
+    assert(access(hostname_path, F_OK) != 0);
+    assert(access(strict_hostname_path, F_OK) == 0);
+    assert(unlink(strict_hostname_path) == 0);
 
     clear_launcher_environment();
     peak_report_snapshot_destroy(snapshot);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -456,7 +456,7 @@ check_strict_rank_local_bounded_names(void)
     assert(unlink(strict_path) == 0);
 
     /* A runtime component limit below the shortest safe strict name fails. */
-    assert(setenv("PEAK_TEST_REPORT_NAME_MAX", "33", 1) == 0);
+    assert(setenv("PEAK_TEST_REPORT_NAME_MAX", "20", 1) == 0);
     assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
     assert(!peak_report_formatter_write_rank_local_csv_host_disambiguated(
         snapshot));
@@ -884,6 +884,117 @@ check_template_parent_creation(const char* temp_directory)
 }
 
 static void
+check_near_path_max_destination(const char* temp_directory)
+{
+    enum { FINAL_LENGTH = PATH_MAX - 7, COMPONENT_LENGTH = 240 };
+    static const char final_name[] = "final.csv";
+    char directories[32][PATH_MAX];
+    char current_directory[PATH_MAX];
+    char final_path[PATH_MAX];
+    char component[COMPONENT_LENGTH + 1];
+    char* strict_name = NULL;
+    FILE* direct;
+    DIR* stream;
+    struct dirent* entry;
+    int directory_fd;
+    size_t depth = 0;
+    PeakReportSnapshot* first = create_fixture("near-path-first");
+    PeakReportSnapshot* second = create_fixture("near-path-second");
+    char* contents;
+
+    assert(strlen(temp_directory) + 1 + strlen(final_name) < FINAL_LENGTH);
+    assert(snprintf(directories[depth], sizeof(directories[depth]), "%s",
+                    temp_directory) > 0);
+    while (strlen(directories[depth]) + 1 + strlen(final_name) <
+           FINAL_LENGTH) {
+        size_t remaining = FINAL_LENGTH - strlen(directories[depth]) - 1 -
+                           strlen(final_name);
+        size_t component_length = remaining > COMPONENT_LENGTH + 1 ?
+                                      COMPONENT_LENGTH : remaining - 1;
+
+        assert(component_length != 0);
+        assert(depth + 1 < sizeof(directories) / sizeof(directories[0]));
+        memset(component, 'n', component_length);
+        component[component_length] = '\0';
+        assert(snprintf(current_directory, sizeof(current_directory), "%s",
+                        directories[depth]) > 0);
+        assert(snprintf(directories[depth + 1], PATH_MAX, "%s/%s",
+                        current_directory, component) < PATH_MAX);
+        assert(mkdir(directories[depth + 1], 0700) == 0);
+        depth++;
+    }
+    assert(snprintf(final_path, sizeof(final_path), "%s/%s", directories[depth],
+                    final_name) == FINAL_LENGTH);
+
+    /* A legal final pathname at this length must work before PEAK uses it. */
+    direct = fopen(final_path, "wx");
+    assert(direct != NULL);
+    assert(fputs("direct-final-path-ok\n", direct) >= 0);
+    assert(fclose(direct) == 0);
+    assert(unlink(final_path) == 0);
+
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", final_path, 1) == 0);
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", "near-path-host", 1) == 0);
+    peak_report_snapshot_prepare_for_render(first);
+    assert(peak_report_formatter_write_csv(first));
+    contents = read_file(final_path);
+    assert(strstr(contents, "near-path-first") != NULL);
+    free(contents);
+
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        first));
+    directory_fd = open(directories[depth], O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    assert(directory_fd >= 0);
+    stream = fdopendir(dup(directory_fd));
+    assert(stream != NULL);
+    while ((entry = readdir(stream)) != NULL) {
+        if (strstr(entry->d_name, "-ranklocal-h") != NULL) {
+            assert(strict_name == NULL);
+            assert(strlen(entry->d_name) <= (size_t)fpathconf(directory_fd,
+                                                               _PC_NAME_MAX));
+            strict_name = strdup(entry->d_name);
+            assert(strict_name != NULL);
+        }
+        assert(strstr(entry->d_name, ".tmp.") == NULL);
+        assert(strstr(entry->d_name, ".peak-tmp.") == NULL);
+    }
+    assert(closedir(stream) == 0);
+    assert(strict_name != NULL);
+    direct = fdopen(openat(directory_fd, strict_name, O_RDONLY | O_CLOEXEC), "r");
+    assert(direct != NULL);
+    contents = read_stream(direct);
+    assert(fclose(direct) == 0);
+    assert(strstr(contents, "near-path-first") != NULL);
+    free(contents);
+
+    peak_report_snapshot_prepare_for_render(second);
+    assert(!peak_report_formatter_write_csv(second));
+    contents = read_file(final_path);
+    assert(strstr(contents, "near-path-first") != NULL);
+    assert(strstr(contents, "near-path-second") == NULL);
+    free(contents);
+    assert(setenv("PEAK_OUTPUT_ALLOW_OVERWRITE", "1", 1) == 0);
+    assert(peak_report_formatter_write_csv(second));
+    assert(unsetenv("PEAK_OUTPUT_ALLOW_OVERWRITE") == 0);
+    contents = read_file(final_path);
+    assert(strstr(contents, "near-path-first") == NULL);
+    assert(strstr(contents, "near-path-second") != NULL);
+    free(contents);
+
+    assert(unlinkat(directory_fd, strict_name, 0) == 0);
+    assert(unlink(final_path) == 0);
+    free(strict_name);
+    assert(close(directory_fd) == 0);
+    assert(unsetenv("PEAK_TEST_REPORT_HOSTNAME") == 0);
+    peak_report_snapshot_destroy(second);
+    peak_report_snapshot_destroy(first);
+    while (depth != 0) {
+        assert(rmdir(directories[depth]) == 0);
+        depth--;
+    }
+}
+
+static void
 check_output_identity_metadata(void)
 {
     char path[512];
@@ -943,6 +1054,7 @@ main(void)
     check_concurrent_no_clobber(temp_directory);
     check_template_parent_creation(temp_directory);
     check_strict_rank_local_bounded_names();
+    check_near_path_max_destination(temp_directory);
 
     assert(unsetenv("PEAK_STATSLOG_PATH") == 0);
     assert(unsetenv("PEAK_STATSLOG_TEMPLATE") == 0);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include "internal/general_listener/report_formatter.h"
+#include "internal/general_listener/output_identity.h"
 
 #include <assert.h>
 #include <dirent.h>
@@ -12,6 +13,7 @@
 #include <string.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 enum { TEST_HOSTNAME_CAPACITY = 256 };
@@ -308,6 +310,7 @@ check_rank_local_csv_names(const char* stats_base,
     peak_report_snapshot_prepare_for_render(snapshot);
 
     /* Aggregate naming remains unchanged even inside a multi-rank job. */
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
     assert(peak_report_formatter_write_csv(snapshot));
     assert(access(aggregate_path, F_OK) == 0);
     assert(unlink(aggregate_path) == 0);
@@ -317,6 +320,7 @@ check_rank_local_csv_names(const char* stats_base,
                     "%s-p%d-r3.csv",
                     stats_base,
                     (int)getpid()) > 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", rank_path, 1) == 0);
     assert(peak_report_formatter_write_rank_local_csv(snapshot));
     assert(access(rank_path, F_OK) == 0);
     assert(access(aggregate_path, F_OK) != 0);
@@ -331,6 +335,7 @@ check_rank_local_csv_names(const char* stats_base,
                     stats_base,
                     (int)getpid(),
                     hostname) > 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", hostname_path, 1) == 0);
     assert(peak_report_formatter_write_rank_local_csv(snapshot));
     assert(access(hostname_path, F_OK) == 0);
     assert(unlink(hostname_path) == 0);
@@ -361,6 +366,7 @@ check_csv_permissions(const char* csv_path)
     struct stat attributes;
     mode_t previous_umask;
 
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
     peak_report_snapshot_prepare_for_render(snapshot);
     previous_umask = umask(0027);
     assert(peak_report_formatter_write_csv(snapshot));
@@ -379,6 +385,7 @@ check_no_output(const char* csv_path)
     char* text;
 
     assert(snapshot != NULL);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
     assert(peak_report_snapshot_set_program(snapshot, "idle"));
     assert(peak_report_snapshot_set_name(snapshot, 0, "idle_hook"));
     snapshot->instrumented[0] = 1;
@@ -399,6 +406,7 @@ check_dropped_only_output(const char* csv_path)
     char* csv;
 
     assert(snapshot != NULL);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
     assert(peak_report_snapshot_set_program(snapshot, "dropped-only"));
     assert(peak_report_snapshot_set_name(snapshot, 0, "untracked"));
     snapshot->instrumented[0] = 1;
@@ -507,6 +515,7 @@ check_long_stats_path(const char* temp_directory)
     assert(snprintf(csv_path, sizeof(csv_path), "%s-p%d.csv",
                     stats_base, (int)getpid()) > 0);
     assert(setenv("PEAK_STATSLOG_PATH", stats_base, 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
 
     peak_report_snapshot_prepare_for_render(snapshot);
     assert(peak_report_formatter_write_csv(snapshot));
@@ -540,6 +549,7 @@ check_failed_csv_never_replaces_final(const char* temp_directory)
     assert(snprintf(csv_path, sizeof(csv_path), "%s-p%d.csv",
                     stats_base, (int)getpid()) > 0);
     assert(setenv("PEAK_STATSLOG_PATH", stats_base, 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
     existing = fopen(csv_path, "w");
     assert(existing != NULL);
     assert(fputs(preserved, existing) >= 0);
@@ -582,6 +592,144 @@ check_failed_csv_never_replaces_final(const char* temp_directory)
     peak_report_snapshot_destroy(snapshot);
 }
 
+static void
+check_output_template_and_no_clobber(const char* temp_directory)
+{
+    char stats_base[512];
+    char template_path[768];
+    char written_path[1024] = {0};
+    DIR* directory;
+    struct dirent* entry;
+    PeakReportSnapshot* first = create_fixture("template-first");
+    PeakReportSnapshot* second = create_fixture("template-second");
+    char* contents;
+
+    assert(snprintf(stats_base, sizeof(stats_base), "%s/template", temp_directory) > 0);
+    assert(snprintf(template_path, sizeof(template_path),
+                    "%s/{jobid}-{stepid}-{host}-{rank}-{pid}-{session}.csv",
+                    temp_directory) > 0);
+    assert(setenv("SLURM_JOB_ID", "job-77", 1) == 0);
+    assert(setenv("SLURM_STEP_ID", "step-9", 1) == 0);
+    assert(setenv("SLURM_PROCID", "6", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_PATH", stats_base, 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) == 0);
+    peak_report_snapshot_prepare_for_render(first);
+    assert(peak_report_formatter_write_csv(first));
+
+    directory = opendir(temp_directory);
+    assert(directory != NULL);
+    while ((entry = readdir(directory)) != NULL) {
+        if (strstr(entry->d_name, "job-77-step-9-") == entry->d_name) {
+            assert(snprintf(written_path, sizeof(written_path), "%s/%s",
+                            temp_directory, entry->d_name) > 0);
+            break;
+        }
+    }
+    assert(closedir(directory) == 0);
+    assert(written_path[0] != '\0');
+    assert(strstr(written_path, "-5-") != NULL);
+    assert(strstr(written_path, "{session}") == NULL);
+    contents = read_file(written_path);
+    assert(strstr(contents, "template-first") != NULL);
+    free(contents);
+
+    peak_report_snapshot_prepare_for_render(second);
+    assert(!peak_report_formatter_write_csv(second));
+    contents = read_file(written_path);
+    assert(strstr(contents, "template-first") != NULL);
+    assert(strstr(contents, "template-second") == NULL);
+    free(contents);
+    assert(unlink(written_path) == 0);
+
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", "{unknown}", 1) == 0);
+    assert(!peak_report_formatter_write_csv(second));
+    assert(unsetenv("SLURM_JOB_ID") == 0);
+    assert(unsetenv("SLURM_STEP_ID") == 0);
+    assert(unsetenv("SLURM_PROCID") == 0);
+    peak_report_snapshot_destroy(second);
+    peak_report_snapshot_destroy(first);
+}
+
+static void
+check_concurrent_no_clobber(const char* temp_directory)
+{
+    char path[768];
+    int start[2];
+    pid_t child;
+    int child_status;
+    bool parent_success;
+    PeakReportSnapshot* snapshot = create_fixture("concurrent");
+
+    assert(snprintf(path, sizeof(path), "%s/concurrent.csv", temp_directory) > 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", path, 1) == 0);
+    peak_report_snapshot_prepare_for_render(snapshot);
+    assert(pipe(start) == 0);
+    child = fork();
+    assert(child >= 0);
+    if (child == 0) {
+        char signal;
+        (void)close(start[1]);
+        if (read(start[0], &signal, 1) != 1) _exit(2);
+        _exit(peak_report_formatter_write_csv(snapshot) ? 0 : 1);
+    }
+    assert(close(start[0]) == 0);
+    assert(write(start[1], "x", 1) == 1);
+    assert(close(start[1]) == 0);
+    parent_success = peak_report_formatter_write_csv(snapshot);
+    assert(waitpid(child, &child_status, 0) == child);
+    assert(WIFEXITED(child_status));
+    assert((parent_success ? 1 : 0) + (WEXITSTATUS(child_status) == 0 ? 1 : 0) == 1);
+    assert(access(path, F_OK) == 0);
+    assert(unlink(path) == 0);
+    peak_report_snapshot_destroy(snapshot);
+}
+
+static void
+check_template_parent_creation(const char* temp_directory)
+{
+    char template_path[768];
+    char final_path[768];
+    char directory_b[640];
+    char directory_a[640];
+    PeakReportSnapshot* snapshot = create_fixture("nested-template");
+
+    assert(snprintf(directory_a, sizeof(directory_a), "%s/./nested", temp_directory) > 0);
+    assert(snprintf(directory_b, sizeof(directory_b), "%s/job", directory_a) > 0);
+    assert(snprintf(template_path, sizeof(template_path), "%s/report.csv", directory_b) > 0);
+    assert(snprintf(final_path, sizeof(final_path), "%s", template_path) > 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", template_path, 1) == 0);
+    peak_report_snapshot_prepare_for_render(snapshot);
+    assert(peak_report_formatter_write_csv(snapshot));
+    assert(access(final_path, F_OK) == 0);
+    assert(unlink(final_path) == 0);
+    assert(rmdir(directory_b) == 0);
+    assert(rmdir(directory_a) == 0);
+    peak_report_snapshot_destroy(snapshot);
+}
+
+static void
+check_output_identity_metadata(void)
+{
+    char path[512];
+
+    assert(setenv("SLURM_JOB_ID", "job-77", 1) == 0);
+    assert(setenv("SLURM_STEP_ID", "step-9", 1) == 0);
+    assert(setenv("PMIX_RANK", "5", 1) == 0);
+    peak_output_identity_initialize();
+    assert(setenv("SLURM_JOB_ID", "../outside", 1) == 0);
+    assert(unsetenv("SLURM_STEP_ID") == 0);
+    assert(setenv("PMIX_RANK", "6", 1) == 0);
+    assert(peak_output_identity_path(path, sizeof(path), "ignored",
+                                     "/tmp/{jobid}/{stepid}/{rank}-{pid}-{session}.csv",
+                                     ".csv", -1));
+    assert(strstr(path, "/job-77/step-9/5-") != NULL);
+    assert(peak_output_identity_path(path, sizeof(path), "ignored",
+                                     "/tmp/{jobid}.csv", ".csv", -1));
+    assert(strcmp(path, "/tmp/job-77.csv") == 0);
+    assert(unsetenv("SLURM_JOB_ID") == 0);
+    assert(unsetenv("PMIX_RANK") == 0);
+}
+
 int
 main(void)
 {
@@ -590,6 +738,7 @@ main(void)
     char csv_path[768];
 
     assert(mkdtemp(temp_directory) != NULL);
+    check_output_identity_metadata();
     clear_launcher_environment();
     assert(snprintf(stats_base,
                     sizeof(stats_base),
@@ -601,6 +750,7 @@ main(void)
                     stats_base,
                     (int)getpid()) > 0);
     assert(setenv("PEAK_STATSLOG_PATH", stats_base, 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", csv_path, 1) == 0);
 
     check_csv_golden(csv_path);
     check_csv_quoted_name(csv_path);
@@ -613,8 +763,12 @@ main(void)
     check_text_flush_failure();
     check_long_stats_path(temp_directory);
     check_failed_csv_never_replaces_final(temp_directory);
+    check_output_template_and_no_clobber(temp_directory);
+    check_concurrent_no_clobber(temp_directory);
+    check_template_parent_creation(temp_directory);
 
     assert(unsetenv("PEAK_STATSLOG_PATH") == 0);
+    assert(unsetenv("PEAK_STATSLOG_TEMPLATE") == 0);
     assert(rmdir(temp_directory) == 0);
     puts("report_formatter_test_ok");
     return 0;

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -7,6 +7,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,6 +16,10 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
 
 enum { TEST_HOSTNAME_CAPACITY = 256 };
 
@@ -96,6 +101,28 @@ directory_has_prefix(const char* directory, const char* prefix)
     }
     assert(closedir(stream) == 0);
     return found;
+}
+
+static void
+remove_directory_files(const char* directory)
+{
+    DIR* stream = opendir(directory);
+    struct dirent* entry;
+
+    assert(stream != NULL);
+    while ((entry = readdir(stream)) != NULL) {
+        char path[PATH_MAX];
+
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        assert(snprintf(path, sizeof(path), "%s/%s", directory,
+                        entry->d_name) < (int)sizeof(path));
+        assert(unlink(path) == 0);
+    }
+    assert(closedir(stream) == 0);
+    assert(rmdir(directory) == 0);
 }
 
 static char*
@@ -363,6 +390,100 @@ check_rank_local_csv_names(const char* stats_base,
 
     clear_launcher_environment();
     peak_report_snapshot_destroy(snapshot);
+}
+
+static void
+check_strict_rank_local_bounded_names(void)
+{
+    char directory[] = "/tmp/peak_report_formatter_strict_XXXXXX";
+    char aggregate_path[PATH_MAX];
+    char strict_path[PATH_MAX];
+    char long_component[NAME_MAX + 1];
+    char long_hostname[255];
+    char alternate_long_hostname[255];
+    PeakReportSnapshot* snapshot = create_fixture("strict-name-boundary");
+    DIR* stream;
+    struct dirent* entry;
+    size_t entries = 0;
+    bool saw_aggregate = false;
+    size_t strict_entries = 0;
+
+    assert(mkdtemp(directory) != NULL);
+    peak_report_snapshot_prepare_for_render(snapshot);
+
+    assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/ordinary.csv",
+                    directory) < (int)sizeof(aggregate_path));
+    assert(snprintf(strict_path, sizeof(strict_path),
+                    "%s/ordinary-ranklocal-hnode-1.csv", directory) <
+           (int)sizeof(strict_path));
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", "node-1", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
+    assert(peak_report_formatter_write_csv(snapshot));
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    memcpy(alternate_long_hostname, long_hostname, sizeof(long_hostname));
+    alternate_long_hostname[sizeof(alternate_long_hostname) - 2] = 'i';
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", alternate_long_hostname, 1) == 0);
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    assert(access(aggregate_path, F_OK) == 0);
+    assert(access(strict_path, F_OK) == 0);
+    assert(!directory_has_prefix(directory, "ordinary.csv.tmp."));
+    assert(unlink(aggregate_path) == 0);
+    assert(unlink(strict_path) == 0);
+
+    assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/bare",
+                    directory) < (int)sizeof(aggregate_path));
+    assert(snprintf(strict_path, sizeof(strict_path),
+                    "%s/bare-ranklocal-hhost_____", directory) <
+           (int)sizeof(strict_path));
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", "host:/\\?*", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
+    assert(peak_report_formatter_write_csv(snapshot));
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    assert(access(aggregate_path, F_OK) == 0);
+    assert(access(strict_path, F_OK) == 0);
+    assert(!directory_has_prefix(directory, "bare.tmp."));
+    assert(unlink(aggregate_path) == 0);
+    assert(unlink(strict_path) == 0);
+
+    memset(long_component, 'a', NAME_MAX - 4);
+    memcpy(long_component + NAME_MAX - 4, ".csv", 5);
+    memset(long_hostname, 'h', sizeof(long_hostname) - 1);
+    long_hostname[sizeof(long_hostname) - 1] = '\0';
+    assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/%s",
+                    directory, long_component) < (int)sizeof(aggregate_path));
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", long_hostname, 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
+    assert(peak_report_formatter_write_csv(snapshot));
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    stream = opendir(directory);
+    assert(stream != NULL);
+    while ((entry = readdir(stream)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        entries++;
+        assert(strlen(entry->d_name) <= NAME_MAX);
+        assert(strstr(entry->d_name, ".tmp.") == NULL);
+        if (strcmp(entry->d_name, long_component) == 0) {
+            saw_aggregate = true;
+        }
+        if (strstr(entry->d_name, "-ranklocal-h") != NULL) {
+            strict_entries++;
+        }
+    }
+    assert(closedir(stream) == 0);
+    assert(entries == 3);
+    assert(saw_aggregate);
+    assert(strict_entries == 2);
+    assert(unsetenv("PEAK_TEST_REPORT_HOSTNAME") == 0);
+    clear_launcher_environment();
+    peak_report_snapshot_destroy(snapshot);
+    remove_directory_files(directory);
 }
 
 static void
@@ -780,6 +901,7 @@ main(void)
     check_output_template_and_no_clobber(temp_directory);
     check_concurrent_no_clobber(temp_directory);
     check_template_parent_creation(temp_directory);
+    check_strict_rank_local_bounded_names();
 
     assert(unsetenv("PEAK_STATSLOG_PATH") == 0);
     assert(unsetenv("PEAK_STATSLOG_TEMPLATE") == 0);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -861,6 +861,55 @@ check_concurrent_no_clobber(const char* temp_directory)
 }
 
 static void
+check_post_publish_temp_cleanup(const char* directory,
+                                const char* filename,
+                                bool compact_temp)
+{
+    char path[PATH_MAX];
+    char temp_prefix[NAME_MAX + 32];
+    PeakReportSnapshot* first = create_fixture("cleanup-first");
+    PeakReportSnapshot* second = create_fixture("cleanup-second");
+    char* contents;
+
+    assert(snprintf(path, sizeof(path), "%s/%s", directory, filename) <
+           (int)sizeof(path));
+    assert(compact_temp ?
+               snprintf(temp_prefix, sizeof(temp_prefix), ".peak-tmp.") > 0 :
+               snprintf(temp_prefix, sizeof(temp_prefix), "%s.tmp.", filename) > 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", path, 1) == 0);
+    assert(setenv("PEAK_TEST_REPORT_FAIL_POST_PUBLISH_TEMP_UNLINK", "1", 1) == 0);
+    peak_report_snapshot_prepare_for_render(first);
+    assert(!peak_report_formatter_write_csv(first));
+    assert(unsetenv("PEAK_TEST_REPORT_FAIL_POST_PUBLISH_TEMP_UNLINK") == 0);
+    contents = read_file(path);
+    assert(strstr(contents, "cleanup-first") != NULL);
+    free(contents);
+    assert(!directory_has_prefix(directory, temp_prefix));
+
+    peak_report_snapshot_prepare_for_render(second);
+    assert(!peak_report_formatter_write_csv(second));
+    contents = read_file(path);
+    assert(strstr(contents, "cleanup-first") != NULL);
+    assert(strstr(contents, "cleanup-second") == NULL);
+    free(contents);
+    assert(!directory_has_prefix(directory, temp_prefix));
+    assert(unlink(path) == 0);
+    peak_report_snapshot_destroy(second);
+    peak_report_snapshot_destroy(first);
+}
+
+static void
+check_post_publish_temp_cleanup_failures(const char* temp_directory)
+{
+    char compact_name[NAME_MAX + 1];
+
+    check_post_publish_temp_cleanup(temp_directory, "cleanup-ordinary.csv", false);
+    memset(compact_name, 't', NAME_MAX - 4);
+    memcpy(compact_name + NAME_MAX - 4, ".csv", 5);
+    check_post_publish_temp_cleanup(temp_directory, compact_name, true);
+}
+
+static void
 check_template_parent_creation(const char* temp_directory)
 {
     char template_path[768];
@@ -1052,6 +1101,7 @@ main(void)
     check_failed_csv_never_replaces_final(temp_directory);
     check_output_template_and_no_clobber(temp_directory);
     check_concurrent_no_clobber(temp_directory);
+    check_post_publish_temp_cleanup_failures(temp_directory);
     check_template_parent_creation(temp_directory);
     check_strict_rank_local_bounded_names();
     check_near_path_max_destination(temp_directory);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -125,6 +125,36 @@ remove_directory_files(const char* directory)
     assert(rmdir(directory) == 0);
 }
 
+static size_t
+collect_strict_rank_local_files(const char* directory,
+                                char paths[][PATH_MAX],
+                                size_t capacity)
+{
+    DIR* stream = opendir(directory);
+    struct dirent* entry;
+    size_t count = 0;
+
+    assert(stream != NULL);
+    while ((entry = readdir(stream)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        assert(strlen(entry->d_name) <= NAME_MAX);
+        assert(strstr(entry->d_name, ".tmp.") == NULL);
+        assert(strstr(entry->d_name, ".peak-tmp.") == NULL);
+        if (strstr(entry->d_name, "-ranklocal-h") == NULL) {
+            continue;
+        }
+        assert(count < capacity);
+        assert(snprintf(paths[count], PATH_MAX, "%s/%s", directory,
+                        entry->d_name) < PATH_MAX);
+        count++;
+    }
+    assert(closedir(stream) == 0);
+    return count;
+}
+
 static char*
 read_stream(FILE* stream)
 {
@@ -395,47 +425,40 @@ check_rank_local_csv_names(const char* stats_base,
 static void
 check_strict_rank_local_bounded_names(void)
 {
-    char directory[] = "/tmp/peak_report_formatter_strict_XXXXXX";
+    char ordinary_directory[] = "/tmp/peak_report_formatter_strict_XXXXXX";
+    char long_directory[] = "/tmp/peak_report_formatter_long_XXXXXX";
     char aggregate_path[PATH_MAX];
     char strict_path[PATH_MAX];
+    char strict_paths[2][PATH_MAX];
     char long_component[NAME_MAX + 1];
     char long_hostname[255];
     char alternate_long_hostname[255];
     PeakReportSnapshot* snapshot = create_fixture("strict-name-boundary");
-    DIR* stream;
-    struct dirent* entry;
-    size_t entries = 0;
-    bool saw_aggregate = false;
-    size_t strict_entries = 0;
+    char* contents;
 
-    assert(mkdtemp(directory) != NULL);
+    assert(mkdtemp(ordinary_directory) != NULL);
     peak_report_snapshot_prepare_for_render(snapshot);
 
     assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/ordinary.csv",
-                    directory) < (int)sizeof(aggregate_path));
+                    ordinary_directory) < (int)sizeof(aggregate_path));
     assert(snprintf(strict_path, sizeof(strict_path),
-                    "%s/ordinary-ranklocal-hnode-1.csv", directory) <
+                    "%s/ordinary-ranklocal-hnode-1.csv", ordinary_directory) <
            (int)sizeof(strict_path));
     assert(setenv("PEAK_TEST_REPORT_HOSTNAME", "node-1", 1) == 0);
     assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
     assert(peak_report_formatter_write_csv(snapshot));
     assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
         snapshot));
-    memcpy(alternate_long_hostname, long_hostname, sizeof(long_hostname));
-    alternate_long_hostname[sizeof(alternate_long_hostname) - 2] = 'i';
-    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", alternate_long_hostname, 1) == 0);
-    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
-        snapshot));
     assert(access(aggregate_path, F_OK) == 0);
     assert(access(strict_path, F_OK) == 0);
-    assert(!directory_has_prefix(directory, "ordinary.csv.tmp."));
+    assert(!directory_has_prefix(ordinary_directory, "ordinary.csv.tmp."));
     assert(unlink(aggregate_path) == 0);
     assert(unlink(strict_path) == 0);
 
     assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/bare",
-                    directory) < (int)sizeof(aggregate_path));
+                    ordinary_directory) < (int)sizeof(aggregate_path));
     assert(snprintf(strict_path, sizeof(strict_path),
-                    "%s/bare-ranklocal-hhost_____", directory) <
+                    "%s/bare-ranklocal-hhost_____", ordinary_directory) <
            (int)sizeof(strict_path));
     assert(setenv("PEAK_TEST_REPORT_HOSTNAME", "host:/\\?*", 1) == 0);
     assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
@@ -444,46 +467,44 @@ check_strict_rank_local_bounded_names(void)
         snapshot));
     assert(access(aggregate_path, F_OK) == 0);
     assert(access(strict_path, F_OK) == 0);
-    assert(!directory_has_prefix(directory, "bare.tmp."));
+    assert(!directory_has_prefix(ordinary_directory, "bare.tmp."));
     assert(unlink(aggregate_path) == 0);
     assert(unlink(strict_path) == 0);
+    assert(rmdir(ordinary_directory) == 0);
 
     memset(long_component, 'a', NAME_MAX - 4);
     memcpy(long_component + NAME_MAX - 4, ".csv", 5);
     memset(long_hostname, 'h', sizeof(long_hostname) - 1);
     long_hostname[sizeof(long_hostname) - 1] = '\0';
+    memcpy(alternate_long_hostname, long_hostname, sizeof(long_hostname));
+    alternate_long_hostname[sizeof(alternate_long_hostname) - 2] = 'i';
+    assert(mkdtemp(long_directory) != NULL);
     assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/%s",
-                    directory, long_component) < (int)sizeof(aggregate_path));
+                    long_directory, long_component) < (int)sizeof(aggregate_path));
     assert(setenv("PEAK_TEST_REPORT_HOSTNAME", long_hostname, 1) == 0);
     assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
     assert(peak_report_formatter_write_csv(snapshot));
     assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
         snapshot));
-    stream = opendir(directory);
-    assert(stream != NULL);
-    while ((entry = readdir(stream)) != NULL) {
-        if (strcmp(entry->d_name, ".") == 0 ||
-            strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
-        entries++;
-        assert(strlen(entry->d_name) <= NAME_MAX);
-        assert(strstr(entry->d_name, ".tmp.") == NULL);
-        if (strcmp(entry->d_name, long_component) == 0) {
-            saw_aggregate = true;
-        }
-        if (strstr(entry->d_name, "-ranklocal-h") != NULL) {
-            strict_entries++;
-        }
+    assert(collect_strict_rank_local_files(long_directory, strict_paths, 2) == 1);
+    assert(setenv("PEAK_TEST_REPORT_HOSTNAME", alternate_long_hostname, 1) == 0);
+    assert(peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    assert(collect_strict_rank_local_files(long_directory, strict_paths, 2) == 2);
+    assert(strcmp(strict_paths[0], strict_paths[1]) != 0);
+    assert(access(aggregate_path, F_OK) == 0);
+    contents = read_file(aggregate_path);
+    assert(strstr(contents, "function,") != NULL);
+    free(contents);
+    for (size_t index = 0; index < 2; index++) {
+        contents = read_file(strict_paths[index]);
+        assert(strstr(contents, "function,") != NULL);
+        free(contents);
     }
-    assert(closedir(stream) == 0);
-    assert(entries == 3);
-    assert(saw_aggregate);
-    assert(strict_entries == 2);
     assert(unsetenv("PEAK_TEST_REPORT_HOSTNAME") == 0);
     clear_launcher_environment();
     peak_report_snapshot_destroy(snapshot);
-    remove_directory_files(directory);
+    remove_directory_files(long_directory);
 }
 
 static void

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -639,6 +639,14 @@ check_output_template_and_no_clobber(const char* temp_directory)
     assert(strstr(contents, "template-first") != NULL);
     assert(strstr(contents, "template-second") == NULL);
     free(contents);
+
+    assert(setenv("PEAK_OUTPUT_ALLOW_OVERWRITE", "1", 1) == 0);
+    assert(peak_report_formatter_write_csv(second));
+    contents = read_file(written_path);
+    assert(strstr(contents, "template-first") == NULL);
+    assert(strstr(contents, "template-second") != NULL);
+    free(contents);
+    assert(unsetenv("PEAK_OUTPUT_ALLOW_OVERWRITE") == 0);
     assert(unlink(written_path) == 0);
 
     assert(setenv("PEAK_STATSLOG_TEMPLATE", "{unknown}", 1) == 0);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -455,6 +455,14 @@ check_strict_rank_local_bounded_names(void)
     assert(unlink(aggregate_path) == 0);
     assert(unlink(strict_path) == 0);
 
+    /* A runtime component limit below the shortest safe strict name fails. */
+    assert(setenv("PEAK_TEST_REPORT_NAME_MAX", "33", 1) == 0);
+    assert(setenv("PEAK_STATSLOG_TEMPLATE", aggregate_path, 1) == 0);
+    assert(!peak_report_formatter_write_rank_local_csv_host_disambiguated(
+        snapshot));
+    assert(access(aggregate_path, F_OK) != 0);
+    assert(unsetenv("PEAK_TEST_REPORT_NAME_MAX") == 0);
+
     assert(snprintf(aggregate_path, sizeof(aggregate_path), "%s/bare",
                     ordinary_directory) < (int)sizeof(aggregate_path));
     assert(snprintf(strict_path, sizeof(strict_path),

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -817,33 +817,45 @@ check_output_template_and_no_clobber(const char* temp_directory)
 static void
 check_concurrent_no_clobber(const char* temp_directory)
 {
-    char path[768];
+    char path[PATH_MAX];
+    char component[NAME_MAX + 1];
     int start[2];
-    pid_t child;
-    int child_status;
-    bool parent_success;
+    pid_t children[32];
+    unsigned int winners = 0;
     PeakReportSnapshot* snapshot = create_fixture("concurrent");
 
-    assert(snprintf(path, sizeof(path), "%s/concurrent.csv", temp_directory) > 0);
+    memset(component, 'c', NAME_MAX - 4);
+    memcpy(component + NAME_MAX - 4, ".csv", 5);
+    assert(snprintf(path, sizeof(path), "%s/%s", temp_directory, component) <
+           (int)sizeof(path));
     assert(setenv("PEAK_STATSLOG_TEMPLATE", path, 1) == 0);
     peak_report_snapshot_prepare_for_render(snapshot);
     assert(pipe(start) == 0);
-    child = fork();
-    assert(child >= 0);
-    if (child == 0) {
-        char signal;
-        (void)close(start[1]);
-        if (read(start[0], &signal, 1) != 1) _exit(2);
-        _exit(peak_report_formatter_write_csv(snapshot) ? 0 : 1);
+    for (size_t index = 0; index < 32; index++) {
+        children[index] = fork();
+        assert(children[index] >= 0);
+        if (children[index] == 0) {
+            char signal;
+            (void)close(start[1]);
+            if (read(start[0], &signal, 1) != 1) _exit(2);
+            _exit(peak_report_formatter_write_csv(snapshot) ? 0 : 1);
+        }
     }
     assert(close(start[0]) == 0);
-    assert(write(start[1], "x", 1) == 1);
+    for (size_t index = 0; index < 32; index++) {
+        assert(write(start[1], "x", 1) == 1);
+    }
     assert(close(start[1]) == 0);
-    parent_success = peak_report_formatter_write_csv(snapshot);
-    assert(waitpid(child, &child_status, 0) == child);
-    assert(WIFEXITED(child_status));
-    assert((parent_success ? 1 : 0) + (WEXITSTATUS(child_status) == 0 ? 1 : 0) == 1);
+    for (size_t index = 0; index < 32; index++) {
+        int child_status;
+
+        assert(waitpid(children[index], &child_status, 0) == children[index]);
+        assert(WIFEXITED(child_status));
+        winners += WEXITSTATUS(child_status) == 0;
+    }
+    assert(winners == 1);
     assert(access(path, F_OK) == 0);
+    assert(!directory_has_prefix(temp_directory, ".peak-tmp."));
     assert(unlink(path) == 0);
     peak_report_snapshot_destroy(snapshot);
 }

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -91,7 +92,9 @@ test_tcp_slot_is_available(int base_port)
         int fd = socket(AF_INET, SOCK_STREAM, 0);
         struct sockaddr_in address = {
             .sin_family = AF_INET,
-            .sin_port = htons((uint16_t)(base_port + offset)),
+            .sin_port = htons((uint16_t)(base_port == 0
+                                             ? 0
+                                             : base_port + offset)),
             .sin_addr.s_addr = htonl(INADDR_ANY),
         };
 
@@ -151,24 +154,21 @@ test_port_ranges_overlap(int first_a,
 }
 
 static int
-reserve_test_port_slot(int* lock_fd_out)
+reserve_test_port_slot_from(int* lock_fd_out,
+                            int port_base,
+                            int first_slot,
+                            bool avoid_linux_ephemeral_ports,
+                            int ephemeral_first,
+                            int ephemeral_last)
 {
-    int first_slot;
-    int ephemeral_first = 0;
-    int ephemeral_last = -1;
-    bool avoid_linux_ephemeral_ports;
-
-    if (lock_fd_out == NULL) {
+    if (lock_fd_out == NULL || first_slot < 0 ||
+        first_slot >= TEST_PORT_SLOT_COUNT) {
         return -1;
     }
     *lock_fd_out = -1;
-    avoid_linux_ephemeral_ports =
-        test_linux_ephemeral_port_range(&ephemeral_first, &ephemeral_last);
-    first_slot = (int)(getpid() % TEST_PORT_SLOT_COUNT);
     for (int offset = 0; offset < TEST_PORT_SLOT_COUNT; offset++) {
         int slot = (first_slot + offset) % TEST_PORT_SLOT_COUNT;
-        int port = TEST_PORT_BASE + slot * TEST_PORT_SLOT_WIDTH;
-        int lock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+        int port = port_base + slot * TEST_PORT_SLOT_WIDTH;
         struct sockaddr_in address = {
             .sin_family = AF_INET,
             .sin_port = htons((uint16_t)port),
@@ -188,6 +188,7 @@ reserve_test_port_slot(int* lock_fd_out)
                                      ephemeral_last)) {
             continue;
         }
+        int lock_fd = socket(AF_INET, SOCK_DGRAM, 0);
         /*
          * UDP and TCP have separate port namespaces. Holding the UDP endpoint
          * gives this process a kernel-enforced, cross-UID slot lock while the
@@ -209,6 +210,23 @@ reserve_test_port_slot(int* lock_fd_out)
 }
 
 static int
+reserve_test_port_slot(int* lock_fd_out)
+{
+    int ephemeral_first = 0;
+    int ephemeral_last = -1;
+    bool avoid_linux_ephemeral_ports =
+        test_linux_ephemeral_port_range(&ephemeral_first, &ephemeral_last);
+
+    return reserve_test_port_slot_from(
+        lock_fd_out,
+        TEST_PORT_BASE,
+        (int)(getpid() % TEST_PORT_SLOT_COUNT),
+        avoid_linux_ephemeral_ports,
+        ephemeral_first,
+        ephemeral_last);
+}
+
+static int
 check_port_slot_avoids_linux_ephemeral_range(int base_port)
 {
     int ephemeral_first;
@@ -223,6 +241,42 @@ check_port_slot_avoids_linux_ephemeral_range(int base_port)
                                     ephemeral_last)
                ? 1
                : 0;
+}
+
+static int
+check_skipped_ephemeral_slots_do_not_consume_fds(void)
+{
+    struct rlimit original_limit;
+    struct rlimit limited_limit;
+    int lock_fd = -1;
+    int result;
+    bool reserved;
+
+    if (getrlimit(RLIMIT_NOFILE, &original_limit) != 0 ||
+        original_limit.rlim_cur <= 128) {
+        return 0;
+    }
+    limited_limit = original_limit;
+    limited_limit.rlim_cur = 128;
+    if (setrlimit(RLIMIT_NOFILE, &limited_limit) != 0) {
+        return 1;
+    }
+    /* Slots 1..349 are filtered; slot 0 uses kernel-selected port zero. */
+    result = reserve_test_port_slot_from(
+        &lock_fd,
+        0,
+        1,
+        true,
+        TEST_PORT_SLOT_WIDTH,
+        TEST_PORT_SLOT_COUNT * TEST_PORT_SLOT_WIDTH - 1);
+    reserved = result == 0 && lock_fd >= 0;
+    if (lock_fd >= 0) {
+        close(lock_fd);
+    }
+    if (setrlimit(RLIMIT_NOFILE, &original_limit) != 0) {
+        return 1;
+    }
+    return !reserved;
 }
 
 static int
@@ -2184,6 +2238,8 @@ main(void)
     CHECK_SOCKET_CASE("port-slot-outside-ephemeral-range",
                       check_port_slot_avoids_linux_ephemeral_range(
                           base_port));
+    CHECK_SOCKET_CASE("ephemeral-slot-skip-does-not-leak-fds",
+                      check_skipped_ephemeral_slots_do_not_consume_fds());
     CHECK_SOCKET_CASE("slurm-host-parser", check_slurm_host_parser());
     CHECK_SOCKET_CASE("progress-hard-cap",
                       check_progress_deadline_hard_cap());

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -1919,6 +1919,7 @@ check_single_process_clone(void)
     if (local == NULL) {
         return 1;
     }
+    (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_NONCE_FAIL", "1", 1);
     status = peak_socket_report_transport_begin(
         local,
         PEAK_SOCKET_REPORT_RANK_ENV_ONLY,
@@ -1936,7 +1937,32 @@ check_single_process_clone(void)
     }
     peak_report_snapshot_destroy(aggregate);
     peak_report_snapshot_destroy(local);
+    (void)unsetenv("PEAK_TEST_OUTPUT_AGGREGATION_NONCE_FAIL");
     return result;
+}
+
+static int
+check_multi_rank_nonce_failure(void)
+{
+    PeakReportSnapshot* local = fixture_snapshot(0, false);
+    PeakReportSnapshot* aggregate = NULL;
+    PeakSocketReportSession* session = NULL;
+    PeakSocketReportStatus status;
+
+    if (local == NULL) return 1;
+    clear_rank_environment();
+    set_test_rank(0, 2);
+    (void)setenv("PEAK_TEST_OUTPUT_AGGREGATION_NONCE_FAIL", "1", 1);
+    status = peak_socket_report_transport_begin(
+        local, PEAK_SOCKET_REPORT_RANK_ENV_ONLY, &session, &aggregate);
+    (void)unsetenv("PEAK_TEST_OUTPUT_AGGREGATION_NONCE_FAIL");
+    clear_rank_environment();
+    peak_socket_report_transport_abort(session);
+    peak_report_snapshot_destroy(aggregate);
+    peak_report_snapshot_destroy(local);
+    return status == PEAK_SOCKET_REPORT_FAILED && session == NULL &&
+                   aggregate == NULL
+               ? 0 : 1;
 }
 
 static int
@@ -2068,6 +2094,7 @@ main(void)
                       check_gather_admission_waves());
     check_listener_bind_scope(base_port + 56);
     CHECK_SOCKET_CASE("single-process", check_single_process_clone());
+    CHECK_SOCKET_CASE("multi-rank-nonce-failure", check_multi_rank_nonce_failure());
     CHECK_SOCKET_CASE("required-rank", check_required_rank_metadata());
     CHECK_SOCKET_CASE("invalid-output-pointers",
                       check_invalid_output_pointers_are_cleared());

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -159,6 +159,46 @@ bind_test_tcp_port(int port, bool reuse_address)
 }
 
 static void
+check_listener_bind_scope(int port)
+{
+    struct sockaddr_in address;
+    socklen_t length = sizeof(address);
+    int fd;
+
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_HOST", "127.0.0.1", 1);
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS");
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND");
+    fd = peak_socket_report_test_bind_listener(port);
+    if (fd < 0 || getsockname(fd, (struct sockaddr*)&address, &length) != 0 ||
+        address.sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
+        fprintf(stderr, "default listener did not bind root-local address\n");
+        if (fd >= 0) close(fd);
+        exit(1);
+    }
+    close(fd);
+
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS", "0.0.0.0", 1);
+    fd = peak_socket_report_test_bind_listener(port + 1);
+    if (fd >= 0) {
+        fprintf(stderr, "wildcard bind bypassed explicit broad opt-in\n");
+        close(fd);
+        exit(1);
+    }
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_BIND_ADDRESS");
+
+    (void)setenv("PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND", "1", 1);
+    fd = peak_socket_report_test_bind_listener(port + 2);
+    if (fd < 0 || getsockname(fd, (struct sockaddr*)&address, &length) != 0 ||
+        address.sin_addr.s_addr != htonl(INADDR_ANY)) {
+        fprintf(stderr, "explicit broad listener bind was not honored\n");
+        if (fd >= 0) close(fd);
+        exit(1);
+    }
+    close(fd);
+    (void)unsetenv("PEAK_OUTPUT_AGGREGATION_ALLOW_BROAD_BIND");
+}
+
+static void
 clear_rank_environment(void)
 {
     static const char* names[] = {
@@ -689,7 +729,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         action == TEST_GATHER_PAYLOAD_DROP_FAILURE) {
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_AFTER_BYTES",
-            /* wire-v12 header (168 bytes) plus 17 payload bytes. */
+            /* wire-v13 header (168 bytes) plus 17 payload bytes. */
             action == TEST_GATHER_DROP_FAILURE ? "1" : "185",
             1);
         (void)setenv(
@@ -810,7 +850,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         peer_ready_fds[0] = -1;
         memset(&telemetry, 0, sizeof(telemetry));
         peak_socket_report_test_telemetry_get(&telemetry);
-        if (telemetry.wire_version != 12U ||
+        if (telemetry.wire_version != 13U ||
             telemetry.peer_receipt_received !=
                 peer_registration_expected ||
             telemetry.peer_confirmation_sent !=
@@ -879,7 +919,9 @@ run_two_rank_case_with_peer_start_delay(int port,
         peak_socket_report_test_receipt_barrier_set(-1, -1);
     }
     if (!peer_exits_before_connect &&
-        (root_telemetry.wire_version != 12U ||
+        (root_telemetry.wire_version != 13U ||
+         (!gather_must_fail &&
+          root_telemetry.root_receipt_session_nonce == 0) ||
         (!early_drop_may_skip_accept &&
          root_telemetry.root_max_active != 1U) ||
         (early_drop_may_skip_accept &&
@@ -1183,7 +1225,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_socket_report_transport_abort(peer_session);
         peak_report_snapshot_destroy(peer_aggregate);
         if (peer_cpu_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-            telemetry.wire_version != 12U ||
+            telemetry.wire_version != 13U ||
             !telemetry.peer_receipt_received ||
             !telemetry.peer_confirmation_sent ||
             !telemetry.peer_release_started ||
@@ -1211,7 +1253,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_report_snapshot_destroy(peer_cuda);
         if ((!cuda_schema_mismatch &&
              (peer_cuda_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-              telemetry.wire_version != 12U ||
+              telemetry.wire_version != 13U ||
               !telemetry.peer_receipt_received ||
               !telemetry.peer_confirmation_sent ||
               !telemetry.peer_release_started ||
@@ -1236,7 +1278,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
     memset(&telemetry, 0, sizeof(telemetry));
     peak_socket_report_test_telemetry_get(&telemetry);
     if (cpu_status != PEAK_SOCKET_REPORT_ROOT_PREPARED || session == NULL ||
-        !aggregate_matches(aggregate) || telemetry.wire_version != 12U ||
+        !aggregate_matches(aggregate) || telemetry.wire_version != 13U ||
         telemetry.root_payload_count != 1U ||
         telemetry.root_receipt_count != 1U ||
         telemetry.root_confirmation_count != 1U ||
@@ -1292,7 +1334,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
             }
         } else if (cuda_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
                    session == NULL || !aggregate_matches(aggregate) ||
-                   telemetry.wire_version != 12U ||
+                   telemetry.wire_version != 13U ||
                    telemetry.root_payload_count != 1U ||
                    telemetry.root_receipt_count != 1U ||
                    telemetry.root_confirmation_count != 1U ||
@@ -1653,7 +1695,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
                 &peer_aggregate);
             memset(&telemetry, 0, sizeof(telemetry));
             peak_socket_report_test_telemetry_get(&telemetry);
-            if (telemetry.wire_version != 12U ||
+            if (telemetry.wire_version != 13U ||
                 !telemetry.peer_receipt_received ||
                 !telemetry.peer_confirmation_sent ||
                 !telemetry.peer_release_started ||
@@ -1683,7 +1725,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
         peak_socket_report_test_telemetry_get(&root_telemetry);
         if (root_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
             session == NULL || aggregate == NULL ||
-            root_telemetry.wire_version != 12U ||
+            root_telemetry.wire_version != 13U ||
             root_telemetry.root_payload_count != (uint32_t)(size - 1) ||
             root_telemetry.root_receipt_count != (uint32_t)(size - 1) ||
             root_telemetry.root_confirmation_count !=
@@ -1842,7 +1884,7 @@ run_duplicate_rank_case(int port)
         peak_socket_report_test_telemetry_get(&telemetry);
         if (status != PEAK_SOCKET_REPORT_FAILED ||
             session != NULL || aggregate != NULL ||
-            telemetry.wire_version != 12U ||
+            telemetry.wire_version != 13U ||
             telemetry.root_payload_count > 1U ||
             telemetry.root_receipt_count >
                 telemetry.root_payload_count ||
@@ -2024,6 +2066,7 @@ main(void)
                       check_sequential_channel_ports());
     CHECK_SOCKET_CASE("gather-admission-waves",
                       check_gather_admission_waves());
+    check_listener_bind_scope(base_port + 56);
     CHECK_SOCKET_CASE("single-process", check_single_process_clone());
     CHECK_SOCKET_CASE("required-rank", check_required_rank_metadata());
     CHECK_SOCKET_CASE("invalid-output-pointers",

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -1,6 +1,7 @@
 #include "internal/general_listener/socket_report_transport.h"
 
 #include <float.h>
+#include <errno.h>
 #include <limits.h>
 #include <netinet/in.h>
 #include <stdbool.h>
@@ -14,7 +15,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define TEST_PORT_SLOT_COUNT 800
+#define TEST_PORT_SLOT_COUNT 350 /* 10000..32399: below Linux defaults. */
 #define TEST_PORT_SLOT_WIDTH 64
 #define TEST_PORT_BASE 10000
 #define TEST_DEFAULT_PORT_BASE 42000
@@ -42,6 +43,31 @@ typedef enum {
 } TestRootAction;
 
 static bool test_saturate_dropped_counters;
+
+static bool
+test_socket_send_byte(int fd, unsigned char value)
+{
+    ssize_t written;
+
+    do {
+        written = send(fd, &value, sizeof(value), MSG_NOSIGNAL);
+    } while (written < 0 && errno == EINTR);
+    return written == (ssize_t)sizeof(value);
+}
+
+static bool
+test_socket_recv_byte(int fd, unsigned char* value_out)
+{
+    ssize_t received;
+
+    if (value_out == NULL) {
+        return false;
+    }
+    do {
+        received = recv(fd, value_out, sizeof(*value_out), 0);
+    } while (received < 0 && errno == EINTR);
+    return received == (ssize_t)sizeof(*value_out);
+}
 
 static int64_t
 test_monotonic_ms(void)
@@ -88,15 +114,56 @@ test_tcp_slot_is_available(int base_port)
     return available;
 }
 
+static bool
+test_linux_ephemeral_port_range(int* first_port_out, int* last_port_out)
+{
+    FILE* range_file;
+    int first_port;
+    int last_port;
+
+    if (first_port_out == NULL || last_port_out == NULL) {
+        return false;
+    }
+    range_file = fopen("/proc/sys/net/ipv4/ip_local_port_range", "r");
+    if (range_file == NULL) {
+        return false;
+    }
+    bool parsed =
+        fscanf(range_file, "%d %d", &first_port, &last_port) == 2 &&
+        first_port > 0 && last_port >= first_port;
+
+    fclose(range_file);
+    if (!parsed) {
+        return false;
+    }
+    *first_port_out = first_port;
+    *last_port_out = last_port;
+    return true;
+}
+
+static bool
+test_port_ranges_overlap(int first_a,
+                         int last_a,
+                         int first_b,
+                         int last_b)
+{
+    return first_a <= last_b && first_b <= last_a;
+}
+
 static int
 reserve_test_port_slot(int* lock_fd_out)
 {
     int first_slot;
+    int ephemeral_first = 0;
+    int ephemeral_last = -1;
+    bool avoid_linux_ephemeral_ports;
 
     if (lock_fd_out == NULL) {
         return -1;
     }
     *lock_fd_out = -1;
+    avoid_linux_ephemeral_ports =
+        test_linux_ephemeral_port_range(&ephemeral_first, &ephemeral_last);
     first_slot = (int)(getpid() % TEST_PORT_SLOT_COUNT);
     for (int offset = 0; offset < TEST_PORT_SLOT_COUNT; offset++) {
         int slot = (first_slot + offset) % TEST_PORT_SLOT_COUNT;
@@ -108,6 +175,19 @@ reserve_test_port_slot(int* lock_fd_out)
             .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
         };
 
+        /*
+         * A loopback peer uses an ephemeral local source port.  Keeping the
+         * entire test slot outside that kernel range prevents a completed
+         * earlier case from retaining a future gather/release port in
+         * TIME_WAIT after this availability check has finished.
+         */
+        if (avoid_linux_ephemeral_ports &&
+            test_port_ranges_overlap(port,
+                                     port + TEST_PORT_SLOT_WIDTH - 1,
+                                     ephemeral_first,
+                                     ephemeral_last)) {
+            continue;
+        }
         /*
          * UDP and TCP have separate port namespaces. Holding the UDP endpoint
          * gives this process a kernel-enforced, cross-UID slot lock while the
@@ -126,6 +206,23 @@ reserve_test_port_slot(int* lock_fd_out)
         }
     }
     return -1;
+}
+
+static int
+check_port_slot_avoids_linux_ephemeral_range(int base_port)
+{
+    int ephemeral_first;
+    int ephemeral_last;
+
+    if (!test_linux_ephemeral_port_range(&ephemeral_first, &ephemeral_last)) {
+        return 0;
+    }
+    return test_port_ranges_overlap(base_port,
+                                    base_port + TEST_PORT_SLOT_WIDTH - 1,
+                                    ephemeral_first,
+                                    ephemeral_last)
+               ? 1
+               : 0;
 }
 
 static int
@@ -820,16 +917,15 @@ run_two_rank_case_with_peer_start_delay(int port,
             receipt_barrier_fds[0] = -1;
         }
         set_test_rank(1, 2);
-        if (peer == NULL ||
-            send(peer_ready_fds[0],
-                 &ready,
-                 sizeof(ready),
-                 MSG_NOSIGNAL) != (ssize_t)sizeof(ready)) {
+        if (peer == NULL) {
             close(peer_ready_fds[0]);
             _exit(99);
         }
-        if (recv(peer_ready_fds[0], &ready, sizeof(ready), 0) !=
-                (ssize_t)sizeof(ready) ||
+        if (!test_socket_send_byte(peer_ready_fds[0], ready)) {
+            close(peer_ready_fds[0]);
+            _exit(99);
+        }
+        if (!test_socket_recv_byte(peer_ready_fds[0], &ready) ||
             ready != 0x73U) {
             close(peer_ready_fds[0]);
             _exit(99);
@@ -895,8 +991,8 @@ run_two_rank_case_with_peer_start_delay(int port,
 
         close(peer_ready_fds[0]);
         peer_ready_fds[0] = -1;
-        if (recv(peer_ready_fds[1], &ready, sizeof(ready), 0) !=
-            (ssize_t)sizeof(ready) || ready != 0x71U) {
+        if (!test_socket_recv_byte(peer_ready_fds[1], &ready) ||
+            ready != 0x71U) {
             result = 1;
         }
     }
@@ -2062,7 +2158,9 @@ main(void)
     /*
      * Hold the UDP endpoint paired with a 64-port TCP slot. The test currently
      * consumes base..base+55, and the kernel lock prevents parallel CTest
-     * processes, including different UIDs, from choosing the same range.
+     * processes, including different UIDs, from choosing the same range. On
+     * Linux the selected slot also excludes the kernel ephemeral range, so a
+     * prior loopback peer cannot hold a future listener port in TIME_WAIT.
      */
     int port_lock_fd = -1;
     int base_port = reserve_test_port_slot(&port_lock_fd);
@@ -2083,6 +2181,9 @@ main(void)
             failed = 1;                                              \
         }                                                            \
     } while (0)
+    CHECK_SOCKET_CASE("port-slot-outside-ephemeral-range",
+                      check_port_slot_avoids_linux_ephemeral_range(
+                          base_port));
     CHECK_SOCKET_CASE("slurm-host-parser", check_slurm_host_parser());
     CHECK_SOCKET_CASE("progress-hard-cap",
                       check_progress_deadline_hard_cap());

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1196,7 +1196,7 @@ def check_final_report_snapshot_order(repo_root):
         socket_prepare_receipt,
         re.DOTALL,
     ) is not None
-    require("#define PEAK_SOCKET_REDUCE_VERSION 12U" in socket_transport and
+    require("#define PEAK_SOCKET_REDUCE_VERSION 13U" in socket_transport and
             "peak_socket_reduce_header_set_report_tuple" in socket_result and
             "peak_socket_reduce_header_report_tuple" in
                 socket_validate_header and

--- a/test/static_checks/check_exec_checkpoint_output_contract.py
+++ b/test/static_checks/check_exec_checkpoint_output_contract.py
@@ -22,6 +22,7 @@ def body(source, name):
 def main(root):
     identity = (root / "src/general_listener/output_identity.c").read_text()
     writer = (root / "src/general_listener/exec_checkpoint_writer.c").read_text()
+    cmake = (root / "test/CMakeLists.txt").read_text()
     ready = body(identity, "peak_output_identity_checkpoint_path")
     writer_path = body(writer, "peak_exec_checkpoint_path")
     forbidden = ("getenv", "pthread_once", "malloc", "free", "snprintf", "strlen",
@@ -30,6 +31,9 @@ def main(root):
         assert token not in ready, f"ready checkpoint path calls {token}"
     assert "_Atomic unsigned int peak_output_checkpoint_prefix_length" in identity
     assert "ATOMIC_INT_LOCK_FREE == 2" in identity
+    assert ready.index("peak_output_checkpoint_state") < ready.index(
+        "peak_output_checkpoint_prefix_length"
+    ), "checkpoint length must be acquired only after READY state"
     ready = "if (identity_path == PEAK_OUTPUT_CHECKPOINT_READY) {\n        return 0;\n    }"
     unavailable = (
         "if (identity_path == PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE) {\n"
@@ -39,6 +43,11 @@ def main(root):
     assert ready in writer_path and unavailable in writer_path
     assert writer_path.index(ready) < legacy
     assert writer_path.index(unavailable) < legacy
+    for target in ("test_report_formatter", "test_exec_checkpoint_writer",
+                   "test_output_identity"):
+        block = cmake[cmake.index(f"target_link_libraries({target}"):]
+        block = block[:block.index(")")]
+        assert "Threads::Threads" in block and "${RT_LIBRARY}" in block, target
     print("exec_checkpoint_output_contract_ok")
 
 

--- a/test/static_checks/check_exec_checkpoint_output_contract.py
+++ b/test/static_checks/check_exec_checkpoint_output_contract.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Keep initialized exec checkpoints on the raw, non-blocking cache path."""
+
+import pathlib
+import sys
+
+
+def body(source, name):
+    start = source.index(name)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening:index + 1]
+    raise AssertionError(f"unterminated {name}")
+
+
+def main(root):
+    identity = (root / "src/general_listener/output_identity.c").read_text()
+    writer = (root / "src/general_listener/exec_checkpoint_writer.c").read_text()
+    ready = body(identity, "peak_output_identity_checkpoint_path")
+    writer_path = body(writer, "peak_exec_checkpoint_path")
+    forbidden = ("getenv", "pthread_once", "malloc", "free", "snprintf", "strlen",
+                 "strcmp", "memcpy", "mutex", "lock")
+    for token in forbidden:
+        assert token not in ready, f"ready checkpoint path calls {token}"
+    assert "_Atomic unsigned int peak_output_checkpoint_prefix_length" in identity
+    assert "ATOMIC_INT_LOCK_FREE == 2" in identity
+    ready = "if (identity_path == PEAK_OUTPUT_CHECKPOINT_READY) {\n        return 0;\n    }"
+    unavailable = (
+        "if (identity_path == PEAK_OUTPUT_CHECKPOINT_UNAVAILABLE) {\n"
+        "        errno = EINVAL;\n        return -1;\n    }"
+    )
+    legacy = writer_path.index("base = getenv")
+    assert ready in writer_path and unavailable in writer_path
+    assert writer_path.index(ready) < legacy
+    assert writer_path.index(unavailable) < legacy
+    print("exec_checkpoint_output_contract_ok")
+
+
+if __name__ == "__main__":
+    main(pathlib.Path(sys.argv[1]))


### PR DESCRIPTION
## Summary

- add job/step/host/rank/PID/session-aware identities for statistics and memory-log outputs, with configurable pathname templates
- publish complete statistics and memory-log CSVs atomically without clobbering prior results by default; retain overwrite only behind an explicit opt-in
- preserve exec-checkpoint safety with a pre-initialized bounded identity cache and lock-free checkpoint read path
- bind the socket reducer to the selected root/node-local IPv4 address by default, with broad binding behind an explicit opt-in
- move the socket protocol to wire v13 and use a fresh unpredictable root nonce for receipt confirmation and peer release; the launcher token remains enrollment metadata, not authentication
- migrate exec, MPI, JIT, fastpath, and MILC-like runners to reject stale PID-only final artifacts and publication residue
- make entropy acquisition portable when `sys/random.h` is unavailable while preserving the existing `/dev/urandom` path

## Root cause

The previous output paths primarily used PID/rank and final publication used replacement semantics, so PID reuse or repeated fixed paths could replace a completed report. The socket reducer also listened on all interfaces and reused a deterministic launcher-derived token throughout the protocol.

## Review and local validation

- exact head: `76612ae8727c9e9984aa2bfb19abe69ce96b2d1f`
- base: `894a20c076b024dc12c6e821f620d0715d2d8c26`
- implementation: GPT-5.6 Terra High
- primary review: ACCEPT
- independent GPT-5.6 Sol High review: ACCEPT
- GCC, Clang, ASan+UBSan, and TSan focused output-identity/socket suites passed in fresh builds
- Clang exec suite: 107/107
- formatter and rank-local no-clobber repetitions: 100/100 each
- the final test-only socket allocator was independently verified under concurrent GCC/Clang/ASan+UBSan suites and GCC/Clang `until-fail` repetitions; a counterfactual with the old FD ordering is rejected by the RLIMIT regression
- `git diff --check`: clean

## State-machine redline

The six detach/reattach redline files are byte-for-byte unchanged from `main` (`894a20c076b024dc12c6e821f620d0715d2d8c26`):

- `src/detach_controller.c`
- `src/pthread_listener.c`
- `include/detach_controller.h`
- `include/general_listener.h`
- `src/unsafe_gum_prologue.c`
- `include/internal/unsafe_gum_prologue.h`

No timeout, detach/reattach state-machine, MILC case, arm order, cooldown, or threshold was changed.

## GitHub CI

- 14/14 checks passed for exact head `76612ae8727c9e9984aa2bfb19abe69ce96b2d1f`
- GCC and Clang CMake builds, MPICH/Open MPI/Intel MPI matrices, controlled dependencies, detach benchmarks, and TSan all passed

## HPC certification

### Exact Frontera MILC artifact

- build job: `7894106` (`small`, 1 node, exit `0:0`, 27s)
- source product hash: `6f65e63593b2a35995899c31786952caa871e5e38c401471aed0749ed511aa0b` across 102 product files
- stage manifest: `d9b412385e62d750f03749c9161ee39c950cc08f5fcbc90b9782361bc2faf907`
- `libpeak.so`: `8d575527347f649202cbd29f8c916c02c44c836e81269eb69a300baf44e48e7d`
- detach helper: `83da6f1c32f0ca064144f7294edf1223a57c7979ddb711b96989d301925c3e7a`
- provenance: `ff758b91b778717fa9dd1571c84958411af11bce1969373e73e63ce17ffa9b03`
- Intel 19.1.1 / Intel MPI 19.0.9, Release, MPI ON, OTF2 OFF

### Frontera high-thread stress

- job: `7894107` (`development`, 1 node, exit `0:0`, 2m58s), excluding `c122-123,c171-091`
- Frontera's Intel 19 environment reported `sys/random.h` unavailable; configure, build, fallback entropy paths, and all tests passed
- 56 persistent workers + 8 transient-thread spawners, 6/6 strict signal-backend samples
- every sample observed detach and reattach; the runner also required redetach-after-reattach and trace diagnostics
- 9/9 issue/FSM focused checks passed
- malloc/free pre-main rollback stress passed 100 repeats

### Vista high-thread stress

- job: `899806` (`gh-dev`, 1 node, exit `0:0`, 3m46s)
- NVHPC/CUDA-enabled build passed
- 72 persistent workers + 8 transient-thread spawners, 6/6 strict signal-backend samples
- every sample observed detach and reattach; the runner also required redetach-after-reattach and trace diagnostics
- 9/9 issue/FSM focused checks passed
- malloc/free pre-main rollback stress passed 100 repeats

### Frontera 1024-node MILC certification

- job: `7894111` (`large`, 1024 nodes, 4096 ranks, 12 CPUs/rank, 24m01s), excluding `c122-123,c171-091`
- case, gauge, backend-repeat arm order, cooldowns, thresholds, Intel/Intel-MPI modules, and artifact were unchanged
- artifact provenance matched before launch: exact head, source hash, 102 product files, `libpeak.so`, helper, and provenance hashes
- all eight arms completed in order: B0/A1/S1/A2/S2/A3/S3/Bend
- B0 and Bend: launcher rc 0, exactly one `RUNNING COMPLETED`, no PEAK markers, no CSV, and no fatal/hang marker
- all six PEAK arms: exactly one `RUNNING COMPLETED`, aggregate report scope of 4096 MPI ranks, `normal_exit` exactly 4096 calls, exactly one PEAK completion, and exactly one 242-line CSV
- all six PEAK arms: `detached_targets=28`, `reattached_targets=27`, `revisited_targets=20` (A2: 21), failed control windows 0, `snapshot_valid=1`, and no fatal/hang marker
- A1/S1/A2/S2/S3 returned launcher rc 0; A3 returned the known bare TACC launcher rc 255 only after MILC and PEAK had fully completed
- A3 stdout contains only TACC startup, `MPI job exited with code: 255`, and clean shutdown; its report is complete and has the same 4096-rank/transition/window/CSV evidence as the other PEAK arms
- the legacy matrix runner therefore returned exit 1 with `failures=1`, but the user-approved application/report criterion passes all 8/8 arms; no rerun or rc255 investigation was performed

Closes #59
