### PR TITLE
Make allocation lifetime accounting linearizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,17 @@ semantics, module lifetime, and supported boundaries.
 | `PEAK_MEMORY_PROFILE` | Enable experimental Linux memory allocation profiling for selected CPU targets. Rejected on macOS. |
 | `PEAK_MEMORY_TRACK_ALL` | On Linux, track all allocation events instead of filtering by target backtraces. |
 | `PEAK_MEMLOG_PATH` | Memory CSV output prefix. Default: `./peak_memlog`. |
-| `PEAK_MEMLOG_CHUNK_EVENTS` | Experimental memory-profiler fixed event capacity. A positive decimal value allocates that many slots once; when full, new events are dropped and reported at finalization. The mapping never grows or moves. |
+| `PEAK_MEMLOG_CHUNK_EVENTS` | Experimental memory-profiler fixed export capacity. A positive decimal value reserves that many events plus at most one 64-event reservation block of slack per tracked thread; when full, new events are dropped and reported at finalization. The mapping never grows or moves. |
 | `PEAK_MEMLOG_OTF2_DIR` | Override the directory for memory-profile OTF2 output. |
+
+Allocation lifetimes are tracked in a lock-free pointer radix. Memory events
+use sharded ordering metadata, and their process-wide `current` totals and
+maximum are reconstructed after allocation hooks quiesce. Concurrent
+allocation calls therefore neither acquire a process-wide tracking lock nor
+update a single process-wide byte counter on the hot path. On Linux, PEAK
+initializes the fixed anonymous event buffer before installing hooks, so event
+writes incur neither first-write faults nor parallel-filesystem dirty-page
+bookkeeping on the allocation hot path.
 
 ### Legacy Controls
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(detach)
+add_subdirectory(memory)

--- a/benchmarks/memory/CMakeLists.txt
+++ b/benchmarks/memory/CMakeLists.txt
@@ -1,0 +1,37 @@
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
+  return()
+endif()
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+add_executable(benchmark_allocation_scaling
+  benchmark_allocation_scaling.c
+)
+target_link_libraries(benchmark_allocation_scaling PRIVATE Threads::Threads)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  target_link_options(benchmark_allocation_scaling PRIVATE -Wl,--export-dynamic)
+endif()
+
+if(TARGET peak)
+  # Shared CI runners provide functional coverage only.  The Frontera suite
+  # applies the strict 1--56 physical-core performance gates.
+  add_test(NAME benchmark_allocation_scaling_smoke
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/run_allocation_scaling.py
+            --exe $<TARGET_FILE:benchmark_allocation_scaling>
+            --current-libpeak $<TARGET_FILE:peak>
+            --threads 1,2
+            --modes pair,realloc,mixed,aligned,posix
+            --iterations 20000
+            --samples 2
+            --max-profiled-ns-per-call 10000
+            --max-incremental-ns-per-call 10000
+            --min-throughput-retention 0
+            --verify-accounting)
+  set_tests_properties(benchmark_allocation_scaling_smoke
+    PROPERTIES
+      LABELS benchmark
+      RESOURCE_LOCK peak_memory_benchmark
+      TIMEOUT 180
+      PASS_REGULAR_EXPRESSION "allocation_scaling_ok")
+endif()

--- a/benchmarks/memory/benchmark_allocation_scaling.c
+++ b/benchmarks/memory/benchmark_allocation_scaling.c
@@ -1,0 +1,250 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef enum {
+    MODE_PAIR = 0,
+    MODE_REALLOC,
+    MODE_MIXED,
+    MODE_ALIGNED,
+    MODE_POSIX,
+} BenchmarkMode;
+
+typedef struct {
+    pthread_barrier_t* ready;
+    pthread_barrier_t* done;
+    size_t iterations;
+    BenchmarkMode mode;
+    int cpu;
+    uintptr_t checksum;
+} Worker;
+
+static uint64_t
+nanoseconds(void)
+{
+    struct timespec value;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &value) != 0) abort();
+    return (uint64_t)value.tv_sec * UINT64_C(1000000000) +
+           (uint64_t)value.tv_nsec;
+}
+
+static void
+pin_worker(int cpu)
+{
+    cpu_set_t affinity;
+
+    CPU_ZERO(&affinity);
+    CPU_SET(cpu, &affinity);
+    if (pthread_setaffinity_np(pthread_self(), sizeof(affinity), &affinity) != 0) {
+        abort();
+    }
+}
+
+static void*
+worker_main(void* opaque)
+{
+    Worker* worker = opaque;
+    void* pointer = NULL;
+
+    pin_worker(worker->cpu);
+    if (worker->mode == MODE_REALLOC) {
+        pointer = malloc(64);
+        if (pointer == NULL) abort();
+    }
+    pthread_barrier_wait(worker->ready);
+    for (size_t i = 0; i < worker->iterations; ++i) {
+        if (worker->mode == MODE_REALLOC) {
+            size_t size = (i & 1u) == 0 ? 128u : 64u;
+            void* resized = realloc(pointer, size);
+            if (resized == NULL) abort();
+            pointer = resized;
+            ((volatile unsigned char*)pointer)[0] = (unsigned char)i;
+        } else {
+            size_t first_size = 64u + (i & 63u);
+            if (worker->mode == MODE_ALIGNED) {
+                pointer = aligned_alloc(64u, 128u);
+            } else if (worker->mode == MODE_POSIX) {
+                if (posix_memalign(&pointer, 64u, 128u) != 0) abort();
+            } else {
+                pointer = malloc(first_size);
+            }
+            if (pointer == NULL) abort();
+            if (worker->mode == MODE_MIXED) {
+                void* resized = realloc(pointer, first_size + 64u);
+                if (resized == NULL) abort();
+                pointer = resized;
+            }
+            ((volatile unsigned char*)pointer)[0] = (unsigned char)i;
+            worker->checksum ^= (uintptr_t)pointer;
+            free(pointer);
+            pointer = NULL;
+        }
+    }
+    pthread_barrier_wait(worker->done);
+    free(pointer);
+    return NULL;
+}
+
+static size_t
+collect_allowed_cpus(int* cpus, size_t capacity)
+{
+    cpu_set_t affinity;
+    struct {
+        int package;
+        int core;
+    } selected[CPU_SETSIZE];
+    size_t count = 0;
+
+    if (sched_getaffinity(0, sizeof(affinity), &affinity) != 0) return 0;
+    for (int cpu = 0; cpu < CPU_SETSIZE && count < capacity; ++cpu) {
+        char path[128];
+        FILE* file;
+        int package;
+        int core;
+        int duplicate = 0;
+
+        if (!CPU_ISSET(cpu, &affinity)) continue;
+        snprintf(path, sizeof(path),
+                 "/sys/devices/system/cpu/cpu%d/topology/physical_package_id",
+                 cpu);
+        file = fopen(path, "r");
+        if (file == NULL || fscanf(file, "%d", &package) != 1) {
+            if (file != NULL) fclose(file);
+            return 0;
+        }
+        fclose(file);
+        snprintf(path, sizeof(path),
+                 "/sys/devices/system/cpu/cpu%d/topology/core_id", cpu);
+        file = fopen(path, "r");
+        if (file == NULL || fscanf(file, "%d", &core) != 1) {
+            if (file != NULL) fclose(file);
+            return 0;
+        }
+        fclose(file);
+        for (size_t i = 0; i < count; ++i) {
+            if (selected[i].package == package && selected[i].core == core) {
+                duplicate = 1;
+                break;
+            }
+        }
+        if (duplicate) continue;
+        selected[count].package = package;
+        selected[count].core = core;
+        cpus[count++] = cpu;
+    }
+    return count;
+}
+
+__attribute__((noinline, noclone, used, externally_visible,
+               visibility("default")))
+uint64_t
+run_allocation_benchmark(size_t thread_count,
+                         size_t iterations,
+                         BenchmarkMode mode)
+{
+    pthread_t* threads = calloc(thread_count, sizeof(*threads));
+    Worker* workers = calloc(thread_count, sizeof(*workers));
+    int* cpus = calloc(thread_count, sizeof(*cpus));
+    pthread_barrier_t ready;
+    pthread_barrier_t done;
+    uint64_t start;
+    uint64_t finish;
+
+    if (threads == NULL || workers == NULL || cpus == NULL ||
+        collect_allowed_cpus(cpus, thread_count) != thread_count) {
+        abort();
+    }
+    if (pthread_barrier_init(&ready, NULL, (unsigned)thread_count + 1u) != 0 ||
+        pthread_barrier_init(&done, NULL, (unsigned)thread_count + 1u) != 0) {
+        abort();
+    }
+    for (size_t i = 0; i < thread_count; ++i) {
+        workers[i].ready = &ready;
+        workers[i].done = &done;
+        workers[i].iterations = iterations;
+        workers[i].mode = mode;
+        workers[i].cpu = cpus[i];
+        if (pthread_create(&threads[i], NULL, worker_main, &workers[i]) != 0) {
+            abort();
+        }
+    }
+    pthread_barrier_wait(&ready);
+    start = nanoseconds();
+    pthread_barrier_wait(&done);
+    finish = nanoseconds();
+    for (size_t i = 0; i < thread_count; ++i) {
+        if (pthread_join(threads[i], NULL) != 0) abort();
+    }
+    pthread_barrier_destroy(&done);
+    pthread_barrier_destroy(&ready);
+    free(cpus);
+    free(workers);
+    free(threads);
+    return finish - start;
+}
+
+static int
+parse_positive_size(const char* text, size_t* out)
+{
+    char* end = NULL;
+    unsigned long long parsed;
+
+    errno = 0;
+    parsed = strtoull(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || parsed == 0 ||
+        parsed > SIZE_MAX) {
+        return 0;
+    }
+    *out = (size_t)parsed;
+    return 1;
+}
+
+int
+main(int argc, char** argv)
+{
+    size_t threads;
+    size_t iterations;
+    BenchmarkMode mode;
+    uint64_t elapsed;
+    uint64_t allocator_calls;
+
+    if (argc != 4 || !parse_positive_size(argv[1], &threads) ||
+        !parse_positive_size(argv[2], &iterations)) {
+        return 2;
+    }
+    if (strcmp(argv[3], "pair") == 0) {
+        mode = MODE_PAIR;
+        allocator_calls = 2;
+    } else if (strcmp(argv[3], "realloc") == 0) {
+        mode = MODE_REALLOC;
+        allocator_calls = 1;
+    } else if (strcmp(argv[3], "mixed") == 0) {
+        mode = MODE_MIXED;
+        allocator_calls = 3;
+    } else if (strcmp(argv[3], "aligned") == 0) {
+        mode = MODE_ALIGNED;
+        allocator_calls = 2;
+    } else if (strcmp(argv[3], "posix") == 0) {
+        mode = MODE_POSIX;
+        allocator_calls = 2;
+    } else {
+        return 2;
+    }
+
+    elapsed = run_allocation_benchmark(threads, iterations, mode);
+    allocator_calls *= (uint64_t)threads * (uint64_t)iterations;
+    printf("mode=%s threads=%zu physical_cores=%zu iterations=%zu elapsed_ns=%llu "
+           "allocator_calls=%llu ns_per_call=%.3f\n",
+           argv[3], threads, threads, iterations,
+           (unsigned long long)elapsed,
+           (unsigned long long)allocator_calls,
+           (double)elapsed / (double)allocator_calls);
+    return 0;
+}

--- a/benchmarks/memory/run_allocation_scaling.py
+++ b/benchmarks/memory/run_allocation_scaling.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import random
+import re
+import statistics
+import subprocess
+import tempfile
+
+from validate_memlog_accounting import validate
+
+RESULT_RE = re.compile(r"ns_per_call=([0-9.]+)")
+MEMLOG_RE = re.compile(r"memlog CSV written: .* \(events=([0-9]+) dropped=([0-9]+)\)")
+
+
+def parse_csv(value, cast):
+    parsed = [cast(item) for item in value.split(",") if item]
+    if not parsed:
+        raise argparse.ArgumentTypeError("list must not be empty")
+    return parsed
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", required=True)
+    parser.add_argument("--current-libpeak", required=True)
+    parser.add_argument("--baseline-libpeak")
+    parser.add_argument("--threads", default="1,2,4,8")
+    parser.add_argument("--modes", default="pair,realloc,mixed")
+    parser.add_argument("--iterations", type=int, default=100000)
+    parser.add_argument("--min-iterations-per-thread", type=int, default=0)
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--max-profiled-ns-per-call", type=float, default=750.0)
+    parser.add_argument("--max-incremental-ns-per-call", type=float, default=700.0)
+    parser.add_argument("--min-throughput-retention", type=float, default=0.90)
+    parser.add_argument("--raw-retention-min-threads", type=int, default=4)
+    parser.add_argument("--verify-accounting", action="store_true")
+    return parser.parse_args()
+
+
+def run_once(args, library, threads, mode):
+    iterations = max(1, args.iterations // threads,
+                     args.min_iterations_per_thread)
+    minimum_events_per_iteration = {
+        "pair": 2,
+        "realloc": 2,
+        "mixed": 4,
+        "aligned": 2,
+        "posix": 2,
+    }[mode]
+    minimum_events = minimum_events_per_iteration * iterations * threads
+    with tempfile.TemporaryDirectory(prefix="peak-memory-benchmark.") as output_dir:
+        stats_path = os.path.join(output_dir, "stats.csv")
+        memlog_path = os.path.join(output_dir, "mem.csv")
+        environment = os.environ.copy()
+        for name in (
+            "LD_PRELOAD",
+            "PEAK_TARGET",
+            "PEAK_MEMORY_PROFILE",
+            "PEAK_MEMORY_TRACK_ALL",
+            "PEAK_MEMLOG_CHUNK_EVENTS",
+            "PEAK_STATSLOG_TEMPLATE",
+            "PEAK_MEMLOG_TEMPLATE",
+        ):
+            environment.pop(name, None)
+        if library is not None:
+            environment.update({
+                "LD_PRELOAD": library,
+                "PEAK_TARGET": "run_allocation_benchmark",
+                "PEAK_VERBOSITY": "debug",
+                "PEAK_MEMORY_PROFILE": "TRUE",
+                "PEAK_MEMORY_TRACK_ALL": "TRUE",
+                "PEAK_MEMLOG_CHUNK_EVENTS": str(iterations * threads * 4 + 1024),
+                "PEAK_STATSLOG_TEMPLATE": stats_path,
+                "PEAK_MEMLOG_TEMPLATE": memlog_path,
+            })
+        result = subprocess.run(
+            [args.exe, str(threads), str(iterations), mode],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+            timeout=60,
+        )
+        combined_output = result.stdout + result.stderr
+        match = RESULT_RE.search(combined_output)
+        if match is None:
+            raise RuntimeError(combined_output)
+        if library is not None:
+            memlog_match = MEMLOG_RE.search(combined_output)
+            failures = []
+            if memlog_match is None:
+                failures.append("missing memlog completion")
+            else:
+                event_count = int(memlog_match.group(1))
+                if event_count < minimum_events:
+                    failures.append(
+                        f"events={event_count} below expected {minimum_events}"
+                    )
+                if int(memlog_match.group(2)) != 0:
+                    failures.append(f"dropped={memlog_match.group(2)}")
+            if not os.path.isfile(stats_path):
+                failures.append("missing stats CSV")
+            if not os.path.isfile(memlog_path):
+                failures.append("missing memlog CSV")
+            if failures:
+                raise RuntimeError("profile artifact validation failed: " +
+                                   ", ".join(failures) + "\n" +
+                                   combined_output)
+            with open(memlog_path, "rb") as memlog:
+                if memlog.readline() != b"ts_ns,delta,current,tid,op\n":
+                    raise RuntimeError("invalid memlog header")
+            if args.verify_accounting:
+                validate(memlog_path)
+        return float(match.group(1))
+
+
+def main():
+    args = parse_args()
+    threads = parse_csv(args.threads, int)
+    modes = parse_csv(args.modes, str)
+    libraries = {"unprofiled": None, "current": args.current_libpeak}
+    if args.baseline_libpeak:
+        libraries["baseline"] = args.baseline_libpeak
+    results = {
+        (label, mode, count): []
+        for label in libraries
+        for mode in modes
+        for count in threads
+    }
+    cases = [
+        (label, mode, count)
+        for _ in range(args.samples)
+        for mode in modes
+        for count in threads
+        for label in libraries
+    ]
+    random.Random(82).shuffle(cases)
+    for label, mode, count in cases:
+        results[(label, mode, count)].append(
+            run_once(args, libraries[label], count, mode)
+        )
+
+    failures = []
+    print("label mode threads median_ns_per_call min_ns_per_call "
+          "max_ns_per_call throughput_calls_per_second")
+    for mode in modes:
+        best_lower_current = None
+        best_lower_unprofiled = None
+        for count in threads:
+            medians = {}
+            for label in libraries:
+                samples = results[(label, mode, count)]
+                value = statistics.median(samples)
+                medians[label] = value
+                print(label, mode, count, f"{value:.3f}",
+                      f"{min(samples):.3f}", f"{max(samples):.3f}",
+                      f"{1e9 / value:.3f}")
+            current = medians["current"]
+            unprofiled = medians["unprofiled"]
+            raw_retention = (1.0 if best_lower_current is None else
+                             best_lower_current / current)
+            unprofiled_retention = (
+                1.0 if best_lower_unprofiled is None else
+                best_lower_unprofiled / unprofiled
+            )
+            relative_retention = (
+                raw_retention / min(1.0, unprofiled_retention)
+            )
+            incremental = current - unprofiled
+            print(
+                "gate",
+                mode,
+                count,
+                f"raw_retention_vs_best_lower={raw_retention:.6f}",
+                f"unprofiled_retention_vs_best_lower={unprofiled_retention:.6f}",
+                f"relative_retention={relative_retention:.6f}",
+                f"incremental_ns={incremental:.3f}",
+                *([] if "baseline" not in medians else [
+                    f"current_over_baseline={current / medians['baseline']:.6f}"
+                ]),
+            )
+            if current > args.max_profiled_ns_per_call:
+                failures.append(f"{mode}/{count}: profiled {current:.3f} ns")
+            if incremental > args.max_incremental_ns_per_call:
+                failures.append(f"{mode}/{count}: incremental {incremental:.3f} ns")
+            if (count >= args.raw_retention_min_threads and
+                    raw_retention < args.min_throughput_retention):
+                failures.append(
+                    f"{mode}/{count}: raw retention {raw_retention:.6f}"
+                )
+            if relative_retention < args.min_throughput_retention:
+                failures.append(
+                    f"{mode}/{count}: relative retention "
+                    f"{relative_retention:.6f}"
+                )
+            if "baseline" in medians and current > medians["baseline"] * 1.05:
+                failures.append(
+                    f"{mode}/{count}: current {current:.3f} ns exceeds baseline "
+                    f"{medians['baseline']:.3f} ns by more than 5%"
+                )
+            if best_lower_current is None or current < best_lower_current:
+                best_lower_current = current
+            if (best_lower_unprofiled is None or
+                    unprofiled < best_lower_unprofiled):
+                best_lower_unprofiled = unprofiled
+    if failures:
+        for failure in failures:
+            print(f"allocation scaling gate failed: {failure}")
+        return 1
+    print("allocation_scaling_ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/memory/validate_memlog_accounting.py
+++ b/benchmarks/memory/validate_memlog_accounting.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import csv
+import sys
+
+
+def validate(path):
+    current = 0
+    maximum = 0
+    previous_timestamp = None
+    events = 0
+    with open(path, newline="", encoding="utf-8") as stream:
+        for row in csv.DictReader(stream):
+            timestamp = int(row["ts_ns"])
+            if previous_timestamp is not None and timestamp < previous_timestamp:
+                raise RuntimeError("memory events are not timestamp ordered")
+            previous_timestamp = timestamp
+            current += int(row["delta"])
+            if current < 0 or int(row["current"]) != current:
+                raise RuntimeError("memory event current total disagrees with deltas")
+            maximum = max(maximum, current)
+            events += 1
+    return events, current, maximum
+
+
+def main():
+    if len(sys.argv) != 2:
+        return 2
+    events, current, maximum = validate(sys.argv[1])
+    print(f"memlog_accounting_ok events={events} final={current} maximum={maximum}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/include/malloc_interceptor.h
+++ b/include/malloc_interceptor.h
@@ -159,6 +159,20 @@ typedef struct {
     int mapping_live;
 } PeakMemLogTestSnapshot;
 
+typedef struct {
+    void* (*malloc_fn)(size_t size);
+    void (*free_fn)(void* ptr);
+    void* (*realloc_fn)(void* ptr, size_t size);
+} PeakMallocTestAllocator;
+
+typedef struct {
+    size_t entry_count;
+    size_t table_bytes;
+    size_t current_bytes;
+    int pointer_tracked;
+    size_t pointer_size;
+} PeakMallocTestTrackingSnapshot;
+
 PEAK_MALLOC_TEST_API void
 peak_memlog_test_set_failure(PeakMemLogTestFailure failure);
 
@@ -191,6 +205,28 @@ peak_malloc_test_failed_realloc_preserves_accounting(void);
 
 PEAK_MALLOC_TEST_API int
 peak_malloc_test_tracking_allocation_failure(void);
+
+PEAK_MALLOC_TEST_API int
+peak_malloc_test_begin(const PeakMallocTestAllocator* allocator);
+
+PEAK_MALLOC_TEST_API int
+peak_malloc_test_seed(void* ptr, size_t size);
+
+PEAK_MALLOC_TEST_API void*
+peak_malloc_test_malloc(size_t size);
+
+PEAK_MALLOC_TEST_API void
+peak_malloc_test_free(void* ptr);
+
+PEAK_MALLOC_TEST_API void*
+peak_malloc_test_realloc(void* ptr, size_t size);
+
+PEAK_MALLOC_TEST_API void
+peak_malloc_test_tracking_snapshot(void* ptr,
+                                   PeakMallocTestTrackingSnapshot* out);
+
+PEAK_MALLOC_TEST_API void
+peak_malloc_test_end(void);
 #endif
 
 /** @} */

--- a/include/malloc_interceptor.h
+++ b/include/malloc_interceptor.h
@@ -50,10 +50,12 @@
 
 /** One packed allocation-accounting event in the PEAK memory log. */
 typedef struct {
-    uint64_t ts_ns;     /**< Absolute `CLOCK_MONOTONIC_RAW` timestamp, in nanoseconds. */
+    uint64_t ts_ns;     /**< Absolute `CLOCK_MONOTONIC` timestamp, in nanoseconds. */
     int64_t  delta;     /**< Signed change in tracked allocated bytes. */
-    uint64_t current;   /**< Tracked allocated-byte total after applying @c delta. */
+    uint64_t current;   /**< Total after @c delta, reconstructed during finalization. */
+    uint64_t accounting_sequence; /**< Internal per-shard transition order. */
     uint32_t tid;       /**< Linux thread ID that recorded the event. */
+    uint16_t accounting_shard; /**< Internal accounting shard, or UINT16_MAX. */
     uint8_t  op;        /**< 1=add/allocation, 2=remove/free; realloc emits those operations. */
 } __attribute__((packed)) PeakMemEvent;
 
@@ -70,7 +72,7 @@ typedef struct {
     char     magic[8];       /**< The eight bytes `PEAKMEM\0`. */
     uint32_t header_bytes;   /**< Page-aligned offset from the mapping to the first event. */
     uint64_t t0_ns;          /**< Log-open time in the same clock domain as event timestamps. */
-    uint64_t clock_id;       /**< Numeric value of `CLOCK_MONOTONIC_RAW`. */
+    uint64_t clock_id;       /**< Numeric value of `CLOCK_MONOTONIC`. */
     int32_t  mpi_rank;       /**< MPI rank, or -1 when unavailable. */
     int32_t  pid;            /**< Process ID captured with `getpid()`. */
     int32_t  ppid;           /**< Parent process ID captured with `getppid()`. */
@@ -78,19 +80,20 @@ typedef struct {
 
 /** Module-owned mutable state for the mapped binary log and its exports. */
 typedef struct {
-    int      fd;                  /**< Descriptor for the temporary binary log. */
+    int      fd;                  /**< Descriptor reserving the temporary output path. */
     void    *map;                 /**< Mapping base containing header followed by events. */
     size_t   map_bytes;           /**< Fixed mapping size, in bytes. */
     size_t   header_bytes;        /**< Page-aligned event-region offset. */
-    size_t   capacity_events;     /**< Number of event slots in the fixed mapping. */
+    size_t   capacity_events;     /**< Configured number of exportable events. */
+    size_t   storage_capacity_events; /**< Slots including bounded reservation slack. */
     size_t   ready_offset;        /**< Offset of one-byte atomic ready flags after events. */
-    _Atomic size_t reserved;      /**< Successfully reserved event slots. */
-    _Atomic size_t committed;     /**< Slots whose payload publication completed. */
-    _Atomic size_t dropped;       /**< Events rejected after capacity is exhausted. */
+    _Alignas(64) _Atomic size_t reserved; /**< Thread-local blocks claimed globally. */
+    _Atomic size_t committed;     /**< Published payloads, compacted at finalization. */
+    _Atomic size_t dropped;       /**< Events rejected or truncated at logical capacity. */
     _Atomic size_t active_writers;/**< Writers admitted before DISABLED. */
-    _Atomic PeakMemLogState state;/**< UNINITIALIZED, ACTIVE, DISABLED, or FINALIZED. */
-    uint64_t t0_ns;               /**< Log-open `CLOCK_MONOTONIC_RAW` time, in nanoseconds. */
-    char     tmp_path[512];       /**< Temporary mapped-file path, unlinked after export. */
+    _Alignas(64) _Atomic PeakMemLogState state; /**< Log lifecycle gate. */
+    uint64_t t0_ns;               /**< Log-open `CLOCK_MONOTONIC` time, in nanoseconds. */
+    char     tmp_path[512];       /**< Temporary reservation path, unlinked after export. */
     char     csv_path[512];       /**< Final CSV output path. */
     char     otf2_prefix[512];    /**< Final OTF2 archive prefix for this rank and process. */
 } PeakMemLog;
@@ -107,9 +110,10 @@ extern "C" {
 /**
  * @brief Installs allocation replacements and opens the memory log.
  *
- * The implementation prepares tracking tables and the binary log before any
- * replacement.  If replacement is only partially successful it reverts every
- * changed entry and flushes before returning a recoverable degraded outcome.
+ * The implementation prepares lock-free tracking state and the binary log
+ * before any replacement. If replacement is only partially successful it
+ * reverts every changed entry and flushes before returning a recoverable
+ * degraded outcome.
  *
  * @return PEAK_MALLOC_ATTACH_OK, PEAK_MALLOC_ATTACH_PREPARE_FAILED, or
  *         PEAK_MALLOC_ATTACH_ROLLED_BACK.  An unprovable post-mutation
@@ -199,6 +203,9 @@ peak_memlog_test_writer_is_paused(void);
 
 PEAK_MALLOC_TEST_API void
 peak_memlog_test_finalize(void);
+
+PEAK_MALLOC_TEST_API uint32_t
+peak_malloc_test_thread_id(void);
 
 PEAK_MALLOC_TEST_API int
 peak_malloc_test_failed_realloc_preserves_accounting(void);

--- a/include/malloc_otf2.h
+++ b/include/malloc_otf2.h
@@ -25,7 +25,7 @@ extern "C" {
  * The archive directory is `PEAK_MEMLOG_OTF2_DIR` when that variable is
  * nonempty, or the current directory otherwise; @p filename is used as the
  * archive name within that directory.  Event timestamps are copied as
- * nanosecond ticks from the `CLOCK_MONOTONIC_RAW` domain, with a 1 GHz timer
+ * nanosecond ticks from the `CLOCK_MONOTONIC` domain, with a 1 GHz timer
  * resolution and the minimum event timestamp as the OTF2 global offset.  They
  * are not Unix-epoch timestamps.
  *

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -59,6 +59,7 @@ static PeakMemLog          g_memlog = {
 static __thread int        in_peak_alloc_hook = 0;
 static __thread int        in_backtrace = 0;
 static PeakEnvWarningState peak_memlog_capacity_warning_emitted;
+static _Atomic int         peak_memory_tracking_warning_emitted = 0;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic PeakMemLogTestFailure g_memlog_test_failure = PEAK_MEMLOG_TEST_FAIL_NONE;
@@ -66,6 +67,11 @@ static _Atomic int g_memlog_test_pause_before_commit = 0;
 static _Atomic int g_memlog_test_writer_paused = 0;
 static _Atomic size_t g_memlog_test_capacity_override = 0;
 static _Atomic size_t g_memlog_test_exported = 0;
+static void* (*g_malloc_test_saved_malloc)(size_t size);
+static void (*g_malloc_test_saved_free)(void* ptr);
+static void* (*g_malloc_test_saved_realloc)(void* ptr, size_t size);
+static gboolean g_malloc_test_saved_track_all;
+static int g_malloc_test_active;
 
 static void* peak_memlog_test_realloc_failure(void* ptr, size_t size) {
     (void) ptr;
@@ -680,12 +686,25 @@ static void peak_memlog_finalize(void) {
   Tracking table helpers
 =========================*/
 
+static void
+note_memory_tracking_degraded(const char* reason)
+{
+    if (atomic_exchange_explicit(&peak_memory_tracking_warning_emitted, 1,
+                                 memory_order_relaxed) == 0) {
+        peak_log_message_always(
+            "[peak] memory allocation tracking degraded (%s)\n", reason);
+    }
+}
+
 static void add_tracking_entry(void* ptr, size_t size, int log) {
     if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) return;
     if (!log) return;
 
     AllocationEntry* entry = internal_malloc(sizeof(AllocationEntry));
-    if (!entry) return;
+    if (!entry) {
+        note_memory_tracking_degraded("tracking entry allocation failed");
+        return;
+    }
 
     entry->ptr      = ptr;
     entry->size     = size;
@@ -694,7 +713,7 @@ static void add_tracking_entry(void* ptr, size_t size, int log) {
     if (size > G_MAXULONG - current_memory) {
         pthread_mutex_unlock(&track_mutex);
         internal_free(entry);
-        peak_log_warn("[peak] memory profiler accounting overflow; allocation not tracked\n");
+        note_memory_tracking_degraded("allocation accounting overflow");
         return;
     }
     gum_metal_hash_table_insert(track_table, ptr, entry);
@@ -709,79 +728,86 @@ static void add_tracking_entry(void* ptr, size_t size, int log) {
     }
 }
 
-static AllocationEntry* find_tracking_entry(void* ptr) {
-    if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) return NULL;
-
-    pthread_mutex_lock(&track_mutex);
-    AllocationEntry* entry = gum_metal_hash_table_lookup(track_table, ptr);
-    if (entry && entry->ptr == ptr) {
-        pthread_mutex_unlock(&track_mutex);
-        return entry;
-    }
-    pthread_mutex_unlock(&track_mutex);
-    return NULL;
-}
-
-static void remove_tracking_entry(void* ptr) {
-    if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) return;
-
-    pthread_mutex_lock(&track_mutex);
-    AllocationEntry* entry = gum_metal_hash_table_lookup(track_table, ptr);
-    if (entry) {
-        gum_metal_hash_table_remove(track_table, ptr);
-        current_memory -= entry->size;
-    }
-
-    if (entry) {
-        int64_t delta;
-        if (size_to_event_delta(entry->size, &delta)) {
-            peak_log_event(nsec_now(), -delta, (uint64_t) current_memory, 2);
-        }
-        internal_free(entry);
-    }
-    pthread_mutex_unlock(&track_mutex);
-}
-
-static int update_tracking_entry_after_realloc(void* old_ptr,
-                                               void* new_ptr,
-                                               size_t new_size,
-                                               size_t* old_size_out,
-                                               gulong* current_after_remove_out,
-                                               gulong* current_after_add_out) {
+static AllocationEntry*
+detach_tracking_entry(void* ptr, gulong* current_after_remove_out)
+{
     AllocationEntry* entry;
 
-    if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) {
-        return 0;
+    if (!track_table ||
+        atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) {
+        return NULL;
     }
 
+    /*
+     * Removing the entry and its bytes under one lock is the lifetime
+     * transition.  It must precede the allocator call, which may immediately
+     * make the same address visible to another allocation.
+     */
     pthread_mutex_lock(&track_mutex);
-    entry = gum_metal_hash_table_lookup(track_table, old_ptr);
-    if (!entry || entry->ptr != old_ptr) {
+    entry = gum_metal_hash_table_lookup(track_table, ptr);
+    if (!entry || entry->ptr != ptr) {
         pthread_mutex_unlock(&track_mutex);
-        return 0;
+        return NULL;
     }
-
-    *old_size_out = entry->size;
+    gum_metal_hash_table_remove(track_table, ptr);
     current_memory -= entry->size;
     *current_after_remove_out = current_memory;
+    pthread_mutex_unlock(&track_mutex);
+    return entry;
+}
+
+static void
+restore_tracking_entry(AllocationEntry* entry)
+{
+    int overflowed = 0;
+
+    pthread_mutex_lock(&track_mutex);
+    gum_metal_hash_table_insert(track_table, entry->ptr, entry);
+    if (entry->size > G_MAXULONG - current_memory) {
+        current_memory = G_MAXULONG;
+        overflowed = 1;
+    } else {
+        current_memory += entry->size;
+    }
+    max_memory = current_memory > max_memory ? current_memory : max_memory;
+    pthread_mutex_unlock(&track_mutex);
+    if (overflowed) {
+        note_memory_tracking_degraded("realloc rollback accounting overflow");
+    }
+}
+
+static int
+commit_reallocated_entry(AllocationEntry* entry,
+                         void* new_ptr,
+                         size_t new_size,
+                         gulong* current_after_add_out)
+{
+    pthread_mutex_lock(&track_mutex);
     if (new_size > G_MAXULONG - current_memory) {
-        gum_metal_hash_table_remove(track_table, old_ptr);
         pthread_mutex_unlock(&track_mutex);
         internal_free(entry);
-        peak_log_warn("[peak] memory profiler accounting overflow after realloc\n");
+        note_memory_tracking_degraded("realloc accounting overflow");
         return 0;
-    }
-    if (new_ptr != old_ptr) {
-        gum_metal_hash_table_remove(track_table, old_ptr);
-        gum_metal_hash_table_insert(track_table, new_ptr, entry);
     }
     entry->ptr = new_ptr;
     entry->size = new_size;
+    gum_metal_hash_table_insert(track_table, new_ptr, entry);
     current_memory += new_size;
     max_memory = current_memory > max_memory ? current_memory : max_memory;
     *current_after_add_out = current_memory;
     pthread_mutex_unlock(&track_mutex);
     return 1;
+}
+
+static void
+publish_removed_entry(AllocationEntry* entry, gulong current_after_remove)
+{
+    int64_t delta;
+
+    if (size_to_event_delta(entry->size, &delta)) {
+        peak_log_event(nsec_now(), -delta,
+                       (uint64_t) current_after_remove, 2);
+    }
 }
 
 static void
@@ -894,6 +920,9 @@ static void* custom_malloc(size_t size) {
 }
 
 static void custom_free(void* ptr) {
+    AllocationEntry* entry;
+    gulong current_after_remove = 0;
+
     if (!ptr) return;
 
     PeakMallocHookEntry hook_entry = malloc_hook_enter();
@@ -907,9 +936,13 @@ static void custom_free(void* ptr) {
 
     int hook_val = in_peak_alloc_hook;
     in_peak_alloc_hook = 1;
+    /* Keep the old entry local while the allocator exposes its address. */
+    entry = detach_tracking_entry(ptr, &current_after_remove);
     original_free(ptr);
-    AllocationEntry* entry = find_tracking_entry(ptr);
-    if (entry) remove_tracking_entry(ptr);
+    if (entry) {
+        publish_removed_entry(entry, current_after_remove);
+        internal_free(entry);
+    }
     in_peak_alloc_hook = hook_val;
     malloc_hook_leave();
 }
@@ -945,6 +978,13 @@ static void* custom_calloc(size_t nmemb, size_t size) {
 }
 
 static void* custom_realloc(void* ptr, size_t size) {
+    AllocationEntry* entry = NULL;
+    gulong current_after_remove = 0;
+    gulong current_after_add = 0;
+    int saved_errno = 0;
+    int realloc_errno;
+    int result_errno;
+
     PeakMallocHookEntry hook_entry = malloc_hook_enter();
     if (hook_entry != PEAK_MALLOC_HOOK_TRACKING) {
         void* result = original_realloc(ptr, size);
@@ -957,59 +997,61 @@ static void* custom_realloc(void* ptr, size_t size) {
     if (!ptr) {
         int hook_val = in_peak_alloc_hook;
         in_peak_alloc_hook = 1;
-        void* new_ptr = original_malloc(size);
+        void* new_ptr = original_realloc(NULL, size);
+        result_errno = errno;
         if (new_ptr) {
             int flag = peak_log_backtrace_malloc();
             add_tracking_entry(new_ptr, size, flag);
         }
+        errno = result_errno;
         in_peak_alloc_hook = hook_val;
         malloc_hook_leave();
         return new_ptr;
     }
-    if (!size) {
-        int hook_val = in_peak_alloc_hook;
-        in_peak_alloc_hook = 1;
-        original_free(ptr);
-        AllocationEntry* entry = find_tracking_entry(ptr);
-        if (entry) remove_tracking_entry(ptr);
-        in_peak_alloc_hook = hook_val;
-        malloc_hook_leave();
-        return NULL;
-    }
 
     int hook_val = in_peak_alloc_hook;
     in_peak_alloc_hook = 1;
+    /*
+     * Keep the entry operation-local while the allocator runs.  Failure
+     * restores the same lifetime without events; success publishes the old
+     * removal and commits the returned pointer as the new lifetime.
+     */
+    entry = detach_tracking_entry(ptr, &current_after_remove);
+
+    if (size == 0) {
+        saved_errno = errno;
+        errno = 0;
+    }
     void* new_ptr = original_realloc(ptr, size);
-    if (!new_ptr) {
-        /* ISO C preserves ptr on realloc failure; do not touch its entry. */
+    realloc_errno = errno;
+    result_errno = size == 0 && realloc_errno == 0
+        ? saved_errno
+        : realloc_errno;
+    if (!new_ptr && (size != 0 || realloc_errno == ENOMEM)) {
+        if (entry) restore_tracking_entry(entry);
+        errno = result_errno;
         in_peak_alloc_hook = hook_val;
         malloc_hook_leave();
         return NULL;
     }
 
-    size_t old_size;
-    gulong current_after_remove;
-    gulong current_after_add;
-    if (update_tracking_entry_after_realloc(ptr,
-                                            new_ptr,
-                                            size,
-                                            &old_size,
-                                            &current_after_remove,
-                                            &current_after_add)) {
-        int64_t old_delta;
+    if (entry) {
+        publish_removed_entry(entry, current_after_remove);
+    }
+    if (entry && new_ptr != NULL &&
+        commit_reallocated_entry(entry, new_ptr, size, &current_after_add)) {
         int64_t new_delta;
-        if (size_to_event_delta(old_size, &old_delta)) {
-            peak_log_event(nsec_now(), -old_delta,
-                           (uint64_t) current_after_remove, 2);
-        }
         if (size_to_event_delta(size, &new_delta)) {
             peak_log_event(nsec_now(), new_delta,
                            (uint64_t) current_after_add, 1);
         }
-    } else {
+    } else if (entry && new_ptr == NULL) {
+        internal_free(entry);
+    } else if (!entry && new_ptr != NULL) {
         int flag = peak_log_backtrace_malloc();
         add_tracking_entry(new_ptr, size, flag);
     }
+    errno = result_errno;
     in_peak_alloc_hook = hook_val;
     malloc_hook_leave();
 
@@ -1410,5 +1452,134 @@ peak_malloc_test_tracking_allocation_failure(void)
     original_malloc = saved_malloc;
     original_free = saved_free;
     return rejected;
+}
+
+int
+peak_malloc_test_begin(const PeakMallocTestAllocator* allocator)
+{
+    GumMetalHashTable* table;
+
+    if (allocator == NULL || allocator->malloc_fn == NULL ||
+        allocator->free_fn == NULL || allocator->realloc_fn == NULL ||
+        g_malloc_test_active || track_table != NULL) {
+        return 0;
+    }
+    table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
+    if (table == NULL) return 0;
+
+    g_malloc_test_saved_malloc = original_malloc;
+    g_malloc_test_saved_free = original_free;
+    g_malloc_test_saved_realloc = original_realloc;
+    g_malloc_test_saved_track_all = peak_memory_track_all;
+    original_malloc = allocator->malloc_fn;
+    original_free = allocator->free_fn;
+    original_realloc = allocator->realloc_fn;
+    peak_memory_track_all = TRUE;
+    track_table = table;
+    current_memory = 0;
+    max_memory = 0;
+    atomic_store_explicit(&cleanup_in_progress, 0, memory_order_release);
+    atomic_store_explicit(&active_alloc_hooks, 0, memory_order_release);
+    in_peak_alloc_hook = 0;
+    g_malloc_test_active = 1;
+    return 1;
+}
+
+int
+peak_malloc_test_seed(void* ptr, size_t size)
+{
+    AllocationEntry* entry;
+
+    if (!g_malloc_test_active || ptr == NULL) return 0;
+    entry = original_malloc(sizeof(*entry));
+    if (entry == NULL) return 0;
+    entry->ptr = ptr;
+    entry->size = size;
+
+    pthread_mutex_lock(&track_mutex);
+    if (gum_metal_hash_table_lookup(track_table, ptr) != NULL ||
+        size > G_MAXULONG - current_memory) {
+        pthread_mutex_unlock(&track_mutex);
+        original_free(entry);
+        return 0;
+    }
+    gum_metal_hash_table_insert(track_table, ptr, entry);
+    current_memory += size;
+    max_memory = current_memory > max_memory ? current_memory : max_memory;
+    pthread_mutex_unlock(&track_mutex);
+    return 1;
+}
+
+void*
+peak_malloc_test_malloc(size_t size)
+{
+    return g_malloc_test_active ? custom_malloc(size) : NULL;
+}
+
+void
+peak_malloc_test_free(void* ptr)
+{
+    if (g_malloc_test_active) custom_free(ptr);
+}
+
+void*
+peak_malloc_test_realloc(void* ptr, size_t size)
+{
+    return g_malloc_test_active ? custom_realloc(ptr, size) : NULL;
+}
+
+void
+peak_malloc_test_tracking_snapshot(void* ptr,
+                                   PeakMallocTestTrackingSnapshot* out)
+{
+    GumMetalHashTableIter iter;
+    gpointer value;
+    AllocationEntry* observed;
+
+    if (out == NULL) return;
+    memset(out, 0, sizeof(*out));
+    if (!g_malloc_test_active) return;
+
+    pthread_mutex_lock(&track_mutex);
+    out->entry_count = gum_metal_hash_table_size(track_table);
+    gum_metal_hash_table_iter_init(&iter, track_table);
+    while (gum_metal_hash_table_iter_next(&iter, NULL, &value)) {
+        AllocationEntry* entry = value;
+        out->table_bytes += entry->size;
+    }
+    out->current_bytes = current_memory;
+    observed = gum_metal_hash_table_lookup(track_table, ptr);
+    if (observed != NULL) {
+        out->pointer_tracked = 1;
+        out->pointer_size = observed->size;
+    }
+    pthread_mutex_unlock(&track_mutex);
+}
+
+void
+peak_malloc_test_end(void)
+{
+    GumMetalHashTable* table;
+    GumMetalHashTableIter iter;
+    gpointer value;
+
+    if (!g_malloc_test_active) return;
+    pthread_mutex_lock(&track_mutex);
+    table = track_table;
+    track_table = NULL;
+    current_memory = 0;
+    max_memory = 0;
+    pthread_mutex_unlock(&track_mutex);
+
+    gum_metal_hash_table_iter_init(&iter, table);
+    while (gum_metal_hash_table_iter_next(&iter, NULL, &value)) {
+        original_free(value);
+    }
+    gum_metal_hash_table_unref(table);
+    original_malloc = g_malloc_test_saved_malloc;
+    original_free = g_malloc_test_saved_free;
+    original_realloc = g_malloc_test_saved_realloc;
+    peak_memory_track_all = g_malloc_test_saved_track_all;
+    g_malloc_test_active = 0;
 }
 #endif

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -4,16 +4,51 @@
 #include "internal/general_listener/output_identity.h"
 #include "logging.h"
 #include "utils/env_parser.h"
+#include <stddef.h>
 #include <sched.h>
 
 /*=========================
   Types
 =========================*/
 
+#define PEAK_ACCOUNTING_SHARD_COUNT 4096u
+#define PEAK_HOOK_ACTIVITY_SHARD_COUNT 4096u
+#define PEAK_TRACKING_RADIX_BITS 10u
+#define PEAK_TRACKING_RADIX_SIZE (1u << PEAK_TRACKING_RADIX_BITS)
+#define PEAK_TRACKING_RADIX_MASK (PEAK_TRACKING_RADIX_SIZE - 1u)
+#define PEAK_TRACKING_RADIX_LEVELS \
+    ((sizeof(uintptr_t) * CHAR_BIT + PEAK_TRACKING_RADIX_BITS - 1u) / \
+     PEAK_TRACKING_RADIX_BITS)
+
+_Static_assert((PEAK_ACCOUNTING_SHARD_COUNT &
+                (PEAK_ACCOUNTING_SHARD_COUNT - 1u)) == 0,
+               "accounting shard count must be a power of two");
+_Static_assert((PEAK_HOOK_ACTIVITY_SHARD_COUNT &
+                (PEAK_HOOK_ACTIVITY_SHARD_COUNT - 1u)) == 0,
+               "hook activity shard count must be a power of two");
+_Static_assert(offsetof(PeakMemLog, reserved) % 64u == 0,
+               "memlog reservation counter must start a cache line");
+_Static_assert(offsetof(PeakMemLog, state) % 64u == 0,
+               "memlog state gate must start a cache line");
+
+typedef struct __attribute__((aligned(64))) {
+    _Atomic gulong current_bytes;
+    _Atomic uint64_t next_sequence;
+} PeakAccountingShard;
+
 typedef struct {
-    void*   ptr;
-    size_t  size;
-} AllocationEntry;
+    _Atomic uintptr_t slots[PEAK_TRACKING_RADIX_SIZE];
+} PeakTrackingRadixNode;
+
+typedef struct __attribute__((aligned(64))) {
+    _Atomic unsigned int active;
+} PeakHookActivityShard;
+
+typedef struct {
+    uint64_t timestamp_ns;
+    uint64_t sequence;
+    uint16_t shard;
+} PeakTrackingTransition;
 
 /*=========================
   mmapped event buffer (binary, fixed capacity)
@@ -21,6 +56,12 @@ typedef struct {
 #ifndef PEAK_MEMLOG_CHUNK_EVENTS
 #define PEAK_MEMLOG_CHUNK_EVENTS (1u * 500u * 1000u) /* fixed event capacity */
 #endif
+#define PEAK_MEMLOG_RESERVATION_BLOCK 64u
+#define PEAK_MEMLOG_BLOCK_THRESHOLD 65536u
+/* Matches PEAK_MAX_NUM_THREADS_LIMIT; each producer can strand at most one
+ * ready-flag cache line of physical slots without reducing the configured
+ * export capacity. */
+#define PEAK_MEMLOG_MAX_TRACKED_THREADS 4096u
 
 /*=========================
   Globals
@@ -29,16 +70,17 @@ extern gboolean            peak_memory_track_all;
 extern size_t              peak_hook_address_count;
 extern char**              peak_hook_strings;
 static GumInterceptor*     malloc_interceptor;
-static pthread_mutex_t     track_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t     caller_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t     memlog_finalize_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t     memlog_admission_mutex = PTHREAD_MUTEX_INITIALIZER;
-static GumMetalHashTable*  track_table = NULL;
+static pthread_once_t      malloc_tid_cache_once = PTHREAD_ONCE_INIT;
+static PeakAccountingShard accounting_shards[PEAK_ACCOUNTING_SHARD_COUNT];
+static PeakTrackingRadixNode tracking_root;
+static _Atomic int         tracking_tables_active = 0;
 static GumMetalHashTable*  memory_caller_target_table = NULL;
 static _Atomic int         cleanup_in_progress = 0;
-static _Atomic int         active_alloc_hooks = 0;
-static gulong              max_memory = 0;
-static gulong              current_memory = 0;
+static PeakHookActivityShard hook_activity_shards[PEAK_HOOK_ACTIVITY_SHARD_COUNT];
+static _Atomic gulong      max_memory = 0;
+static _Atomic gulong      fallback_current_memory = 0;
 static gpointer            malloc_addr = NULL;
 static gpointer            free_addr = NULL;
 static gpointer            calloc_addr = NULL;
@@ -58,8 +100,15 @@ static PeakMemLog          g_memlog = {
 };
 static __thread int        in_peak_alloc_hook = 0;
 static __thread int        in_backtrace = 0;
+static __thread uint32_t   cached_thread_id = 0;
+static _Atomic int         thread_id_cache_ready = 0;
+#ifndef PEAK_ENABLE_TEST_HOOKS
+static __thread size_t     memlog_reservation_next = 0;
+static __thread size_t     memlog_reservation_end = 0;
+#endif
 static PeakEnvWarningState peak_memlog_capacity_warning_emitted;
 static _Atomic int         peak_memory_tracking_warning_emitted = 0;
+static _Atomic int         peak_memlog_full = 0;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic PeakMemLogTestFailure g_memlog_test_failure = PEAK_MEMLOG_TEST_FAIL_NONE;
@@ -88,8 +137,18 @@ peak_malloc_test_should_fail_replace(const char* name)
     return configured != NULL && name != NULL &&
            strcmp(configured, name) == 0;
 }
+static gboolean
+peak_malloc_test_should_force_standard_replace(const char* name)
+{
+    const char* configured = getenv("PEAK_TEST_FORCE_MALLOC_STANDARD_REPLACE");
+
+    return configured != NULL && name != NULL &&
+           strcmp(configured, name) == 0;
+}
 #define PEAK_MALLOC_REPLACE_FAST(_addr, _hook, _orig, _name) \
     (peak_malloc_test_should_fail_replace(_name) ? GUM_REPLACE_WRONG_TYPE : \
+     peak_malloc_test_should_force_standard_replace(_name) ? \
+         GUM_REPLACE_WRONG_SIGNATURE : \
      gum_interceptor_replace_fast(malloc_interceptor, _addr, _hook, \
                                   (gpointer*)(&_orig), NULL))
 #else
@@ -113,7 +172,7 @@ static int   (*original_posix_memalign)(void** memptr, size_t alignment, size_t 
   Internal alloc helpers (use originals)
 =========================*/
 
-static void* internal_malloc(size_t size) {
+static int peak_tracking_entry_prepare(void) {
 #ifdef PEAK_ENABLE_TEST_HOOKS
     PeakMemLogTestFailure expected = PEAK_MEMLOG_TEST_FAIL_ALLOCATION;
     if (atomic_compare_exchange_strong_explicit(&g_memlog_test_failure,
@@ -122,28 +181,52 @@ static void* internal_malloc(size_t size) {
                                                 memory_order_acq_rel,
                                                 memory_order_acquire)) {
         errno = ENOMEM;
-        return NULL;
+        return 0;
     }
 #endif
-    return original_malloc(size);
+    return 1;
 }
-static void  internal_free(void* ptr)     { original_free(ptr); }
 
 /*=========================
   Fast time & TID helpers
 =========================*/
 
 static inline uint32_t peak_gettid(void) {
+    uint32_t thread_id;
+
+    if (cached_thread_id != 0) return cached_thread_id;
 #ifdef SYS_gettid
-    return (uint32_t) syscall(SYS_gettid);
+    thread_id = (uint32_t) syscall(SYS_gettid);
 #else
-    return (uint32_t) getpid();
+    thread_id = (uint32_t) getpid();
 #endif
+    if (atomic_load_explicit(&thread_id_cache_ready, memory_order_acquire)) {
+        cached_thread_id = thread_id;
+    }
+    return thread_id;
+}
+
+static void
+malloc_tid_cache_atfork_child(void)
+{
+    cached_thread_id = 0;
+#ifndef PEAK_ENABLE_TEST_HOOKS
+    memlog_reservation_next = 0;
+    memlog_reservation_end = 0;
+#endif
+}
+
+static void
+malloc_tid_cache_initialize(void)
+{
+    if (pthread_atfork(NULL, NULL, malloc_tid_cache_atfork_child) == 0) {
+        atomic_store_explicit(&thread_id_cache_ready, 1, memory_order_release);
+    }
 }
 
 static inline uint64_t nsec_now(void) {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t) ts.tv_sec * 1000000000ull + (uint64_t) ts.tv_nsec;
 }
 
@@ -293,29 +376,66 @@ static void build_paths(char out_tmp[512], char out_csv[512], char out_otf2[512]
   Memlog: fixed mapping / publish / finalize
 =========================*/
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
 static int peak_memlog_writer_enter(void) {
-    int admitted = 0;
-    pthread_mutex_lock(&memlog_admission_mutex);
+    if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) !=
+        PEAK_MEMLOG_ACTIVE) {
+        return 0;
+    }
+    atomic_fetch_add_explicit(&g_memlog.active_writers, 1,
+                              memory_order_acq_rel);
     if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) ==
         PEAK_MEMLOG_ACTIVE) {
-        admitted = 1;
+        return 1;
     }
-    if (admitted) {
-        atomic_fetch_add_explicit(&g_memlog.active_writers, 1, memory_order_acq_rel);
-    }
-    pthread_mutex_unlock(&memlog_admission_mutex);
-    return admitted;
+    atomic_fetch_sub_explicit(&g_memlog.active_writers, 1,
+                              memory_order_release);
+    return 0;
 }
 
 static void peak_memlog_writer_leave(void) {
     atomic_fetch_sub_explicit(&g_memlog.active_writers, 1, memory_order_release);
 }
+#endif
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic uint8_t* peak_memlog_ready_flags(void) {
     return (_Atomic uint8_t*) ((uint8_t*) g_memlog.map + g_memlog.ready_offset);
 }
+#endif
 
 static int peak_memlog_reserve_slot(size_t* index_out) {
+#ifndef PEAK_ENABLE_TEST_HOOKS
+    size_t reserved;
+    size_t reservation_count = 1;
+
+    if (atomic_load_explicit(&peak_memlog_full, memory_order_relaxed)) {
+        atomic_fetch_add_explicit(&g_memlog.dropped, 1, memory_order_relaxed);
+        return 0;
+    }
+    if (g_memlog.storage_capacity_events != g_memlog.capacity_events) {
+        if (memlog_reservation_next != memlog_reservation_end) {
+            *index_out = memlog_reservation_next++;
+            return 1;
+        }
+        reservation_count = PEAK_MEMLOG_RESERVATION_BLOCK;
+    }
+    reserved = atomic_fetch_add_explicit(&g_memlog.reserved,
+                                         reservation_count,
+                                         memory_order_relaxed);
+    if (reserved >= g_memlog.storage_capacity_events) {
+        atomic_store_explicit(&peak_memlog_full, 1, memory_order_relaxed);
+        atomic_fetch_add_explicit(&g_memlog.dropped, 1, memory_order_relaxed);
+        return 0;
+    }
+    *index_out = reserved;
+    memlog_reservation_next = reserved + 1;
+    memlog_reservation_end = reserved + reservation_count;
+    if (memlog_reservation_end > g_memlog.storage_capacity_events) {
+        memlog_reservation_end = g_memlog.storage_capacity_events;
+    }
+    return 1;
+#else
     size_t reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_relaxed);
 
     for (;;) {
@@ -332,6 +452,7 @@ static int peak_memlog_reserve_slot(size_t* index_out) {
             return 1;
         }
     }
+#endif
 }
 
 static int peak_memlog_ftruncate(int fd, size_t bytes) {
@@ -345,28 +466,39 @@ static int peak_memlog_ftruncate(int fd, size_t bytes) {
     return ftruncate(fd, (off_t) bytes);
 }
 
-static inline void peak_log_event(uint64_t ts, int64_t delta, uint64_t current, uint8_t op) {
+static inline int
+peak_log_event_write(uint64_t ts,
+                     int64_t delta,
+                     uint64_t current,
+                     uint8_t op,
+                     uint16_t accounting_shard,
+                     uint64_t accounting_sequence)
+{
     size_t index;
     PeakMemEvent* event;
+#ifdef PEAK_ENABLE_TEST_HOOKS
     _Atomic uint8_t* ready;
+#endif
     uint8_t* base;
 
-    if (!peak_memlog_writer_enter()) return;
     if (!peak_memlog_reserve_slot(&index)) {
-        peak_memlog_writer_leave();
-        return;
+        return 0;
     }
 
     base = (uint8_t*) g_memlog.map + g_memlog.header_bytes;
     event = (PeakMemEvent*) (base + index * sizeof(*event));
+#ifdef PEAK_ENABLE_TEST_HOOKS
     ready = peak_memlog_ready_flags();
+#endif
     event->ts_ns = ts;
     event->delta = delta;
     event->current = current;
+    event->accounting_sequence = accounting_sequence;
     event->tid = peak_gettid();
-    event->op = op;
+    event->accounting_shard = accounting_shard;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
+    event->op = op;
     if (atomic_load_explicit(&g_memlog_test_pause_before_commit,
                              memory_order_acquire)) {
         atomic_store_explicit(&g_memlog_test_writer_paused, 1, memory_order_release);
@@ -376,25 +508,42 @@ static inline void peak_log_event(uint64_t ts, int64_t delta, uint64_t current, 
         }
         atomic_store_explicit(&g_memlog_test_writer_paused, 0, memory_order_release);
     }
-#endif
-
-    /* Release publishes every payload field to an acquire scanner/exporter. */
     atomic_store_explicit(&ready[index], 1, memory_order_release);
-    atomic_fetch_add_explicit(&g_memlog.committed, 1, memory_order_release);
-    peak_memlog_writer_leave();
+    atomic_fetch_add_explicit(&g_memlog.committed, 1,
+                              memory_order_release);
+#else
+    /* Production finalization starts only after allocation hooks quiesce.
+     * Publishing op last distinguishes completed records from unused slots
+     * without a second per-event atomic write on the allocation hot path. */
+    event->op = op;
+#endif
+    return 1;
+}
+
+static inline void
+peak_log_event(uint64_t ts,
+               int64_t delta,
+               uint64_t current,
+               uint8_t op,
+               uint16_t accounting_shard,
+               uint64_t accounting_sequence)
+{
+    /* Allocation hooks are quiesced before production finalization, so their
+     * hot path needs only the state gate.  The test API below retains explicit
+     * writer admission for concurrent-finalizer coverage. */
+    if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) !=
+        PEAK_MEMLOG_ACTIVE) {
+        return;
+    }
+    (void)peak_log_event_write(ts, delta, current, op,
+                               accounting_shard, accounting_sequence);
 }
 
 static void peak_memlog_disable(void) {
     PeakMemLogState state;
 
-    /* The mutex closes admission before a finalizer observes writer count. */
-    pthread_mutex_lock(&memlog_admission_mutex);
-    state = atomic_load_explicit(&g_memlog.state, memory_order_acquire);
-    if (state == PEAK_MEMLOG_ACTIVE) {
-        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED,
-                              memory_order_release);
-    }
-    pthread_mutex_unlock(&memlog_admission_mutex);
+    state = atomic_exchange_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED,
+                                     memory_order_acq_rel);
 
     if (state == PEAK_MEMLOG_ACTIVE || state == PEAK_MEMLOG_DISABLED) {
         while (atomic_load_explicit(&g_memlog.active_writers,
@@ -408,14 +557,24 @@ static size_t peak_memlog_compact_committed(void) {
     size_t reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_acquire);
     size_t complete = 0;
     uint8_t* base;
+#ifdef PEAK_ENABLE_TEST_HOOKS
     _Atomic uint8_t* ready;
+#endif
 
-    if (reserved > g_memlog.capacity_events) reserved = g_memlog.capacity_events;
+    if (reserved > g_memlog.storage_capacity_events) {
+        reserved = g_memlog.storage_capacity_events;
+    }
     base = (uint8_t*) g_memlog.map + g_memlog.header_bytes;
+#ifdef PEAK_ENABLE_TEST_HOOKS
     ready = peak_memlog_ready_flags();
+#endif
     for (size_t i = 0; i < reserved; ++i) {
         PeakMemEvent* source = (PeakMemEvent*) (base + i * sizeof(*source));
+#ifdef PEAK_ENABLE_TEST_HOOKS
         if (!atomic_load_explicit(&ready[i], memory_order_acquire)) continue;
+#else
+        if (source->op == 0) continue;
+#endif
 
         if (complete != i) {
             PeakMemEvent* destination =
@@ -423,7 +582,9 @@ static size_t peak_memlog_compact_committed(void) {
             destination->ts_ns = source->ts_ns;
             destination->delta = source->delta;
             destination->current = source->current;
+            destination->accounting_sequence = source->accounting_sequence;
             destination->tid = source->tid;
+            destination->accounting_shard = source->accounting_shard;
             destination->op = source->op;
         }
         ++complete;
@@ -431,8 +592,73 @@ static size_t peak_memlog_compact_committed(void) {
     return complete;
 }
 
+static int
+peak_memlog_event_order_compare(const void* left_opaque,
+                                const void* right_opaque)
+{
+    const PeakMemEvent* left = left_opaque;
+    const PeakMemEvent* right = right_opaque;
+
+    if (left->ts_ns != right->ts_ns) {
+        return left->ts_ns < right->ts_ns ? -1 : 1;
+    }
+    if (left->accounting_shard == right->accounting_shard &&
+        left->accounting_shard != UINT16_MAX &&
+        left->accounting_sequence != right->accounting_sequence) {
+        return left->accounting_sequence < right->accounting_sequence ? -1 : 1;
+    }
+    if (left->accounting_shard != right->accounting_shard) {
+        return left->accounting_shard < right->accounting_shard ? -1 : 1;
+    }
+    if (left->accounting_sequence != right->accounting_sequence) {
+        return left->accounting_sequence < right->accounting_sequence ? -1 : 1;
+    }
+    if (left->tid != right->tid) return left->tid < right->tid ? -1 : 1;
+    return 0;
+}
+
+static void
+peak_memlog_replay_accounting(PeakMemEvent* events, size_t count)
+{
+    uint64_t current = 0;
+    uint64_t maximum = 0;
+    int valid = 1;
+
+    qsort(events, count, sizeof(*events), peak_memlog_event_order_compare);
+    for (size_t i = 0; i < count; ++i) {
+        int64_t delta = events[i].delta;
+
+        if (delta >= 0) {
+            uint64_t increase = (uint64_t)delta;
+            if (increase > UINT64_MAX - current) {
+                current = UINT64_MAX;
+                valid = 0;
+            } else {
+                current += increase;
+            }
+        } else {
+            uint64_t decrease = (uint64_t)(-(delta + 1)) + 1u;
+            if (decrease > current) {
+                current = 0;
+                valid = 0;
+            } else {
+                current -= decrease;
+            }
+        }
+        events[i].current = current;
+        if (current > maximum) maximum = current;
+    }
+    atomic_store_explicit(&max_memory,
+                          maximum > G_MAXULONG ? G_MAXULONG : (gulong)maximum,
+                          memory_order_relaxed);
+    if (!valid) {
+        peak_log_warn("[peak] memlog: allocation accounting replay overflowed or underflowed\n");
+    }
+}
+
 static void peak_memlog_open(void) {
     size_t capacity_events = PEAK_MEMLOG_CHUNK_EVENTS;
+    size_t storage_capacity_events;
     size_t header_bytes;
     size_t event_bytes;
     size_t ready_offset;
@@ -464,11 +690,27 @@ static void peak_memlog_open(void) {
     }
 #endif
 
+    storage_capacity_events = capacity_events;
+#ifndef PEAK_ENABLE_TEST_HOOKS
+    if (capacity_events >= PEAK_MEMLOG_BLOCK_THRESHOLD &&
+        !checked_add_size(capacity_events,
+                          PEAK_MEMLOG_MAX_TRACKED_THREADS *
+                              (PEAK_MEMLOG_RESERVATION_BLOCK - 1u),
+                          &storage_capacity_events)) {
+        peak_log_warn("[peak] memlog: reservation slack overflow; disabling log\n");
+        atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED,
+                              memory_order_release);
+        return;
+    }
+#endif
+
     if (!page_align_up(sizeof(PeakMemHeader), &header_bytes) ||
         header_bytes > UINT32_MAX ||
-        !checked_mul_size(capacity_events, sizeof(PeakMemEvent), &event_bytes) ||
+        !checked_mul_size(storage_capacity_events, sizeof(PeakMemEvent),
+                          &event_bytes) ||
         !checked_add_size(header_bytes, event_bytes, &ready_offset) ||
-        !checked_mul_size(capacity_events, sizeof(_Atomic uint8_t), &ready_bytes) ||
+        !checked_mul_size(storage_capacity_events, sizeof(_Atomic uint8_t),
+                          &ready_bytes) ||
         !checked_add_size(ready_offset, ready_bytes, &map_bytes) ||
         !size_fits_off_t(map_bytes)) {
         peak_log_warn("[peak] memlog: fixed storage size is invalid; disabling log\n");
@@ -519,7 +761,8 @@ static void peak_memlog_open(void) {
     } else
 #endif
     {
-        base = mmap(NULL, map_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        base = mmap(NULL, map_bytes, PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     }
     if (base == MAP_FAILED) {
         peak_log_warn("[peak] memlog: mmap init failed: %s\n", strerror(errno));
@@ -529,13 +772,15 @@ static void peak_memlog_open(void) {
         return;
     }
 
+    /* Keep anonymous first-write faults out of allocation hooks. */
+    memset(base, 0, map_bytes);
+
     PeakMemHeader* hdr = (PeakMemHeader*) base;
-    memset(hdr, 0, sizeof(*hdr));
     memcpy(hdr->magic, "PEAKMEM\0", 8);
     hdr->header_bytes = (uint32_t) header_bytes;
     g_memlog.t0_ns = nsec_now();
     hdr->t0_ns = g_memlog.t0_ns;
-    hdr->clock_id = (uint64_t) CLOCK_MONOTONIC_RAW;
+    hdr->clock_id = (uint64_t) CLOCK_MONOTONIC;
     {
         int rank = -1;
         get_mpi_rank(&rank);
@@ -549,17 +794,19 @@ static void peak_memlog_open(void) {
     g_memlog.map_bytes = map_bytes;
     g_memlog.header_bytes = header_bytes;
     g_memlog.capacity_events = capacity_events;
+    g_memlog.storage_capacity_events = storage_capacity_events;
     g_memlog.ready_offset = ready_offset;
     atomic_store_explicit(&g_memlog.reserved, 0, memory_order_relaxed);
     atomic_store_explicit(&g_memlog.committed, 0, memory_order_relaxed);
     atomic_store_explicit(&g_memlog.dropped, 0, memory_order_relaxed);
     atomic_store_explicit(&g_memlog.active_writers, 0, memory_order_relaxed);
+    atomic_store_explicit(&peak_memlog_full, 0, memory_order_relaxed);
 #ifdef PEAK_ENABLE_TEST_HOOKS
     atomic_store_explicit(&g_memlog_test_exported, 0, memory_order_relaxed);
 #endif
     atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_ACTIVE, memory_order_release);
 
-    peak_log_event(nsec_now(), 0, 0, 1);
+    peak_log_event(nsec_now(), 0, 0, 1, UINT16_MAX, 0);
 }
 
 /* small helper to keep CSV emit identical but clearer */
@@ -572,11 +819,9 @@ static inline int peak_csv_emit_line(int fd_csv, const PeakMemEvent *e) {
                    (unsigned)           e->op) >= 0;
 }
 
-/* Convert the mmapped binary buffer to a CSV file (and remove the temp backing file). */
+/* Convert the fixed event buffer to CSV and remove its temporary reservation. */
 static void peak_memlog_finalize(void) {
     size_t events;
-    size_t event_bytes;
-    size_t used_bytes;
     PeakMemLogState state;
 
     /* Serialize finalizers; a DISABLED state can still have admitted writers. */
@@ -601,21 +846,22 @@ static void peak_memlog_finalize(void) {
 
     /* Never use committed as a prefix length: reservations can complete out of order. */
     events = peak_memlog_compact_committed();
-    if (!checked_mul_size(events, sizeof(PeakMemEvent), &event_bytes) ||
-        !checked_add_size(g_memlog.header_bytes, event_bytes, &used_bytes)) {
-        peak_log_warn("[peak] memlog: final size overflow; exporting no events\n");
-        events = 0;
-        used_bytes = g_memlog.header_bytes;
+    if (events > g_memlog.capacity_events) {
+        atomic_fetch_add_explicit(&g_memlog.dropped,
+                                  events - g_memlog.capacity_events,
+                                  memory_order_relaxed);
+        events = g_memlog.capacity_events;
     }
+    atomic_store_explicit(&g_memlog.committed, events, memory_order_release);
 #ifdef PEAK_ENABLE_TEST_HOOKS
     atomic_store_explicit(&g_memlog_test_exported, events, memory_order_release);
 #endif
 
-    msync(g_memlog.map, used_bytes, MS_SYNC);
-
     /* base pointer of the events region (after header) */
     uint8_t *base_bytes = (uint8_t *) g_memlog.map + g_memlog.header_bytes;
     PeakMemEvent *base_chunk  = (PeakMemEvent *) base_bytes;
+
+    peak_memlog_replay_accounting(base_chunk, events);
 
     /* 1) OTF2 export */
     peak_memlog_export_otf2(g_memlog.otf2_prefix, base_chunk, events);
@@ -677,6 +923,7 @@ static void peak_memlog_finalize(void) {
     g_memlog.map = NULL;
     g_memlog.map_bytes = 0;
     g_memlog.capacity_events = 0;
+    g_memlog.storage_capacity_events = 0;
     g_memlog.fd = -1;
     atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_FINALIZED, memory_order_release);
     pthread_mutex_unlock(&memlog_finalize_mutex);
@@ -696,127 +943,348 @@ note_memory_tracking_degraded(const char* reason)
     }
 }
 
-static void add_tracking_entry(void* ptr, size_t size, int log) {
-    if (!track_table || atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) return;
-    if (!log) return;
+static int
+tracking_tables_create(void)
+{
+    if (atomic_load_explicit(&tracking_tables_active, memory_order_acquire)) {
+        return 0;
+    }
+    if (!atomic_is_lock_free(&tracking_root.slots[0]) ||
+        !atomic_is_lock_free(&accounting_shards[0].current_bytes) ||
+        !atomic_is_lock_free(&accounting_shards[0].next_sequence)) {
+        return 0;
+    }
+    for (size_t i = 0; i < PEAK_ACCOUNTING_SHARD_COUNT; ++i) {
+        atomic_store_explicit(&accounting_shards[i].current_bytes, 0,
+                              memory_order_relaxed);
+        atomic_store_explicit(&accounting_shards[i].next_sequence, 0,
+                              memory_order_relaxed);
+    }
+    atomic_store_explicit(&max_memory, 0, memory_order_relaxed);
+    atomic_store_explicit(&fallback_current_memory, 0, memory_order_relaxed);
+    atomic_store_explicit(&tracking_tables_active, 1, memory_order_release);
+    return 1;
+}
 
-    AllocationEntry* entry = internal_malloc(sizeof(AllocationEntry));
-    if (!entry) {
+static void
+tracking_radix_release_node(PeakTrackingRadixNode* node,
+                            unsigned int remaining_levels)
+{
+    for (size_t i = 0; i < PEAK_TRACKING_RADIX_SIZE; ++i) {
+        uintptr_t value = atomic_load_explicit(&node->slots[i],
+                                               memory_order_relaxed);
+        if (value == 0) continue;
+        if (remaining_levels > 1) {
+            tracking_radix_release_node((PeakTrackingRadixNode*)value,
+                                        remaining_levels - 1);
+        }
+        original_free((void*)value);
+        atomic_store_explicit(&node->slots[i], 0, memory_order_relaxed);
+    }
+}
+
+static void
+tracking_tables_release(void)
+{
+    atomic_store_explicit(&tracking_tables_active, 0, memory_order_release);
+    tracking_radix_release_node(&tracking_root,
+                                PEAK_TRACKING_RADIX_LEVELS - 1u);
+    for (size_t i = 0; i < PEAK_ACCOUNTING_SHARD_COUNT; ++i) {
+        atomic_store_explicit(&accounting_shards[i].current_bytes, 0,
+                              memory_order_relaxed);
+        atomic_store_explicit(&accounting_shards[i].next_sequence, 0,
+                              memory_order_relaxed);
+    }
+}
+
+static PeakTrackingRadixNode*
+tracking_radix_allocate_node(void)
+{
+    PeakTrackingRadixNode* node = original_malloc(sizeof(*node));
+
+    if (node != NULL) memset(node, 0, sizeof(*node));
+    return node;
+}
+
+static _Atomic uintptr_t*
+tracking_radix_slot(const void* ptr, int create)
+{
+    PeakTrackingRadixNode* node = &tracking_root;
+    uintptr_t key = (uintptr_t)ptr;
+
+    for (unsigned int level = PEAK_TRACKING_RADIX_LEVELS - 1u;
+         level != 0; --level) {
+        unsigned int shift = level * PEAK_TRACKING_RADIX_BITS;
+        size_t index = (size_t)((key >> shift) & PEAK_TRACKING_RADIX_MASK);
+        uintptr_t child = atomic_load_explicit(&node->slots[index],
+                                               memory_order_acquire);
+
+        if (child == 0) {
+            PeakTrackingRadixNode* allocated;
+            uintptr_t expected = 0;
+
+            if (!create) return NULL;
+            allocated = tracking_radix_allocate_node();
+            if (allocated == NULL) return NULL;
+            if (!atomic_compare_exchange_strong_explicit(
+                    &node->slots[index], &expected, (uintptr_t)allocated,
+                    memory_order_release, memory_order_acquire)) {
+                original_free(allocated);
+                child = expected;
+            } else {
+                child = (uintptr_t)allocated;
+            }
+        }
+        node = (PeakTrackingRadixNode*)child;
+    }
+    return &node->slots[key & PEAK_TRACKING_RADIX_MASK];
+}
+
+static int
+tracking_radix_insert(const void* ptr, size_t size)
+{
+    _Atomic uintptr_t* slot;
+    uintptr_t expected = 0;
+
+    if (size == SIZE_MAX) return 0;
+    slot = tracking_radix_slot(ptr, 1);
+    return slot != NULL && atomic_compare_exchange_strong_explicit(
+        slot, &expected, (uintptr_t)size + 1u,
+        memory_order_release, memory_order_relaxed);
+}
+
+static int
+tracking_radix_remove(const void* ptr, size_t* size_out)
+{
+    _Atomic uintptr_t* slot = tracking_radix_slot(ptr, 0);
+    uintptr_t encoded;
+
+    if (slot == NULL) return 0;
+    encoded = atomic_exchange_explicit(slot, 0, memory_order_acq_rel);
+    if (encoded == 0) return 0;
+    *size_out = (size_t)(encoded - 1u);
+    return 1;
+}
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static int
+tracking_radix_lookup(const void* ptr, size_t* size_out)
+{
+    _Atomic uintptr_t* slot = tracking_radix_slot(ptr, 0);
+    uintptr_t encoded;
+
+    if (slot == NULL) return 0;
+    encoded = atomic_load_explicit(slot, memory_order_acquire);
+    if (encoded == 0) return 0;
+    *size_out = (size_t)(encoded - 1u);
+    return 1;
+}
+#endif
+
+static PeakAccountingShard*
+accounting_shard_for(const void* ptr)
+{
+    uintptr_t value = (uintptr_t)ptr >> 4;
+
+    value ^= value >> 17;
+    value ^= value >> 9;
+    return &accounting_shards[value & (PEAK_ACCOUNTING_SHARD_COUNT - 1u)];
+}
+
+static int
+tracking_fallback_account_add(size_t size)
+{
+    gulong observed = atomic_load_explicit(&fallback_current_memory,
+                                           memory_order_relaxed);
+    gulong updated;
+
+    if ((uintmax_t)size > G_MAXULONG) return 0;
+    for (;;) {
+        if ((gulong)size > G_MAXULONG - observed) return 0;
+        updated = observed + (gulong)size;
+        if (atomic_compare_exchange_weak_explicit(&fallback_current_memory,
+                                                  &observed, updated,
+                                                  memory_order_relaxed,
+                                                  memory_order_relaxed)) {
+            gulong maximum = atomic_load_explicit(&max_memory,
+                                                  memory_order_relaxed);
+            while (maximum < updated &&
+                   !atomic_compare_exchange_weak_explicit(
+                       &max_memory, &maximum, updated,
+                       memory_order_relaxed, memory_order_relaxed)) {
+            }
+            return 1;
+        }
+    }
+}
+
+static int
+tracking_account_add(PeakAccountingShard* shard,
+                     size_t size,
+                     PeakTrackingTransition* transition_out)
+{
+    gulong observed;
+    gulong updated;
+
+    if ((uintmax_t)size > G_MAXULONG) return 0;
+    if (transition_out != NULL) {
+        transition_out->timestamp_ns = nsec_now();
+        transition_out->sequence = atomic_fetch_add_explicit(
+            &shard->next_sequence, 1, memory_order_relaxed);
+        transition_out->shard = (uint16_t)(shard - accounting_shards);
+    }
+    if (atomic_load_explicit(&g_memlog.state, memory_order_relaxed) ==
+        PEAK_MEMLOG_ACTIVE) {
+        return 1;
+    }
+    observed = atomic_load_explicit(&shard->current_bytes,
+                                    memory_order_relaxed);
+    for (;;) {
+        if ((gulong)size > G_MAXULONG - observed) return 0;
+        updated = observed + (gulong)size;
+        if (atomic_compare_exchange_weak_explicit(
+                &shard->current_bytes, &observed, updated,
+                memory_order_relaxed, memory_order_relaxed)) {
+            break;
+        }
+    }
+    if (!tracking_fallback_account_add(size)) {
+        atomic_fetch_sub_explicit(&shard->current_bytes, (gulong)size,
+                                  memory_order_relaxed);
+        return 0;
+    }
+    return 1;
+}
+
+static void
+tracking_account_remove(PeakAccountingShard* shard,
+                        size_t size,
+                        PeakTrackingTransition* transition_out)
+{
+    transition_out->timestamp_ns = nsec_now();
+    transition_out->sequence = atomic_fetch_add_explicit(
+        &shard->next_sequence, 1, memory_order_relaxed);
+    transition_out->shard = (uint16_t)(shard - accounting_shards);
+    if (atomic_load_explicit(&g_memlog.state, memory_order_relaxed) ==
+        PEAK_MEMLOG_ACTIVE) {
+        return;
+    }
+    atomic_fetch_sub_explicit(&shard->current_bytes, (gulong)size,
+                              memory_order_relaxed);
+    atomic_fetch_sub_explicit(&fallback_current_memory, (gulong)size,
+                              memory_order_relaxed);
+}
+
+static int
+tracking_account_restore(PeakAccountingShard* shard, size_t size)
+{
+    return tracking_account_add(shard, size, NULL);
+}
+
+static void add_tracking_entry(void* ptr, size_t size, int log) {
+    PeakAccountingShard* shard;
+    PeakTrackingTransition transition;
+    size_t ignored_size;
+
+    if (!atomic_load_explicit(&tracking_tables_active, memory_order_acquire) ||
+        atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) return;
+    if (!log) return;
+    if (!peak_tracking_entry_prepare()) {
         note_memory_tracking_degraded("tracking entry allocation failed");
         return;
     }
 
-    entry->ptr      = ptr;
-    entry->size     = size;
-
-    pthread_mutex_lock(&track_mutex);
-    if (size > G_MAXULONG - current_memory) {
-        pthread_mutex_unlock(&track_mutex);
-        internal_free(entry);
+    if (!tracking_radix_insert(ptr, size)) {
+        note_memory_tracking_degraded("tracking radix insertion failed");
+        return;
+    }
+    shard = accounting_shard_for(ptr);
+    if (!tracking_account_add(shard, size, &transition)) {
+        (void)tracking_radix_remove(ptr, &ignored_size);
         note_memory_tracking_degraded("allocation accounting overflow");
         return;
     }
-    gum_metal_hash_table_insert(track_table, ptr, entry);
-    current_memory += size;
-    max_memory = current_memory > max_memory ? current_memory : max_memory;
-    gulong current_snapshot = current_memory;
-    pthread_mutex_unlock(&track_mutex);
 
     int64_t delta;
     if (log && size_to_event_delta(size, &delta)) {
-        peak_log_event(nsec_now(), delta, (uint64_t) current_snapshot, 1);
+        peak_log_event(transition.timestamp_ns, delta, 0, 1,
+                       transition.shard, transition.sequence);
     }
 }
 
-static AllocationEntry*
-detach_tracking_entry(void* ptr, gulong* current_after_remove_out)
+static int
+detach_tracking_entry(void* ptr,
+                      size_t* size_out,
+                      PeakTrackingTransition* transition_out)
 {
-    AllocationEntry* entry;
+    PeakAccountingShard* shard;
 
-    if (!track_table ||
+    if (!atomic_load_explicit(&tracking_tables_active, memory_order_acquire) ||
         atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) {
-        return NULL;
+        return 0;
     }
 
-    /*
-     * Removing the entry and its bytes under one lock is the lifetime
-     * transition.  It must precede the allocator call, which may immediately
-     * make the same address visible to another allocation.
-     */
-    pthread_mutex_lock(&track_mutex);
-    entry = gum_metal_hash_table_lookup(track_table, ptr);
-    if (!entry || entry->ptr != ptr) {
-        pthread_mutex_unlock(&track_mutex);
-        return NULL;
-    }
-    gum_metal_hash_table_remove(track_table, ptr);
-    current_memory -= entry->size;
-    *current_after_remove_out = current_memory;
-    pthread_mutex_unlock(&track_mutex);
-    return entry;
+    /* The atomic slot removal is the lifetime transition.  It precedes the
+     * allocator call, which may make the address available for immediate
+     * reuse on another thread. */
+    if (!tracking_radix_remove(ptr, size_out)) return 0;
+    shard = accounting_shard_for(ptr);
+    tracking_account_remove(shard, *size_out, transition_out);
+    return 1;
 }
 
 static void
-restore_tracking_entry(AllocationEntry* entry)
+restore_tracking_entry(void* ptr, size_t size)
 {
-    int overflowed = 0;
+    PeakAccountingShard* shard = accounting_shard_for(ptr);
 
-    pthread_mutex_lock(&track_mutex);
-    gum_metal_hash_table_insert(track_table, entry->ptr, entry);
-    if (entry->size > G_MAXULONG - current_memory) {
-        current_memory = G_MAXULONG;
-        overflowed = 1;
-    } else {
-        current_memory += entry->size;
+    if (!tracking_radix_insert(ptr, size)) {
+        note_memory_tracking_degraded("realloc rollback tracking failed");
+        return;
     }
-    max_memory = current_memory > max_memory ? current_memory : max_memory;
-    pthread_mutex_unlock(&track_mutex);
-    if (overflowed) {
+    if (!tracking_account_restore(shard, size)) {
+        atomic_store_explicit(&shard->current_bytes, G_MAXULONG,
+                              memory_order_relaxed);
         note_memory_tracking_degraded("realloc rollback accounting overflow");
     }
 }
 
 static int
-commit_reallocated_entry(AllocationEntry* entry,
-                         void* new_ptr,
+commit_reallocated_entry(void* new_ptr,
                          size_t new_size,
-                         gulong* current_after_add_out)
+                         PeakTrackingTransition* transition_out)
 {
-    pthread_mutex_lock(&track_mutex);
-    if (new_size > G_MAXULONG - current_memory) {
-        pthread_mutex_unlock(&track_mutex);
-        internal_free(entry);
+    PeakAccountingShard* shard = accounting_shard_for(new_ptr);
+    size_t ignored_size;
+
+    if (!tracking_radix_insert(new_ptr, new_size)) {
+        note_memory_tracking_degraded("realloc tracking insertion failed");
+        return 0;
+    }
+    if (!tracking_account_add(shard, new_size, transition_out)) {
+        (void)tracking_radix_remove(new_ptr, &ignored_size);
         note_memory_tracking_degraded("realloc accounting overflow");
         return 0;
     }
-    entry->ptr = new_ptr;
-    entry->size = new_size;
-    gum_metal_hash_table_insert(track_table, new_ptr, entry);
-    current_memory += new_size;
-    max_memory = current_memory > max_memory ? current_memory : max_memory;
-    *current_after_add_out = current_memory;
-    pthread_mutex_unlock(&track_mutex);
     return 1;
 }
 
 static void
-publish_removed_entry(AllocationEntry* entry, gulong current_after_remove)
+publish_removed_entry(size_t size,
+                      const PeakTrackingTransition* transition)
 {
     int64_t delta;
 
-    if (size_to_event_delta(entry->size, &delta)) {
-        peak_log_event(nsec_now(), -delta,
-                       (uint64_t) current_after_remove, 2);
+    if (size_to_event_delta(size, &delta)) {
+        peak_log_event(transition->timestamp_ns, -delta, 0, 2,
+                       transition->shard, transition->sequence);
     }
 }
 
 static void
 malloc_interceptor_release_tracking_tables(void)
 {
-    if (track_table != NULL) {
-        gum_metal_hash_table_unref(track_table);
-        track_table = NULL;
-    }
+    tracking_tables_release();
     if (memory_caller_target_table != NULL) {
         gum_metal_hash_table_unref(memory_caller_target_table);
         memory_caller_target_table = NULL;
@@ -826,7 +1294,6 @@ malloc_interceptor_release_tracking_tables(void)
 static int
 init_table(void)
 {
-    GumMetalHashTable* new_track_table;
     GumMetalHashTable* new_caller_table;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -836,10 +1303,8 @@ init_table(void)
         return 0;
     }
 #endif
-    new_track_table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
     new_caller_table = gum_metal_hash_table_new(g_str_hash, str_equal_function);
-    if (!new_track_table || !new_caller_table) {
-        if (new_track_table) gum_metal_hash_table_unref(new_track_table);
+    if (!new_caller_table || !tracking_tables_create()) {
         if (new_caller_table) gum_metal_hash_table_unref(new_caller_table);
         return 0;
     }
@@ -851,7 +1316,6 @@ init_table(void)
                                     peak_hook_strings[i]);
     }
     pthread_mutex_unlock(&caller_mutex);
-    track_table = new_track_table;
     memory_caller_target_table = new_caller_table;
     return 1;
 }
@@ -866,14 +1330,29 @@ typedef enum {
     PEAK_MALLOC_HOOK_FORWARDING,
 } PeakMallocHookEntry;
 
+static inline PeakHookActivityShard*
+malloc_hook_activity_shard(void)
+{
+    uintptr_t shard_key = (uintptr_t)&in_peak_alloc_hook >> 6;
+
+    shard_key ^= shard_key >> 17;
+    shard_key ^= shard_key >> 9;
+    return &hook_activity_shards[
+        shard_key & (PEAK_HOOK_ACTIVITY_SHARD_COUNT - 1u)];
+}
+
 static PeakMallocHookEntry
 malloc_hook_enter(void)
 {
+    PeakHookActivityShard* activity_shard;
+
     if (in_peak_alloc_hook) {
         return PEAK_MALLOC_HOOK_RECURSIVE;
     }
 
-    atomic_fetch_add_explicit(&active_alloc_hooks, 1, memory_order_acquire);
+    activity_shard = malloc_hook_activity_shard();
+    atomic_fetch_add_explicit(&activity_shard->active, 1,
+                              memory_order_acquire);
     if (atomic_load_explicit(&cleanup_in_progress, memory_order_acquire)) {
         return PEAK_MALLOC_HOOK_FORWARDING;
     }
@@ -882,18 +1361,31 @@ malloc_hook_enter(void)
 
 static void malloc_hook_leave(void)
 {
-    atomic_fetch_sub_explicit(&active_alloc_hooks, 1, memory_order_release);
+    atomic_fetch_sub_explicit(&malloc_hook_activity_shard()->active, 1,
+                              memory_order_release);
+}
+
+static int
+malloc_interceptor_hooks_are_quiescent(void)
+{
+    for (size_t i = 0; i < PEAK_HOOK_ACTIVITY_SHARD_COUNT; ++i) {
+        if (atomic_load_explicit(&hook_activity_shards[i].active,
+                                 memory_order_acquire) != 0) {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 static int malloc_interceptor_wait_for_quiescence(void)
 {
     for (unsigned int attempt = 0; attempt < 1000; attempt++) {
-        if (atomic_load_explicit(&active_alloc_hooks, memory_order_acquire) == 0) {
+        if (malloc_interceptor_hooks_are_quiescent()) {
             return 1;
         }
         usleep(1000);
     }
-    return atomic_load_explicit(&active_alloc_hooks, memory_order_acquire) == 0;
+    return malloc_interceptor_hooks_are_quiescent();
 }
 
 static void* custom_malloc(size_t size) {
@@ -920,8 +1412,9 @@ static void* custom_malloc(size_t size) {
 }
 
 static void custom_free(void* ptr) {
-    AllocationEntry* entry;
-    gulong current_after_remove = 0;
+    size_t tracked_size;
+    PeakTrackingTransition transition;
+    int tracked;
 
     if (!ptr) return;
 
@@ -937,11 +1430,10 @@ static void custom_free(void* ptr) {
     int hook_val = in_peak_alloc_hook;
     in_peak_alloc_hook = 1;
     /* Keep the old entry local while the allocator exposes its address. */
-    entry = detach_tracking_entry(ptr, &current_after_remove);
+    tracked = detach_tracking_entry(ptr, &tracked_size, &transition);
     original_free(ptr);
-    if (entry) {
-        publish_removed_entry(entry, current_after_remove);
-        internal_free(entry);
+    if (tracked) {
+        publish_removed_entry(tracked_size, &transition);
     }
     in_peak_alloc_hook = hook_val;
     malloc_hook_leave();
@@ -978,9 +1470,10 @@ static void* custom_calloc(size_t nmemb, size_t size) {
 }
 
 static void* custom_realloc(void* ptr, size_t size) {
-    AllocationEntry* entry = NULL;
-    gulong current_after_remove = 0;
-    gulong current_after_add = 0;
+    size_t tracked_size = 0;
+    int tracked = 0;
+    PeakTrackingTransition remove_transition;
+    PeakTrackingTransition add_transition;
     int saved_errno = 0;
     int realloc_errno;
     int result_errno;
@@ -1016,7 +1509,7 @@ static void* custom_realloc(void* ptr, size_t size) {
      * restores the same lifetime without events; success publishes the old
      * removal and commits the returned pointer as the new lifetime.
      */
-    entry = detach_tracking_entry(ptr, &current_after_remove);
+    tracked = detach_tracking_entry(ptr, &tracked_size, &remove_transition);
 
     if (size == 0) {
         saved_errno = errno;
@@ -1028,26 +1521,24 @@ static void* custom_realloc(void* ptr, size_t size) {
         ? saved_errno
         : realloc_errno;
     if (!new_ptr && (size != 0 || realloc_errno == ENOMEM)) {
-        if (entry) restore_tracking_entry(entry);
+        if (tracked) restore_tracking_entry(ptr, tracked_size);
         errno = result_errno;
         in_peak_alloc_hook = hook_val;
         malloc_hook_leave();
         return NULL;
     }
 
-    if (entry) {
-        publish_removed_entry(entry, current_after_remove);
+    if (tracked) {
+        publish_removed_entry(tracked_size, &remove_transition);
     }
-    if (entry && new_ptr != NULL &&
-        commit_reallocated_entry(entry, new_ptr, size, &current_after_add)) {
+    if (tracked && new_ptr != NULL &&
+        commit_reallocated_entry(new_ptr, size, &add_transition)) {
         int64_t new_delta;
         if (size_to_event_delta(size, &new_delta)) {
-            peak_log_event(nsec_now(), new_delta,
-                           (uint64_t) current_after_add, 1);
+            peak_log_event(add_transition.timestamp_ns, new_delta, 0, 1,
+                           add_transition.shard, add_transition.sequence);
         }
-    } else if (entry && new_ptr == NULL) {
-        internal_free(entry);
-    } else if (!entry && new_ptr != NULL) {
+    } else if (!tracked && new_ptr != NULL) {
         int flag = peak_log_backtrace_malloc();
         add_tracking_entry(new_ptr, size, flag);
     }
@@ -1109,7 +1600,8 @@ static int custom_posix_memalign(void** memptr, size_t alignment, size_t size) {
 
 static void memory_usage_log_print(void) {
     peak_log_info("[peak] Memory allocation interceptors detached and resources cleaned up\n");
-    peak_log_report("Max usage (bytes): %lu\n", max_memory);
+    peak_log_report("Max usage (bytes): %lu\n",
+                    atomic_load_explicit(&max_memory, memory_order_relaxed));
 }
 
 /*=========================
@@ -1120,8 +1612,17 @@ static void memory_usage_log_print(void) {
     do {                                                                                  \
         if (_addr) {                                                                      \
             GumReplaceReturn r = PEAK_MALLOC_REPLACE_FAST(_addr, _hook, _orig, _name);  \
+            /* Legacy libc entry stubs may not satisfy fast-replace's direct            \
+             * signature contract.  Standard replacement preserves the same             \
+             * transaction and original-function semantics for those entries. */         \
+            if (r == GUM_REPLACE_WRONG_SIGNATURE) {                                       \
+                r = gum_interceptor_replace(malloc_interceptor, _addr, _hook,             \
+                                            (gpointer*)(&_orig), NULL);                    \
+            }                                                                             \
             _replaced = r == GUM_REPLACE_OK;                                              \
-            (void)r;                                                                      \
+            if (!_replaced) {                                                             \
+                peak_log_warn("[peak] failed to replace " _name ": %d\n", r);            \
+            }                                                                             \
         }                                                                                 \
     } while (0)
 
@@ -1153,6 +1654,7 @@ malloc_interceptor_flush_rollback(void)
 PeakMallocInterceptorAttachResult
 malloc_interceptor_attach(void)
 {
+    pthread_once(&malloc_tid_cache_once, malloc_tid_cache_initialize);
     atomic_store_explicit(&cleanup_in_progress, 0, memory_order_release);
     if (!init_table()) {
         return PEAK_MALLOC_ATTACH_PREPARE_FAILED;
@@ -1242,12 +1744,7 @@ malloc_interceptor_detach(void)
         return;
     }
 
-    pthread_mutex_lock(&track_mutex);
-    if (track_table != NULL) {
-        gum_metal_hash_table_unref(track_table);
-        track_table = NULL;
-    }
-    pthread_mutex_unlock(&track_mutex);
+    tracking_tables_release();
     pthread_mutex_lock(&caller_mutex);
     if (memory_caller_target_table != NULL) {
         gum_metal_hash_table_unref(memory_caller_target_table);
@@ -1259,8 +1756,8 @@ malloc_interceptor_detach(void)
     malloc_interceptor = NULL;
     malloc_interceptor_attached = FALSE;
 
-    memory_usage_log_print();
     peak_memlog_finalize();
+    memory_usage_log_print();
 }
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -1284,7 +1781,9 @@ peak_memlog_test_open(size_t capacity_events)
 void
 peak_memlog_test_log_event(uint64_t ts, int64_t delta, uint64_t current, uint8_t op)
 {
-    peak_log_event(ts, delta, current, op);
+    if (!peak_memlog_writer_enter()) return;
+    (void)peak_log_event_write(ts, delta, current, op, UINT16_MAX, 0);
+    peak_memlog_writer_leave();
 }
 
 size_t
@@ -1296,7 +1795,9 @@ peak_memlog_test_ready_records(void)
 
     if (!g_memlog.map) return 0;
     reserved = atomic_load_explicit(&g_memlog.reserved, memory_order_acquire);
-    if (reserved > g_memlog.capacity_events) reserved = g_memlog.capacity_events;
+    if (reserved > g_memlog.storage_capacity_events) {
+        reserved = g_memlog.storage_capacity_events;
+    }
     ready_flags = peak_memlog_ready_flags();
     for (size_t i = 0; i < reserved; ++i) {
         if (atomic_load_explicit(&ready_flags[i], memory_order_acquire)) ++ready_count;
@@ -1310,7 +1811,8 @@ peak_memlog_test_read_event(size_t index, PeakMemEvent* out)
     PeakMemEvent* event;
     _Atomic uint8_t* ready;
 
-    if (!out || !g_memlog.map || index >= g_memlog.capacity_events) return 0;
+    if (!out || !g_memlog.map ||
+        index >= g_memlog.storage_capacity_events) return 0;
     ready = peak_memlog_ready_flags();
     if (!atomic_load_explicit(&ready[index], memory_order_acquire)) return 0;
     event = (PeakMemEvent*) ((uint8_t*) g_memlog.map + g_memlog.header_bytes +
@@ -1318,7 +1820,9 @@ peak_memlog_test_read_event(size_t index, PeakMemEvent* out)
     out->ts_ns = event->ts_ns;
     out->delta = event->delta;
     out->current = event->current;
+    out->accounting_sequence = event->accounting_sequence;
     out->tid = event->tid;
+    out->accounting_shard = event->accounting_shard;
     out->op = event->op;
     return 1;
 }
@@ -1359,11 +1863,19 @@ peak_memlog_test_finalize(void)
     peak_memlog_finalize();
 }
 
+uint32_t
+peak_malloc_test_thread_id(void)
+{
+    pthread_once(&malloc_tid_cache_once, malloc_tid_cache_initialize);
+    return peak_gettid();
+}
+
 int
 peak_malloc_test_failed_realloc_preserves_accounting(void)
 {
-    AllocationEntry* entry;
-    AllocationEntry* observed;
+    size_t observed_size = 0;
+    PeakAccountingShard* shard;
+    PeakTrackingTransition transition;
     void* ptr;
     void* result;
     int preserved;
@@ -1371,45 +1883,44 @@ peak_malloc_test_failed_realloc_preserves_accounting(void)
     void (*saved_free)(void*) = original_free;
     void* (*saved_realloc)(void*, size_t) = original_realloc;
 
-    if (track_table != NULL) return 0;
+    if (atomic_load_explicit(&tracking_tables_active, memory_order_acquire)) return 0;
     original_malloc = malloc;
     original_free = free;
     original_realloc = peak_memlog_test_realloc_failure;
     ptr = original_malloc(64);
-    entry = original_malloc(sizeof(*entry));
-    if (!ptr || !entry) {
-        original_free(ptr);
-        original_free(entry);
-        original_malloc = saved_malloc;
-        original_free = saved_free;
-        original_realloc = saved_realloc;
-        return 0;
-    }
-    track_table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
-    if (!track_table) {
-        original_free(entry);
+    if (!ptr) {
         original_free(ptr);
         original_malloc = saved_malloc;
         original_free = saved_free;
         original_realloc = saved_realloc;
         return 0;
     }
-    entry->ptr = ptr;
-    entry->size = 64;
-    current_memory = 64;
-    gum_metal_hash_table_insert(track_table, ptr, entry);
-
+    if (!tracking_tables_create()) {
+        original_free(ptr);
+        original_malloc = saved_malloc;
+        original_free = saved_free;
+        original_realloc = saved_realloc;
+        return 0;
+    }
+    shard = accounting_shard_for(ptr);
+    if (!tracking_radix_insert(ptr, 64) ||
+        !tracking_account_add(shard, 64, &transition)) {
+        tracking_tables_release();
+        original_free(ptr);
+        original_malloc = saved_malloc;
+        original_free = saved_free;
+        original_realloc = saved_realloc;
+        return 0;
+    }
     result = custom_realloc(ptr, SIZE_MAX);
-    pthread_mutex_lock(&track_mutex);
-    observed = gum_metal_hash_table_lookup(track_table, ptr);
-    preserved = result == NULL && observed == entry && observed->size == 64 &&
-        current_memory == 64;
-    gum_metal_hash_table_remove(track_table, ptr);
-    pthread_mutex_unlock(&track_mutex);
-    gum_metal_hash_table_unref(track_table);
-    track_table = NULL;
-    current_memory = 0;
-    original_free(entry);
+    preserved = result == NULL &&
+        tracking_radix_lookup(ptr, &observed_size) &&
+        observed_size == 64 &&
+        atomic_load_explicit(&shard->current_bytes, memory_order_relaxed) == 64;
+    (void)tracking_radix_remove(ptr, &observed_size);
+    atomic_store_explicit(&shard->current_bytes, 0, memory_order_relaxed);
+    atomic_store_explicit(&fallback_current_memory, 0, memory_order_relaxed);
+    tracking_tables_release();
     original_free(ptr);
     original_malloc = saved_malloc;
     original_free = saved_free;
@@ -1423,31 +1934,25 @@ peak_malloc_test_tracking_allocation_failure(void)
     void* ptr;
     void* (*saved_malloc)(size_t) = original_malloc;
     void (*saved_free)(void*) = original_free;
-    GumMetalHashTable* table;
+    size_t observed_size;
     int rejected;
 
-    if (track_table != NULL) return 0;
+    if (atomic_load_explicit(&tracking_tables_active, memory_order_acquire)) return 0;
     original_malloc = malloc;
     original_free = free;
     ptr = original_malloc(64);
-    table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
-    if (!ptr || !table) {
+    if (!ptr || !tracking_tables_create()) {
         original_free(ptr);
-        if (table) gum_metal_hash_table_unref(table);
         original_malloc = saved_malloc;
         original_free = saved_free;
         return 0;
     }
-    track_table = table;
-    current_memory = 0;
     peak_memlog_test_set_failure(PEAK_MEMLOG_TEST_FAIL_ALLOCATION);
     add_tracking_entry(ptr, 64, 1);
-    pthread_mutex_lock(&track_mutex);
-    rejected = gum_metal_hash_table_lookup(track_table, ptr) == NULL && current_memory == 0;
-    pthread_mutex_unlock(&track_mutex);
-    gum_metal_hash_table_unref(track_table);
-    track_table = NULL;
-    current_memory = 0;
+    rejected = !tracking_radix_lookup(ptr, &observed_size) &&
+        atomic_load_explicit(&accounting_shard_for(ptr)->current_bytes,
+                             memory_order_relaxed) == 0;
+    tracking_tables_release();
     original_free(ptr);
     original_malloc = saved_malloc;
     original_free = saved_free;
@@ -1457,15 +1962,14 @@ peak_malloc_test_tracking_allocation_failure(void)
 int
 peak_malloc_test_begin(const PeakMallocTestAllocator* allocator)
 {
-    GumMetalHashTable* table;
-
     if (allocator == NULL || allocator->malloc_fn == NULL ||
         allocator->free_fn == NULL || allocator->realloc_fn == NULL ||
-        g_malloc_test_active || track_table != NULL) {
+        g_malloc_test_active ||
+        atomic_load_explicit(&tracking_tables_active, memory_order_acquire)) {
         return 0;
     }
-    table = gum_metal_hash_table_new(g_direct_hash, g_direct_equal);
-    if (table == NULL) return 0;
+    pthread_once(&malloc_tid_cache_once, malloc_tid_cache_initialize);
+    if (!tracking_tables_create()) return 0;
 
     g_malloc_test_saved_malloc = original_malloc;
     g_malloc_test_saved_free = original_free;
@@ -1475,11 +1979,11 @@ peak_malloc_test_begin(const PeakMallocTestAllocator* allocator)
     original_free = allocator->free_fn;
     original_realloc = allocator->realloc_fn;
     peak_memory_track_all = TRUE;
-    track_table = table;
-    current_memory = 0;
-    max_memory = 0;
     atomic_store_explicit(&cleanup_in_progress, 0, memory_order_release);
-    atomic_store_explicit(&active_alloc_hooks, 0, memory_order_release);
+    for (size_t i = 0; i < PEAK_HOOK_ACTIVITY_SHARD_COUNT; ++i) {
+        atomic_store_explicit(&hook_activity_shards[i].active, 0,
+                              memory_order_release);
+    }
     in_peak_alloc_hook = 0;
     g_malloc_test_active = 1;
     return 1;
@@ -1488,25 +1992,17 @@ peak_malloc_test_begin(const PeakMallocTestAllocator* allocator)
 int
 peak_malloc_test_seed(void* ptr, size_t size)
 {
-    AllocationEntry* entry;
+    PeakAccountingShard* shard;
+    size_t ignored_size = 0;
 
     if (!g_malloc_test_active || ptr == NULL) return 0;
-    entry = original_malloc(sizeof(*entry));
-    if (entry == NULL) return 0;
-    entry->ptr = ptr;
-    entry->size = size;
 
-    pthread_mutex_lock(&track_mutex);
-    if (gum_metal_hash_table_lookup(track_table, ptr) != NULL ||
-        size > G_MAXULONG - current_memory) {
-        pthread_mutex_unlock(&track_mutex);
-        original_free(entry);
+    shard = accounting_shard_for(ptr);
+    if (!tracking_radix_insert(ptr, size)) return 0;
+    if (!tracking_account_add(shard, size, NULL)) {
+        (void)tracking_radix_remove(ptr, &ignored_size);
         return 0;
     }
-    gum_metal_hash_table_insert(track_table, ptr, entry);
-    current_memory += size;
-    max_memory = current_memory > max_memory ? current_memory : max_memory;
-    pthread_mutex_unlock(&track_mutex);
     return 1;
 }
 
@@ -1528,54 +2024,59 @@ peak_malloc_test_realloc(void* ptr, size_t size)
     return g_malloc_test_active ? custom_realloc(ptr, size) : NULL;
 }
 
+static void
+peak_malloc_test_snapshot_node(PeakTrackingRadixNode* node,
+                               unsigned int level,
+                               PeakMallocTestTrackingSnapshot* out)
+{
+    for (size_t i = 0; i < PEAK_TRACKING_RADIX_SIZE; ++i) {
+        uintptr_t value = atomic_load_explicit(&node->slots[i],
+                                               memory_order_acquire);
+        if (value == 0) continue;
+        if (level == 0) {
+            ++out->entry_count;
+            out->table_bytes += (size_t)(value - 1u);
+        } else {
+            peak_malloc_test_snapshot_node((PeakTrackingRadixNode*)value,
+                                           level - 1u, out);
+        }
+    }
+}
+
 void
 peak_malloc_test_tracking_snapshot(void* ptr,
                                    PeakMallocTestTrackingSnapshot* out)
 {
-    GumMetalHashTableIter iter;
-    gpointer value;
-    AllocationEntry* observed;
+    size_t observed_size;
 
     if (out == NULL) return;
     memset(out, 0, sizeof(*out));
     if (!g_malloc_test_active) return;
 
-    pthread_mutex_lock(&track_mutex);
-    out->entry_count = gum_metal_hash_table_size(track_table);
-    gum_metal_hash_table_iter_init(&iter, track_table);
-    while (gum_metal_hash_table_iter_next(&iter, NULL, &value)) {
-        AllocationEntry* entry = value;
-        out->table_bytes += entry->size;
+    peak_malloc_test_snapshot_node(&tracking_root,
+                                   PEAK_TRACKING_RADIX_LEVELS - 1u, out);
+    for (size_t i = 0; i < PEAK_ACCOUNTING_SHARD_COUNT; ++i) {
+        gulong shard_current = atomic_load_explicit(
+            &accounting_shards[i].current_bytes, memory_order_relaxed);
+        if (shard_current > G_MAXULONG - out->current_bytes) {
+            out->current_bytes = G_MAXULONG;
+        } else {
+            out->current_bytes += shard_current;
+        }
     }
-    out->current_bytes = current_memory;
-    observed = gum_metal_hash_table_lookup(track_table, ptr);
-    if (observed != NULL) {
+    if (ptr != NULL && tracking_radix_lookup(ptr, &observed_size)) {
         out->pointer_tracked = 1;
-        out->pointer_size = observed->size;
+        out->pointer_size = observed_size;
     }
-    pthread_mutex_unlock(&track_mutex);
 }
 
 void
 peak_malloc_test_end(void)
 {
-    GumMetalHashTable* table;
-    GumMetalHashTableIter iter;
-    gpointer value;
-
     if (!g_malloc_test_active) return;
-    pthread_mutex_lock(&track_mutex);
-    table = track_table;
-    track_table = NULL;
-    current_memory = 0;
-    max_memory = 0;
-    pthread_mutex_unlock(&track_mutex);
-
-    gum_metal_hash_table_iter_init(&iter, table);
-    while (gum_metal_hash_table_iter_next(&iter, NULL, &value)) {
-        original_free(value);
-    }
-    gum_metal_hash_table_unref(table);
+    tracking_tables_release();
+    atomic_store_explicit(&max_memory, 0, memory_order_relaxed);
+    atomic_store_explicit(&fallback_current_memory, 0, memory_order_relaxed);
     original_malloc = g_malloc_test_saved_malloc;
     original_free = g_malloc_test_saved_free;
     original_realloc = g_malloc_test_saved_realloc;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3402,6 +3402,17 @@ if(BUILD_TESTING)
     set_tests_properties(test_memory_interceptor_recoverable_rollback_fail_open
         PROPERTIES
             ENVIRONMENT "PEAK_TARGET=main,my_sleep_func;PEAK_MEMORY_PROFILE=1;PEAK_TEST_FAIL_MALLOC_REPLACE=free;${PRELOAD_VAR}")
+    add_test(NAME test_memory_interceptor_standard_replace_fallback
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stderr-regex "Memory allocation functions intercepted successfully"
+                --stderr-count-regex "disabling non-critical profiler subsystem"
+                --stderr-count 0
+                -- ${PROJECT_BINARY_DIR}/test/heartbeat/test_heartbeat)
+    set_tests_properties(test_memory_interceptor_standard_replace_fallback
+        PROPERTIES
+            ENVIRONMENT "PEAK_TARGET=main,my_sleep_func;PEAK_MEMORY_PROFILE=1;PEAK_VERBOSITY=info;PEAK_TEST_FORCE_MALLOC_STANDARD_REPLACE=posix_memalign;${PRELOAD_VAR}")
     foreach(peak_rollback_failure_target malloc free)
         add_test(NAME test_memory_interceptor_pre_main_worker_${peak_rollback_failure_target}
             COMMAND ${Python3_EXECUTABLE}
@@ -3429,7 +3440,7 @@ if(BUILD_TESTING)
 
     # Add test of memory allocation intercepting
     add_subdirectory(memory)
-    foreach(memlog_case create sizing mapping overflow capacity stalled stress no-clobber allocation realloc)
+    foreach(memlog_case create sizing mapping overflow capacity stalled stress no-clobber allocation realloc tid-fork)
         add_test(NAME test_memlog_${memlog_case}
             COMMAND test_memlog_safety ${memlog_case})
         set_tests_properties(test_memlog_${memlog_case}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3437,6 +3437,14 @@ if(BUILD_TESTING)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 TIMEOUT 10)
     endforeach()
+    foreach(allocation_lifetime_case free-reuse realloc-reuse realloc-matrix stress)
+        add_test(NAME test_allocation_lifetime_${allocation_lifetime_case}
+            COMMAND test_allocation_lifetime ${allocation_lifetime_case})
+        set_tests_properties(test_allocation_lifetime_${allocation_lifetime_case}
+            PROPERTIES
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                TIMEOUT 30)
+    endforeach()
     set_tests_properties(test_memlog_sizing
         PROPERTIES PASS_REGULAR_EXPRESSION "memlog: ftruncate init failed")
     add_test(NAME test_memory COMMAND ${PROJECT_BINARY_DIR}/test/memory/test_memory)

--- a/test/memory/CMakeLists.txt
+++ b/test/memory/CMakeLists.txt
@@ -6,3 +6,8 @@ add_executable(test_memlog_safety test_memlog_safety.c)
 target_include_directories(test_memlog_safety PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_compile_definitions(test_memlog_safety PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
 target_link_libraries(test_memlog_safety PRIVATE peak Threads::Threads)
+
+add_executable(test_allocation_lifetime test_allocation_lifetime.c)
+target_include_directories(test_allocation_lifetime PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_compile_definitions(test_allocation_lifetime PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
+target_link_libraries(test_allocation_lifetime PRIVATE peak Threads::Threads)

--- a/test/memory/test_allocation_lifetime.c
+++ b/test/memory/test_allocation_lifetime.c
@@ -1,0 +1,475 @@
+#define PEAK_ENABLE_TEST_HOOKS 1
+#include "malloc_interceptor.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    OLD_SIZE = 64,
+    REUSED_SIZE = 80,
+    NEW_SIZE = 128,
+    STRESS_THREADS = 8,
+    STRESS_ITERATIONS = 256,
+};
+
+typedef enum {
+    ALLOCATOR_LIBC = 0,
+    ALLOCATOR_FREE_REUSE,
+    ALLOCATOR_REALLOC_MOVE_REUSE,
+    ALLOCATOR_REALLOC_IN_PLACE,
+    ALLOCATOR_REALLOC_FAILURE,
+    ALLOCATOR_REALLOC_ZERO_FREE,
+    ALLOCATOR_REALLOC_ZERO_ALLOCATE,
+    ALLOCATOR_REALLOC_ZERO_FAILURE,
+    ALLOCATOR_REALLOC_UNTRACKED,
+    ALLOCATOR_REALLOC_NULL,
+} TestAllocatorMode;
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    TestAllocatorMode mode;
+    void* old_pointer;
+    void* result_pointer;
+    int address_reusable;
+    int reused_lifetime_tracked;
+    unsigned int realloc_calls;
+    unsigned int realloc_null_calls;
+} TestAllocatorState;
+
+typedef struct {
+    _Atomic int failures;
+    unsigned int id;
+} StressWorker;
+
+static TestAllocatorState allocator_state = {
+    .mutex = PTHREAD_MUTEX_INITIALIZER,
+    .condition = PTHREAD_COND_INITIALIZER,
+};
+
+static int
+expect(int condition, const char* message)
+{
+    if (!condition) {
+        fprintf(stderr, "allocation lifetime test: %s\n", message);
+        return 0;
+    }
+    return 1;
+}
+
+static void
+reset_allocator(TestAllocatorMode mode, void* old_pointer, void* result_pointer)
+{
+    pthread_mutex_lock(&allocator_state.mutex);
+    allocator_state.mode = mode;
+    allocator_state.old_pointer = old_pointer;
+    allocator_state.result_pointer = result_pointer;
+    allocator_state.address_reusable = 0;
+    allocator_state.reused_lifetime_tracked = 0;
+    allocator_state.realloc_calls = 0;
+    allocator_state.realloc_null_calls = 0;
+    pthread_mutex_unlock(&allocator_state.mutex);
+}
+
+static void*
+test_malloc(size_t size)
+{
+    TestAllocatorMode mode;
+    void* old_pointer;
+
+    pthread_mutex_lock(&allocator_state.mutex);
+    mode = allocator_state.mode;
+    old_pointer = allocator_state.old_pointer;
+    pthread_mutex_unlock(&allocator_state.mutex);
+    if ((mode == ALLOCATOR_FREE_REUSE ||
+         mode == ALLOCATOR_REALLOC_MOVE_REUSE) &&
+        size == REUSED_SIZE) {
+        return old_pointer;
+    }
+    return malloc(size);
+}
+
+static void
+wait_for_reused_lifetime(void)
+{
+    pthread_mutex_lock(&allocator_state.mutex);
+    allocator_state.address_reusable = 1;
+    pthread_cond_broadcast(&allocator_state.condition);
+    while (!allocator_state.reused_lifetime_tracked) {
+        pthread_cond_wait(&allocator_state.condition, &allocator_state.mutex);
+    }
+    pthread_mutex_unlock(&allocator_state.mutex);
+}
+
+static void
+test_free(void* ptr)
+{
+    TestAllocatorMode mode;
+    void* old_pointer;
+
+    pthread_mutex_lock(&allocator_state.mutex);
+    mode = allocator_state.mode;
+    old_pointer = allocator_state.old_pointer;
+    pthread_mutex_unlock(&allocator_state.mutex);
+    if (mode == ALLOCATOR_FREE_REUSE && ptr == old_pointer) {
+        wait_for_reused_lifetime();
+        return;
+    }
+    free(ptr);
+}
+
+static void*
+test_realloc(void* ptr, size_t size)
+{
+    TestAllocatorMode mode;
+    void* old_pointer;
+    void* result_pointer;
+
+    pthread_mutex_lock(&allocator_state.mutex);
+    ++allocator_state.realloc_calls;
+    if (ptr == NULL) ++allocator_state.realloc_null_calls;
+    mode = allocator_state.mode;
+    old_pointer = allocator_state.old_pointer;
+    result_pointer = allocator_state.result_pointer;
+    pthread_mutex_unlock(&allocator_state.mutex);
+
+    if (mode == ALLOCATOR_REALLOC_MOVE_REUSE && ptr == old_pointer) {
+        wait_for_reused_lifetime();
+        return result_pointer;
+    }
+    if (mode == ALLOCATOR_REALLOC_IN_PLACE) return ptr;
+    if (mode == ALLOCATOR_REALLOC_FAILURE ||
+        mode == ALLOCATOR_REALLOC_ZERO_FAILURE) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (mode == ALLOCATOR_REALLOC_ZERO_FREE) {
+        errno = 0;
+        return NULL;
+    }
+    if (mode == ALLOCATOR_REALLOC_ZERO_ALLOCATE ||
+        mode == ALLOCATOR_REALLOC_UNTRACKED ||
+        mode == ALLOCATOR_REALLOC_NULL) {
+        return result_pointer;
+    }
+    return realloc(ptr, size);
+}
+
+static int
+begin_tracking(TestAllocatorMode mode, void* old_pointer, void* result_pointer)
+{
+    const PeakMallocTestAllocator allocator = {
+        .malloc_fn = test_malloc,
+        .free_fn = test_free,
+        .realloc_fn = test_realloc,
+    };
+
+    reset_allocator(mode, old_pointer, result_pointer);
+    return expect(peak_malloc_test_begin(&allocator),
+                  "could not initialize tracking fixture");
+}
+
+static void*
+reuse_old_address(void* unused)
+{
+    void* result;
+
+    (void) unused;
+    pthread_mutex_lock(&allocator_state.mutex);
+    while (!allocator_state.address_reusable) {
+        pthread_cond_wait(&allocator_state.condition, &allocator_state.mutex);
+    }
+    pthread_mutex_unlock(&allocator_state.mutex);
+
+    result = peak_malloc_test_malloc(REUSED_SIZE);
+    pthread_mutex_lock(&allocator_state.mutex);
+    allocator_state.reused_lifetime_tracked = result == allocator_state.old_pointer;
+    pthread_cond_broadcast(&allocator_state.condition);
+    pthread_mutex_unlock(&allocator_state.mutex);
+    return result == allocator_state.old_pointer ? NULL : (void*) 1;
+}
+
+static int
+run_free_reuse(void)
+{
+    PeakMallocTestTrackingSnapshot snapshot;
+    pthread_t reuse_thread;
+    void* thread_result = NULL;
+    void* old_pointer = malloc(NEW_SIZE);
+    int result = 1;
+
+    if (!expect(old_pointer != NULL, "could not allocate free fixture")) return 1;
+    if (!begin_tracking(ALLOCATOR_FREE_REUSE, old_pointer, NULL)) goto out;
+    if (!expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                "could not seed freed lifetime")) goto tracking_out;
+    if (!expect(pthread_create(&reuse_thread, NULL, reuse_old_address, NULL) == 0,
+                "could not start reuse thread")) goto tracking_out;
+    peak_malloc_test_free(old_pointer);
+    pthread_join(reuse_thread, &thread_result);
+    peak_malloc_test_tracking_snapshot(old_pointer, &snapshot);
+    result = !(expect(thread_result == NULL, "allocator did not reuse the old address") &&
+               expect(snapshot.entry_count == 1 && snapshot.pointer_tracked &&
+                      snapshot.pointer_size == REUSED_SIZE,
+                      "free bookkeeping removed the reused lifetime") &&
+               expect(snapshot.current_bytes == REUSED_SIZE &&
+                      snapshot.table_bytes == REUSED_SIZE,
+                      "free reuse accounting diverged"));
+
+tracking_out:
+    peak_malloc_test_end();
+out:
+    free(old_pointer);
+    return result;
+}
+
+static int
+run_realloc_reuse(void)
+{
+    PeakMallocTestTrackingSnapshot old_snapshot;
+    PeakMallocTestTrackingSnapshot new_snapshot;
+    pthread_t reuse_thread;
+    void* thread_result = NULL;
+    void* old_pointer = malloc(OLD_SIZE);
+    void* new_pointer = malloc(NEW_SIZE);
+    void* realloc_result;
+    int result = 1;
+
+    if (!expect(old_pointer != NULL && new_pointer != NULL,
+                "could not allocate moving realloc fixture")) goto out;
+    if (!begin_tracking(ALLOCATOR_REALLOC_MOVE_REUSE,
+                        old_pointer, new_pointer)) goto out;
+    if (!expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                "could not seed realloc lifetime")) goto tracking_out;
+    if (!expect(pthread_create(&reuse_thread, NULL, reuse_old_address, NULL) == 0,
+                "could not start realloc reuse thread")) goto tracking_out;
+    realloc_result = peak_malloc_test_realloc(old_pointer, NEW_SIZE);
+    pthread_join(reuse_thread, &thread_result);
+    peak_malloc_test_tracking_snapshot(old_pointer, &old_snapshot);
+    peak_malloc_test_tracking_snapshot(new_pointer, &new_snapshot);
+    result = !(expect(realloc_result == new_pointer && thread_result == NULL,
+                      "moving realloc did not use deterministic addresses") &&
+               expect(old_snapshot.entry_count == 2 &&
+                      old_snapshot.pointer_tracked &&
+                      old_snapshot.pointer_size == REUSED_SIZE,
+                      "moving realloc mutated the reused lifetime") &&
+               expect(new_snapshot.pointer_tracked &&
+                      new_snapshot.pointer_size == NEW_SIZE,
+                      "moving realloc lost its new lifetime") &&
+               expect(new_snapshot.current_bytes == REUSED_SIZE + NEW_SIZE &&
+                      new_snapshot.table_bytes == REUSED_SIZE + NEW_SIZE,
+                      "moving realloc accounting diverged"));
+
+tracking_out:
+    peak_malloc_test_end();
+out:
+    free(old_pointer);
+    free(new_pointer);
+    return result;
+}
+
+static int
+check_single_entry(void* pointer, size_t size, const char* message)
+{
+    PeakMallocTestTrackingSnapshot snapshot;
+
+    peak_malloc_test_tracking_snapshot(pointer, &snapshot);
+    return expect(snapshot.entry_count == 1 && snapshot.pointer_tracked &&
+                  snapshot.pointer_size == size &&
+                  snapshot.current_bytes == size && snapshot.table_bytes == size,
+                  message);
+}
+
+static int
+run_realloc_matrix(void)
+{
+    PeakMallocTestTrackingSnapshot snapshot;
+    void* old_pointer = malloc(NEW_SIZE);
+    void* new_pointer = malloc(NEW_SIZE);
+    void* result;
+    int passed = 1;
+
+    if (!expect(old_pointer != NULL && new_pointer != NULL,
+                "could not allocate realloc matrix fixture")) goto out;
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_FAILURE, old_pointer, NULL);
+    passed &= expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                     "could not seed failed realloc");
+    result = peak_malloc_test_realloc(old_pointer, NEW_SIZE);
+    passed &= expect(result == NULL, "failed realloc unexpectedly succeeded");
+    passed &= check_single_entry(old_pointer, OLD_SIZE,
+                                 "failed realloc did not restore accounting");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_IN_PLACE, old_pointer, NULL);
+    passed &= expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                     "could not seed in-place realloc");
+    result = peak_malloc_test_realloc(old_pointer, NEW_SIZE);
+    passed &= expect(result == old_pointer, "in-place realloc moved");
+    passed &= check_single_entry(old_pointer, NEW_SIZE,
+                                 "in-place realloc accounting is wrong");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_ZERO_FREE, old_pointer, NULL);
+    passed &= expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                     "could not seed zero-size realloc");
+    errno = E2BIG;
+    result = peak_malloc_test_realloc(old_pointer, 0);
+    peak_malloc_test_tracking_snapshot(old_pointer, &snapshot);
+    passed &= expect(result == NULL && errno == E2BIG,
+                     "zero-size realloc did not preserve allocator result or errno");
+    passed &= expect(snapshot.entry_count == 0 && snapshot.current_bytes == 0 &&
+                     snapshot.table_bytes == 0,
+                     "zero-size freeing realloc remained tracked");
+    passed &= expect(allocator_state.realloc_calls == 1,
+                     "zero-size realloc bypassed the real realloc");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_ZERO_ALLOCATE,
+                             old_pointer, new_pointer);
+    passed &= expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                     "could not seed allocating zero-size realloc");
+    result = peak_malloc_test_realloc(old_pointer, 0);
+    passed &= expect(result == new_pointer,
+                     "zero-size allocating realloc result changed");
+    passed &= check_single_entry(new_pointer, 0,
+                                 "zero-size allocation was not tracked");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_ZERO_FAILURE, old_pointer, NULL);
+    passed &= expect(peak_malloc_test_seed(old_pointer, OLD_SIZE),
+                     "could not seed failed zero-size realloc");
+    result = peak_malloc_test_realloc(old_pointer, 0);
+    passed &= expect(result == NULL && errno == ENOMEM,
+                     "zero-size realloc failure changed errno");
+    passed &= check_single_entry(old_pointer, OLD_SIZE,
+                                 "zero-size realloc failure lost the old lifetime");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_UNTRACKED,
+                             old_pointer, new_pointer);
+    result = peak_malloc_test_realloc(old_pointer, NEW_SIZE);
+    passed &= expect(result == new_pointer,
+                     "untracked-pointer realloc result changed");
+    passed &= check_single_entry(new_pointer, NEW_SIZE,
+                                 "untracked-pointer realloc was not added");
+    peak_malloc_test_end();
+
+    passed &= begin_tracking(ALLOCATOR_REALLOC_NULL, NULL, new_pointer);
+    result = peak_malloc_test_realloc(NULL, NEW_SIZE);
+    passed &= expect(result == new_pointer && allocator_state.realloc_null_calls == 1,
+                     "realloc(NULL, size) did not call the real realloc");
+    passed &= check_single_entry(new_pointer, NEW_SIZE,
+                                 "realloc(NULL, size) was not tracked");
+    peak_malloc_test_end();
+
+out:
+    free(old_pointer);
+    free(new_pointer);
+    return !passed;
+}
+
+static void*
+run_stress_worker(void* data)
+{
+    StressWorker* worker = data;
+
+    for (unsigned int i = 0; i < STRESS_ITERATIONS; ++i) {
+        size_t first_size = 32 + worker->id + (i % 17);
+        size_t second_size = first_size + 31;
+        void* pointer = peak_malloc_test_malloc(first_size);
+        void* resized;
+
+        if (pointer == NULL) {
+            atomic_fetch_add_explicit(&worker->failures, 1, memory_order_relaxed);
+            continue;
+        }
+        resized = peak_malloc_test_realloc(pointer, second_size);
+        if (resized == NULL) {
+            atomic_fetch_add_explicit(&worker->failures, 1, memory_order_relaxed);
+            peak_malloc_test_free(pointer);
+            continue;
+        }
+        peak_malloc_test_free(resized);
+    }
+    return NULL;
+}
+
+static int
+run_tracking_stress(void)
+{
+    const size_t expected_events =
+        1 + STRESS_THREADS * STRESS_ITERATIONS * 4;
+    PeakMallocTestTrackingSnapshot tracking;
+    PeakMemLogTestSnapshot memlog;
+    StressWorker workers[STRESS_THREADS];
+    pthread_t threads[STRESS_THREADS];
+    int64_t event_delta = 0;
+    int passed = 1;
+
+    if (!begin_tracking(ALLOCATOR_LIBC, NULL, NULL)) return 1;
+    if (!expect(peak_memlog_test_open(expected_events),
+                "could not open stress event log")) {
+        peak_malloc_test_end();
+        return 1;
+    }
+    for (unsigned int i = 0; i < STRESS_THREADS; ++i) {
+        atomic_init(&workers[i].failures, 0);
+        workers[i].id = i;
+        if (pthread_create(&threads[i], NULL, run_stress_worker, &workers[i]) != 0) {
+            return 1;
+        }
+    }
+    for (unsigned int i = 0; i < STRESS_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+        passed &= expect(atomic_load_explicit(&workers[i].failures,
+                                             memory_order_relaxed) == 0,
+                         "stress allocator operation failed");
+    }
+    peak_malloc_test_tracking_snapshot(NULL, &tracking);
+    peak_memlog_test_snapshot(&memlog);
+    passed &= expect(tracking.entry_count == 0 && tracking.current_bytes == 0 &&
+                     tracking.table_bytes == 0,
+                     "stress tracking table did not return to zero");
+    passed &= expect(memlog.committed == expected_events && memlog.dropped == 0,
+                     "stress event log lost committed transitions");
+    for (size_t i = 0; i < memlog.committed; ++i) {
+        PeakMemEvent event;
+        if (!peak_memlog_test_read_event(i, &event)) {
+            passed = 0;
+            break;
+        }
+        event_delta += event.delta;
+    }
+    passed &= expect(event_delta == 0,
+                     "stress event deltas disagree with aggregate accounting");
+    peak_memlog_test_finalize();
+    peak_malloc_test_end();
+    return !passed;
+}
+
+int
+main(int argc, char** argv)
+{
+    int result;
+
+    if (argc != 2) return 2;
+    gum_init_embedded();
+    if (strcmp(argv[1], "free-reuse") == 0) {
+        result = run_free_reuse();
+    } else if (strcmp(argv[1], "realloc-reuse") == 0) {
+        result = run_realloc_reuse();
+    } else if (strcmp(argv[1], "realloc-matrix") == 0) {
+        result = run_realloc_matrix();
+    } else if (strcmp(argv[1], "stress") == 0) {
+        result = run_tracking_stress();
+    } else {
+        result = 2;
+    }
+    gum_deinit_embedded();
+    return result;
+}

--- a/test/memory/test_memlog_safety.c
+++ b/test/memory/test_memlog_safety.c
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define STRESS_THREADS 8
@@ -199,6 +201,44 @@ static int run_output_no_clobber(void)
     return 0;
 }
 
+static int run_tid_fork(void)
+{
+    struct {
+        uint32_t cached;
+        uint32_t actual;
+    } child_ids = {0};
+    uint32_t parent_tid = peak_malloc_test_thread_id();
+    int pipe_fds[2];
+    pid_t child;
+    int status;
+
+    if (pipe(pipe_fds) != 0) return 1;
+    child = fork();
+    if (child < 0) return 1;
+    if (child == 0) {
+        ssize_t written;
+
+        close(pipe_fds[0]);
+        child_ids.cached = peak_malloc_test_thread_id();
+        child_ids.actual = (uint32_t)syscall(SYS_gettid);
+        written = write(pipe_fds[1], &child_ids, sizeof(child_ids));
+        close(pipe_fds[1]);
+        _exit(written == (ssize_t)sizeof(child_ids) ? 0 : 1);
+    }
+    close(pipe_fds[1]);
+    if (read(pipe_fds[0], &child_ids, sizeof(child_ids)) !=
+        (ssize_t)sizeof(child_ids)) {
+        close(pipe_fds[0]);
+        waitpid(child, &status, 0);
+        return 1;
+    }
+    close(pipe_fds[0]);
+    if (waitpid(child, &status, 0) != child) return 1;
+    return !(WIFEXITED(status) && WEXITSTATUS(status) == 0 &&
+             child_ids.cached == child_ids.actual &&
+             child_ids.cached != parent_tid);
+}
+
 int main(int argc, char** argv)
 {
     if (argc != 2) return 2;
@@ -210,6 +250,7 @@ int main(int argc, char** argv)
     if (strcmp(argv[1], "stalled") == 0) return run_stalled_writer();
     if (strcmp(argv[1], "stress") == 0) return run_multithread_stress();
     if (strcmp(argv[1], "no-clobber") == 0) return run_output_no_clobber();
+    if (strcmp(argv[1], "tid-fork") == 0) return run_tid_fork();
     if (strcmp(argv[1], "realloc") == 0) {
         gum_init_embedded();
         int result = !peak_malloc_test_failed_realloc_preserves_accounting();

--- a/test/static_checks/check_gum_mutation_allowlist.py
+++ b/test/static_checks/check_gum_mutation_allowlist.py
@@ -25,6 +25,7 @@ EXPECTED = {
         "begin_transaction": 1,
         "end_transaction": 2,
         "flush": 1,
+        "replace": 1,
         "replace_fast": 2,
         "revert": 6,
     },


### PR DESCRIPTION
Closes #82.

## Summary

- detach allocation lifetimes before `free()` or `realloc()` can expose an address for immediate reuse
- restore the original lifetime and accounting when `realloc()` fails, while preserving native `realloc(NULL, size)` and zero-size behavior
- replace the process-wide allocation table lock with a lock-free pointer radix and 4096-way cache-line-separated accounting and hook-activity shards
- reserve memory-log slots in thread-local blocks and reconstruct process-wide current/maximum totals only after allocation hooks quiesce
- keep the fixed event buffer anonymous and preinitialized so allocator callbacks do not dirty parallel-filesystem pages or take first-write faults
- use `CLOCK_MONOTONIC`, whose vDSO path avoids the per-event syscall cost observed for `CLOCK_MONOTONIC_RAW` on Frontera
- add a physical-core allocation benchmark for malloc/free, realloc, mixed, aligned_alloc, and posix_memalign, with accounting validation

The normal `PEAK_MEMORY_TRACK_ALL=TRUE` allocation path has no process-wide mutex and no per-call update of a single process-wide byte counter. The existing target-filtered backtrace path still uses its pre-existing caller-table mutex; this change neither adds to nor serializes that mode.

## Local validation

- GCC memory lifecycle/memlog suite: 21/21
- Clang memory lifecycle/memlog suite: 21/21
- ASan+UBSan memory lifecycle/memlog suite: 15/15
- deterministic free/realloc/matrix/stress regressions: 400/400 repeated runs
- static policy/header/CMake/detach-invariant gates: 4/4
- allocation-scaling benchmark smoke test
- fresh Clang production build with tests disabled
- Python bytecode validation and `git diff --check`
- six detach/reattach lifecycle redline files unchanged

## Frontera performance evidence

All runs pin one worker to each distinct physical `(package, core)` pair and validate the emitted memory accounting with zero dropped events.

- focused 4/16/28/56-core run: job `7908031`, `COMPLETED 0:0`
  - run directory: `/scratch2/05450/wangyinz/codex-tests/peak/20260820-205824-memory-scaling-debug-285325fe`
  - seven randomized samples per point for malloc/free, realloc, and mixed allocation traffic
  - raw 28-to-56-core throughput retention: pair `1.2353`, realloc `0.9683`, mixed `0.9899` (required `>= 0.95`)
  - 56-core incremental overhead: pair `11.6`, realloc `36.8`, mixed `15.6` ns/allocation call
  - all profiled totals below `500` ns/call; all incremental costs below `450` ns/call

- final nine-sample 1/2/4/8/16/28/56-core, five-mode matrix: job `7908072`, `COMPLETED 0:0`
  - run directory: `/scratch2/05450/wangyinz/codex-tests/peak/20260820-212453-memory-scaling-878076a2`
  - `allocation_scaling_ok`; all five modes and all accounting checks passed with zero dropped events
  - minimum raw throughput retention at 8/16/28/56 cores: `0.982662` (required `>= 0.95`)
  - minimum baseline-adjusted retention over every core count: `0.982662` (required `>= 0.95`)
  - maximum profiled total: `314.578` ns/call (required `<= 500` ns/call)
  - maximum incremental overhead: `248.150` ns/call (required `<= 450` ns/call)
  - at 56 cores, raw retention was pair `1.047571`, realloc `0.982662`, mixed `1.158060`, aligned `1.150193`, and posix `1.077968`

## CI

- GitHub Actions: 16/16 checks passed on exact head `678dc668d5cac2271382a55974f217e79385cf57`

## Environment limitation

Local TSan execution is unavailable because the host runtime is missing `/usr/lib64/libtsan.so.0.0.0`; sanitizer expansion remains tracked by #61.
