### PR TITLE
Make CUDA event profiling sustainable and bounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,12 +431,84 @@ semantics, module lifetime, and supported boundaries.
 | `PEAK_GPU_TARGET` | Comma-separated demangled base kernel names. |
 | `PEAK_GPU_TARGET_FILE` | File containing one GPU kernel name per line. |
 | `PEAK_GPU_MONITOR_ALL` | Profile every observed GPU kernel. |
-| `PEAK_CUDA_EVENT_POOL_CAPACITY` | CUDA event-pool capacity. Default: `256` events; accepts `1` through `65536`. |
+| `PEAK_CUDA_EVENT_POOL_CAPACITY` | Maximum in-flight CUDA timing samples. Each fixed slot owns one start/end event pair. Default: `256`; accepts `1` through `65536`. |
+| `PEAK_CUDA_FINALIZATION_TIMEOUT_MS` | Maximum time for bounded CUDA timing completion at report or detach. Default: `1000`; accepts `1` through `60000`. |
 | `PEAK_MEMORY_PROFILE` | Enable experimental Linux memory allocation profiling for selected CPU targets. Rejected on macOS. |
 | `PEAK_MEMORY_TRACK_ALL` | On Linux, track all allocation events instead of filtering by target backtraces. |
 | `PEAK_MEMLOG_PATH` | Memory CSV output prefix. Default: `./peak_memlog`. |
 | `PEAK_MEMLOG_CHUNK_EVENTS` | Experimental memory-profiler fixed export capacity. A positive decimal value reserves that many events plus at most one 64-event reservation block of slack per tracked thread; when full, new events are dropped and reported at finalization. The mapping never grows or moves. |
 | `PEAK_MEMLOG_OTF2_DIR` | Override the directory for memory-profile OTF2 output. |
+
+CUDA timing uses one process-wide, fixed-capacity slot pool partitioned by CUDA
+context. An event pair is created and reused only in its owning context, after
+the previous end event reports completion. Slot allocation, launch accounting,
+and producer-to-harvester handoff are partitioned across fixed shards, so
+concurrent launch wrappers do not acquire a process-wide lock or update one
+shared queue position. A dedicated helper harvests a bounded number of ready
+samples without making launch wrappers wait. Neither the launch path nor
+finalization calls a device, stream, or context-wide synchronization API. PEAK
+initializes the CUDA backend and helper only when
+`PEAK_GPU_TARGET`, `PEAK_GPU_TARGET_FILE`, or `PEAK_GPU_MONITOR_ALL` explicitly
+requests GPU profiling; CPU-only profiling does not load the Driver API or
+create an idle CUDA helper.
+
+When the complete typed Driver launch surface is available, PEAK times Runtime
+launches at the corresponding Driver entry point and does not install a second
+Runtime launch replacement. This keeps mixed Runtime/Driver coverage and exact
+one-sample accounting without sending each Runtime launch through two Gum
+dispatches. Driver timing records events through the Driver API, including
+when the intercepted Driver launch originated in the Runtime, so the wrapper
+does not re-enter the Runtime API from inside a Runtime launch. If that Driver
+surface is incomplete, PEAK retains the Runtime launch replacements as the
+compatibility path.
+
+The CUDA report distinguishes launches that entered profiler accounting
+(`observed`), timing samples that were successfully recorded and queued
+(`accepted`), and samples whose elapsed time was harvested (`completed`). Pool
+exhaustion skips only the timing sample and increments `pool_full`; the
+application launch still runs. This makes `accepted` the sustainable-sampling
+count when launches outpace the fixed pool and harvester. Reports also carry
+`pool_high_water`, `identity_full`, `harvester_unavailable`, event
+creation/record/query/elapsed failures, capture-query failures,
+context-query/switch/restore failures, `unsupported_multi_device`,
+`dimension_overflow`, and finalization timeout/incomplete counts through the
+normal local, socket, or MPI report transport. CUDA kernel `Calls` and timing
+averages describe harvested completed samples, not all application launches
+when any sample was skipped or dropped.
+Kernel and graph identities are also process-bounded; new graph handles beyond
+four times the event-pool capacity increment `identity_full` instead of growing
+the aggregate map.
+
+Runtime and Driver capture lifecycle listeners close a sharded timing-admission
+gate before a capture transition and reopen it only after capture quiescence is
+proven. Launch wrappers therefore do not repeat a Driver capture query for each
+target. Active capture, incomplete capture interception, or a capture-query
+error keeps the gate closed and skips timing without recording events into the
+captured stream. Cooperative
+multi-device launch APIs are also passed through without timing because one
+reusable event pair cannot safely represent multiple device contexts. These
+skips are reported and do not change the application launch. The dedicated
+capture lifecycle listeners cover both legacy-stream and per-thread-default
+entry points. Before timing opens, PEAK validates the Driver's known capture
+entry-point variants; incomplete interception or an uninstrumented returned
+pointer disables CUDA timing while leaving application CUDA calls unchanged.
+Driver launch timing is likewise disabled for ABI-generic redirect stubs that
+cannot safely receive typed replacements. The dedicated
+harvester enters CUDA's relaxed thread-local capture interaction mode before
+timing admission opens, so it can query PEAK events recorded before an
+unrelated concurrent global capture without invalidating that capture. The
+one-time cold handshake is requested by the first matching CUDA launch; attach
+and non-target launches do not initialize CUDA. Matching launches pass through
+without waiting while the helper is initializing, and increment
+`harvester_unavailable`. If the mode cannot be established, CUDA timing remains
+disabled and launches continue to pass through unchanged.
+
+At report or detach, PEAK stops admitting CUDA samples and lets the harvester
+run until the configured monotonic deadline. If work remains, PEAK reports the
+incomplete count, logs bounded context/device diagnostics, and retains the
+affected event state instead of destroying an event in the wrong or unfinished
+context. That retained state remains process-owned until operating-system
+reclamation, so a blocked CUDA query cannot race library teardown.
 
 Allocation lifetimes are tracked in a lock-free pointer radix. Memory events
 use sharded ordering metadata, and their process-wide `current` totals and
@@ -492,8 +564,8 @@ toolchains and host capabilities detected during configuration.
 - `PEAK_TARGET`, `PEAK_TARGET_GROUP`, and `PEAK_TARGET_FILE` are merged;
   duplicate entries are handled automatically but are best avoided.
 - CUDA profiling includes first-use initialization and kernel warm-up effects.
-  CUDA graphs may be reported as graph execution or as captured launches,
-  depending on how the graph was created.
+  Launches issued while a stream is being captured are not timed; later graph
+  execution outside capture can be reported as graph execution.
 - JIT targets require runtime metadata; PEAK does not infer names or boundaries
   from anonymous executable pages.
 - Strict detach backend availability depends on platform signal support and,

--- a/cmake/frida-gum.cmake
+++ b/cmake/frida-gum.cmake
@@ -9,7 +9,7 @@ set(PEAK_PATCHED_GUM_INCLUDE_DIR "" CACHE PATH
 set(PEAK_PATCHED_GUM_LIBRARY "" CACHE FILEPATH
     "Static library for a PEAK-patched Frida Gum devkit")
 option(PEAK_REQUIRE_GUM_PEAK_API
-    "Require the selected Frida Gum headers to expose PEAK PC classification and x86 exact-entry APIs"
+    "Require the selected Frida Gum headers to expose PEAK PC classification and exact-entry APIs"
     OFF)
 
 macro(fetch_frida_gum _download_module_path _download_root)
@@ -389,8 +389,10 @@ int main(void)
 #include <frida-gum.h>
 
 #if !defined(GUM_PEAK_EXACT_ATTACH_API_VERSION) || \
-    GUM_PEAK_EXACT_ATTACH_API_VERSION != 1
-#error Missing PEAK exact-attach API
+    GUM_PEAK_EXACT_ATTACH_API_VERSION != 1 || \
+    !defined(GUM_PEAK_REDIRECT_RESOLVER_API_VERSION) || \
+    GUM_PEAK_REDIRECT_RESOLVER_API_VERSION != 1
+#error Missing PEAK exact-entry APIs
 #endif
 
 int main(void)
@@ -402,7 +404,11 @@ int main(void)
         const GumAttachOptions *);
     PeakAttachExactFunc volatile attach_exact =
         gum_interceptor_peak_attach_exact;
-    return attach_exact == NULL;
+    typedef gboolean (*PeakResolveRedirectFunc)(
+        GumInterceptor *, gpointer, gpointer *);
+    PeakResolveRedirectFunc volatile resolve_redirect =
+        gum_interceptor_peak_resolve_redirect_chain;
+    return attach_exact == NULL || resolve_redirect == NULL;
 }
 ")
     unset(PEAK_GUM_HAS_PEAK_EXACT_ATTACH_API CACHE)
@@ -411,11 +417,11 @@ int main(void)
 
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _peak_processor)
     if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
-       _peak_processor MATCHES "^(x86_64|amd64)$" AND
+       _peak_processor MATCHES "^(x86_64|amd64|aarch64|arm64)$" AND
        NOT PEAK_GUM_HAS_PEAK_EXACT_ATTACH_API)
         message(FATAL_ERROR
-            "The selected PEAK-patched Frida Gum devkit does not expose the x86 exact-entry attach API. "
-            "Use the current auto-patched devkit, or rebuild the caller-provided devkit with GUM_PEAK_EXACT_ATTACH_API_VERSION=1 and gum_interceptor_peak_attach_exact().")
+            "The selected PEAK-patched Frida Gum devkit does not expose the exact-entry attach and redirect-resolution APIs for this architecture. "
+            "Use the current auto-patched devkit, or rebuild the caller-provided devkit with the current PEAK Gum API overlay.")
     endif()
 
     set(CMAKE_REQUIRED_INCLUDES "${_saved_required_includes}")

--- a/cmake/peak-gum/frida-gum-peak-api.h
+++ b/cmake/peak-gum/frida-gum-peak-api.h
@@ -180,8 +180,9 @@ GUM_API gboolean gum_interceptor_peak_get_function_patch(
     guint8 * original_prologue,
     guint * prologue_len);
 
-#if defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64__) || defined(__amd64__) || defined(__aarch64__)
 # define GUM_PEAK_EXACT_ATTACH_API_VERSION 1
+# define GUM_PEAK_REDIRECT_RESOLVER_API_VERSION 1
 
 /* Attach to the supplied entry without following its leading redirect. */
 GUM_API GumAttachReturn gum_interceptor_peak_attach_exact(
@@ -189,6 +190,12 @@ GUM_API GumAttachReturn gum_interceptor_peak_attach_exact(
     gpointer function_address,
     GumInvocationListener * listener,
     const GumAttachOptions * options);
+
+/* Resolves the same redirect chain followed by Gum replacement APIs. */
+GUM_API gboolean gum_interceptor_peak_resolve_redirect_chain(
+    GumInterceptor * interceptor,
+    gpointer function_address,
+    gpointer * resolved_address);
 #endif
 
 #ifdef __cplusplus

--- a/cmake/peak-gum/gum_peak_pc_api.c
+++ b/cmake/peak-gum/gum_peak_pc_api.c
@@ -587,7 +587,7 @@ typedef guint8 PeakGumInterceptorType17;
 typedef struct _PeakGumInterceptorBackend17 PeakGumInterceptorBackend17;
 typedef struct _PeakGumFunctionContext17 PeakGumFunctionContext17;
 typedef union _PeakGumFunctionContextBackendData17 PeakGumFunctionContextBackendData17;
-#if defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64__) || defined(__amd64__) || defined(__aarch64__)
 typedef struct _GumInterceptorBackend GumInterceptorBackend;
 
 G_GNUC_INTERNAL gpointer
@@ -723,6 +723,53 @@ typedef struct _PeakGumInterceptor17 {
     PeakGumInterceptorTransaction17 current_transaction;
     gpointer unwind_broker;
 } PeakGumInterceptor17;
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__aarch64__)
+gboolean
+gum_interceptor_peak_resolve_redirect_chain(
+    GumInterceptor * interceptor,
+    gpointer function_address,
+    gpointer * resolved_address)
+{
+    PeakGumInterceptor17 * private_interceptor;
+    gpointer visited[64];
+    gpointer current;
+    guint depth;
+
+    if (interceptor == NULL || function_address == NULL ||
+        resolved_address == NULL) {
+        return FALSE;
+    }
+
+    private_interceptor = (PeakGumInterceptor17 *)interceptor;
+    if (private_interceptor->backend == NULL) {
+        return FALSE;
+    }
+
+    current = function_address;
+    for (depth = 0; depth != G_N_ELEMENTS(visited); ++depth) {
+        gpointer next;
+        guint previous;
+
+        visited[depth] = current;
+        next = _gum_interceptor_backend_resolve_redirect(
+            (GumInterceptorBackend *)private_interceptor->backend,
+            current);
+        if (next == NULL) {
+            *resolved_address = current;
+            return TRUE;
+        }
+        for (previous = 0; previous <= depth; ++previous) {
+            if (visited[previous] == next) {
+                return FALSE;
+            }
+        }
+        current = next;
+    }
+
+    return FALSE;
+}
+#endif
 
 union _PeakGumFunctionContextBackendData17 {
     gchar storage[3 * GLIB_SIZEOF_VOID_P];

--- a/cmake/peak-gum/patch_frida_gum_elf_module.py
+++ b/cmake/peak-gum/patch_frida_gum_elf_module.py
@@ -1178,7 +1178,7 @@ def main() -> int:
     if args.nm is None or args.objcopy is None:
         fail("PEAK invocation dispatch patch requires --nm and --objcopy")
 
-    if machine == 62:  # EM_X86_64
+    if machine in (62, 183):  # EM_X86_64 or EM_AARCH64
         route_redirect_resolver_through_overlay(
             library,
             members,

--- a/include/cuda_interceptor.h
+++ b/include/cuda_interceptor.h
@@ -8,8 +8,10 @@
  * PEAK replaces the CUDA Runtime and Driver kernel- and graph-launch entry
  * points that are present in the process.  The wrappers record launch
  * metadata and CUDA events while preserving the original CUDA return value.
- * All interceptor state, CUDA events, and result maps are owned by this
- * module; callers do not acquire ownership through this interface.
+ * A dedicated helper harvests completed event pairs within a fixed work
+ * budget; launch wrappers never synchronize a CUDA device or stream. All
+ * interceptor state, CUDA events, and result maps are owned by this module;
+ * callers do not acquire ownership through this interface.
  */
 #include "frida-gum.h"
 #include "utils/utils.h"
@@ -59,10 +61,13 @@ int cuda_interceptor_attach();
  * the interceptor, CUDA events, and result maps so live trampoline users do
  * not observe freed state.  A successful flush still retains the bounded CUDA
  * state when an in-flight wrapper is observed; a later detach retry drains
- * pending events and releases the module-owned maps and event pool only once
- * no wrappers remain.  The Gum interceptor reference itself remains pinned to
- * cover wrappers that may already have entered before in-flight accounting
- * began.
+ * pending events until the configured finite finalization deadline and
+ * releases the module-owned maps and event pool only once no admitted
+ * lifecycle readers remain.
+ * Incomplete context-owned CUDA state is retained after a deadline or context
+ * failure instead of being destroyed from the wrong context. The Gum
+ * interceptor reference itself remains pinned so a wrapper rejected by the
+ * lifecycle gate can still delegate through Gum's original trampoline.
  *
  * The function is a no-op when no interceptor has been obtained.
  */
@@ -84,14 +89,16 @@ void cuda_interceptor_dettach();
 void cuda_interceptor_print(int is_MPI);
 
 /**
- * @brief Synchronizes pending CUDA work and reports collected launch data.
+ * @brief Boundedly harvests pending CUDA work and reports collected data.
  *
  * Calling this function permanently stops admission of new events for the
- * current attachment, synchronizes the CUDA device, and drains kernel and
- * graph event records. Kernel rows use a separate, bounded report snapshot
- * through the established aggregation transport; rank-local graph rows are
- * printed here. The function is a no-op if the result maps were not
- * initialized.
+ * current attachment and gives PEAK-owned event records up to
+ * `PEAK_CUDA_FINALIZATION_TIMEOUT_MS` (default 1000 ms) to complete. It never
+ * synchronizes a CUDA device or stream. Records still incomplete at the
+ * deadline are counted and retained safely. Kernel rows use a separate,
+ * bounded report snapshot through the established aggregation transport;
+ * rank-local graph rows are printed here. The function is a no-op if the
+ * result maps were not initialized.
  *
  * @param[in] aggregation_mode A `PeakOutputAggregationMode` numeric value.
  * @param[in] active_mpi_job Nonzero when this process belongs to an active MPI
@@ -101,6 +108,41 @@ void cuda_interceptor_print(int is_MPI);
  */
 void cuda_interceptor_print_with_mpi_job_policy(int aggregation_mode,
                                                 int active_mpi_job);
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+/** Forces accepted CUDA events to remain pending in regression tests. */
+void peak_cuda_test_force_incomplete_events(int enabled);
+/** Forces the next harvested CUDA event query down the error path. */
+void peak_cuda_test_force_query_error_once(int enabled);
+/** Returns completed real event queries made by the CUDA helper. */
+unsigned long long peak_cuda_test_harvester_query_count(void);
+/** Returns nonzero after the deferred CUDA helper handshake succeeds. */
+int peak_cuda_test_harvester_ready(void);
+/** Returns the number of currently leased CUDA timing slots. */
+unsigned long long peak_cuda_test_active_slot_count(void);
+/** Pauses a capture-begin hook after CUDA sections are drained. */
+void peak_cuda_test_pause_capture_begin(int enabled);
+/** Returns nonzero while a capture-begin hook is paused. */
+int peak_cuda_test_capture_begin_waiting(void);
+/** Pauses CUDA sections immediately after capture-gate admission. */
+void peak_cuda_test_pause_cuda_section(int enabled);
+/** Returns the number of CUDA sections paused by the test seam. */
+unsigned int peak_cuda_test_cuda_sections_waiting(void);
+/** Returns nonzero while capture coordination blocks CUDA sections. */
+int peak_cuda_test_capture_blocked(void);
+/** Pauses lifecycle admission after the first open-gate observation. */
+void peak_cuda_test_pause_lifecycle_before_increment(int enabled);
+/** Returns the number of lifecycle readers paused before shard admission. */
+unsigned int peak_cuda_test_lifecycle_before_increment_waiting(void);
+/** Pauses lifecycle readers after successful shard admission. */
+void peak_cuda_test_pause_lifecycle_after_admission(int enabled);
+/** Returns the number of admitted lifecycle readers paused by the test seam. */
+unsigned int peak_cuda_test_lifecycle_after_admission_waiting(void);
+/** Returns nonzero after lifecycle admission is permanently closed. */
+int peak_cuda_test_lifecycle_closing(void);
+/** Bounded-finalization seam for CUDA regression tests. */
+void peak_cuda_test_finalize(void);
+#endif
 
 /** @} */
 

--- a/include/internal/cuda_profiler_state.h
+++ b/include/internal/cuda_profiler_state.h
@@ -1,39 +1,203 @@
 #ifndef PEAK_CUDA_PROFILER_STATE_H
 #define PEAK_CUDA_PROFILER_STATE_H
 
+#include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-/** CUDA-free admission and identity state used by the CUDA interceptor. */
-struct PeakCudaProfilerCounters {
+struct PeakCudaSlotLease {
+    std::size_t index;
+    std::uint64_t generation;
+    std::uintptr_t context;
+    std::size_t shard;
+};
+
+struct PeakCudaSlotAllocatorCounters {
     std::size_t capacity;
-    std::size_t identity_capacity;
-    std::size_t cached_identities;
+    std::size_t assigned_slots;
+    std::size_t context_count;
     std::size_t active_slots;
     std::size_t high_water_slots;
+};
+
+struct PeakCudaLaunchDimensions {
+    std::uint64_t total_threads;
+    std::uint64_t grid_size;
+    std::uint64_t block_size;
+    bool overflow;
+};
+
+std::uint64_t peak_cuda_saturating_add_u64(std::uint64_t left,
+                                           std::uint64_t right,
+                                           bool* overflow = nullptr);
+PeakCudaLaunchDimensions peak_cuda_compute_launch_dimensions(
+    unsigned int grid_x, unsigned int grid_y, unsigned int grid_z,
+    unsigned int block_x, unsigned int block_y, unsigned int block_z);
+
+/** Fixed-capacity, context-partitioned logical CUDA event-slot allocator. */
+class PeakCudaSlotAllocator {
+public:
+    static constexpr std::size_t kShardCount = 256;
+    static constexpr std::size_t kCacheLineBytes = 64;
+
+    explicit PeakCudaSlotAllocator(std::size_t capacity = 0);
+
+    void reset(std::size_t capacity);
+    bool acquire(std::uintptr_t context,
+                 PeakCudaSlotLease* lease);
+    bool acquire(std::uintptr_t context, std::size_t shard,
+                 PeakCudaSlotLease* lease);
+    bool acquire_if_accepting(std::uintptr_t context,
+                              const std::atomic_bool& accepting,
+                              PeakCudaSlotLease* lease,
+                              bool* admission_closed);
+    bool acquire_if_accepting(std::uintptr_t context, std::size_t shard,
+                              const std::atomic_bool& accepting,
+                              PeakCudaSlotLease* lease,
+                              bool* admission_closed);
+    bool release(const PeakCudaSlotLease& lease);
+    std::size_t active_count() const noexcept;
+    std::size_t snapshot_active_leases(PeakCudaSlotLease* leases,
+                                       std::size_t lease_capacity) const;
+    bool try_snapshot_active_leases(PeakCudaSlotLease* leases,
+                                    std::size_t lease_capacity,
+                                    std::size_t* active) const;
+    PeakCudaSlotAllocatorCounters counters() const;
+
+private:
+    struct FreeHead {
+        std::atomic<std::uint64_t> value;
+        std::array<unsigned char,
+                   kCacheLineBytes - sizeof(std::atomic<std::uint64_t>)>
+            padding;
+    };
+
+    struct CounterShard {
+        std::atomic<std::size_t> active;
+        std::atomic<std::size_t> handoff;
+        std::atomic<std::size_t> high_water;
+        std::array<unsigned char,
+                   kCacheLineBytes - 3 * sizeof(std::atomic<std::size_t>)>
+            padding;
+    };
+
+    static_assert(sizeof(FreeHead) == kCacheLineBytes,
+                  "free-list heads must occupy separate cache lines");
+    static_assert(sizeof(CounterShard) == kCacheLineBytes,
+                  "allocator counters must occupy separate cache lines");
+
+    struct Slot {
+        std::atomic<std::uint32_t> next_free;
+        std::atomic<std::uint64_t> generation;
+        std::uintptr_t context;
+        std::uint16_t shard;
+        std::atomic<unsigned char> state;
+    };
+
+    std::size_t find_or_claim_context(std::uintptr_t context);
+    bool pop_free(std::size_t context_index, std::size_t shard,
+                  PeakCudaSlotLease* lease);
+    void push_free(std::size_t context_index, std::size_t shard,
+                   std::uint32_t index);
+    bool reserve_unassigned(std::size_t context_index,
+                            std::uintptr_t context, std::size_t shard,
+                            PeakCudaSlotLease* lease);
+    std::size_t context_index(std::uintptr_t context) const;
+    void record_active_acquire(std::size_t shard);
+
+    std::unique_ptr<Slot[]> slots_;
+    std::unique_ptr<std::atomic<std::uintptr_t>[]> contexts_;
+    std::unique_ptr<FreeHead[]> free_heads_;
+    std::size_t capacity_;
+    std::size_t context_capacity_;
+    std::atomic<std::size_t> next_unassigned_;
+    std::atomic<std::size_t> assigned_slots_;
+    std::atomic<std::size_t> context_count_;
+    std::array<CounterShard, kShardCount> counter_shards_;
+    std::uint64_t generation_seed_;
+};
+
+/** Fixed-capacity MPMC handoff from launch wrappers to the harvester. */
+class PeakCudaPendingQueue {
+public:
+    explicit PeakCudaPendingQueue(std::size_t capacity = 0);
+
+    void reset(std::size_t capacity);
+    bool push(const PeakCudaSlotLease& lease, bool* shard_was_empty = nullptr);
+    bool pop(PeakCudaSlotLease* lease);
+    bool requeue_local(const PeakCudaSlotLease& lease);
+
+private:
+    struct QueueShard {
+        std::atomic<std::uint64_t> head;
+        std::array<unsigned char,
+                   PeakCudaSlotAllocator::kCacheLineBytes -
+                       sizeof(std::atomic<std::uint64_t>)>
+            padding;
+    };
+
+    static_assert(sizeof(QueueShard) ==
+                      PeakCudaSlotAllocator::kCacheLineBytes,
+                  "pending queues must occupy separate cache lines");
+
+    std::unique_ptr<std::atomic<std::uint32_t>[]> next_;
+    std::unique_ptr<PeakCudaSlotLease[]> leases_;
+    std::array<QueueShard, PeakCudaSlotAllocator::kShardCount> shards_;
+    std::array<std::uint32_t,
+               PeakCudaSlotAllocator::kShardCount> local_heads_;
+    std::size_t capacity_;
+    std::size_t dequeue_shard_;
+};
+
+/** CUDA-free admission and identity state used by the CUDA interceptor. */
+struct PeakCudaProfilerCounters {
+    std::size_t identity_capacity;
+    std::size_t cached_identities;
+    std::uint64_t observed_launches;
+    std::uint64_t accepted_launches;
+    std::uint64_t completed_launches;
     std::uint64_t dropped_pool_full;
     std::uint64_t dropped_identity_full;
     std::uint64_t dropped_event_create;
+    /** Legacy aggregate for event record/query/elapsed-time failures. */
     std::uint64_t dropped_timing_error;
+    std::uint64_t dropped_harvester_unavailable;
+    std::uint64_t dropped_stream_capture;
+    std::uint64_t dropped_capture_query;
+    std::uint64_t dropped_capture_query_unsupported;
+    std::uint64_t dropped_unsupported_multi_device;
+    std::uint64_t dropped_event_query;
+    std::uint64_t dropped_elapsed_time;
+    std::uint64_t dropped_context_query;
+    std::uint64_t dropped_context_switch;
+    std::uint64_t dropped_context_restore;
+    std::uint64_t finalization_timeouts;
+    std::uint64_t finalization_incomplete;
+    std::uint64_t dropped_dimension_overflow;
 };
 
 struct PeakCudaKernelIdentity {
-    std::string name;
+    std::array<char, 256> name;
     bool target_match;
 };
 
 struct PeakCudaIdentityKey {
     std::uintptr_t value;
     bool driver_function;
+    std::uintptr_t context;
 
     bool operator==(const PeakCudaIdentityKey& other) const
     {
-        return value == other.value && driver_function == other.driver_function;
+        return value == other.value &&
+               driver_function == other.driver_function &&
+               context == other.context;
     }
 };
 
@@ -41,7 +205,8 @@ struct PeakCudaIdentityKeyHash {
     std::size_t operator()(const PeakCudaIdentityKey& key) const
     {
         return std::hash<std::uintptr_t>()(key.value) ^
-               (std::hash<bool>()(key.driver_function) << 1);
+               (std::hash<bool>()(key.driver_function) << 1) ^
+               (std::hash<std::uintptr_t>()(key.context) << 2);
     }
 };
 
@@ -57,33 +222,78 @@ public:
         const char* display_name,
         const char* target_name,
         bool monitor_all,
-        const std::vector<std::string>& targets);
+        const std::vector<std::string>& targets,
+        std::uintptr_t context = 0);
 
     bool cached_identity(std::uintptr_t identity,
                          bool driver_function,
-                         PeakCudaKernelIdentity* result) const;
+                         PeakCudaKernelIdentity* result,
+                         std::uintptr_t context = 0) const;
 
-    bool acquire_slot();
-    void release_slot();
+    void record_launch_observed(std::size_t shard = 0,
+                                bool exclusive = false);
+    void record_launch_accepted(std::size_t shard = 0,
+                                bool exclusive = false);
+    void record_launch_completed();
+    void record_pool_full();
+    void record_identity_full();
     void record_event_create_failure();
     void record_timing_error();
+    void record_harvester_unavailable();
+    void record_stream_capture_skip();
+    void record_capture_query_failure();
+    void record_capture_query_unsupported();
+    void record_unsupported_multi_device();
+    void record_event_query_failure();
+    void record_elapsed_time_failure();
+    void record_context_query_failure();
+    void record_context_switch_failure();
+    void record_context_restore_failure();
+    void record_finalization_timeout(std::size_t incomplete_records);
+    void record_dimension_overflow();
     PeakCudaProfilerCounters counters() const;
 
 private:
+    struct LaunchCounterShard {
+        std::atomic<std::uint64_t> observed;
+        std::atomic<std::uint64_t> accepted;
+        std::array<unsigned char,
+                   PeakCudaSlotAllocator::kCacheLineBytes -
+                       2 * sizeof(std::atomic<std::uint64_t>)>
+            padding;
+    };
+
+    static_assert(sizeof(LaunchCounterShard) ==
+                      PeakCudaSlotAllocator::kCacheLineBytes,
+                  "launch counters must occupy separate cache lines");
+
     static bool target_matches(const std::string& name,
                                const std::vector<std::string>& targets);
 
     mutable std::mutex mutex_;
     std::unordered_map<PeakCudaIdentityKey, PeakCudaKernelIdentity,
                        PeakCudaIdentityKeyHash> identities_;
-    std::size_t capacity_;
     std::size_t identity_capacity_;
-    std::size_t active_slots_;
-    std::size_t high_water_slots_;
-    std::uint64_t dropped_pool_full_;
-    std::uint64_t dropped_identity_full_;
-    std::uint64_t dropped_event_create_;
-    std::uint64_t dropped_timing_error_;
+    std::array<LaunchCounterShard,
+               PeakCudaSlotAllocator::kShardCount> launch_counter_shards_;
+    std::atomic<std::uint64_t> completed_launches_;
+    std::atomic<std::uint64_t> dropped_pool_full_;
+    std::atomic<std::uint64_t> dropped_identity_full_;
+    std::atomic<std::uint64_t> dropped_event_create_;
+    std::atomic<std::uint64_t> dropped_timing_error_;
+    std::atomic<std::uint64_t> dropped_harvester_unavailable_;
+    std::atomic<std::uint64_t> dropped_stream_capture_;
+    std::atomic<std::uint64_t> dropped_capture_query_;
+    std::atomic<std::uint64_t> dropped_capture_query_unsupported_;
+    std::atomic<std::uint64_t> dropped_unsupported_multi_device_;
+    std::atomic<std::uint64_t> dropped_event_query_;
+    std::atomic<std::uint64_t> dropped_elapsed_time_;
+    std::atomic<std::uint64_t> dropped_context_query_;
+    std::atomic<std::uint64_t> dropped_context_switch_;
+    std::atomic<std::uint64_t> dropped_context_restore_;
+    std::atomic<std::uint64_t> finalization_timeouts_;
+    std::atomic<std::uint64_t> finalization_incomplete_;
+    std::atomic<std::uint64_t> dropped_dimension_overflow_;
 };
 
 #endif /* PEAK_CUDA_PROFILER_STATE_H */

--- a/include/internal/unsafe_gum_prologue.h
+++ b/include/internal/unsafe_gum_prologue.h
@@ -8,6 +8,10 @@
 
 #include "frida-gum.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PEAK_ALLOW_UNSAFE_GUM_PROLOGUE_ENV "PEAK_ALLOW_UNSAFE_GUM_PROLOGUE"
 #define PEAK_UNSAFE_GUM_PROLOGUE_POLICY_ENV "PEAK_UNSAFE_GUM_PROLOGUE_POLICY"
 
@@ -65,5 +69,9 @@ peak_gum_interceptor_attach_target(GumInterceptor* interceptor,
 gboolean
 peak_unsafe_gum_support_prologue_check(gpointer address,
                                        const char** reason_out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PEAK_UNSAFE_GUM_PROLOGUE_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,10 @@ endif()
 if(BUILD_TESTS OR BUILD_TESTING)
     target_compile_definitions(peak PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
     target_compile_definitions(peak PRIVATE PEAK_TARGET_RESOLVER_TESTING=1)
+    if(TARGET cuda_interceptor_obj)
+        target_compile_definitions(cuda_interceptor_obj
+            PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
+    endif()
 endif()
 
 if (CUDA_FOUND OR CUDAToolkit_FOUND)

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -1,9 +1,20 @@
 #include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <dlfcn.h>
+#include <limits>
+#include <thread>
+#include <time.h>
+#if defined(__linux__)
+#include <sched.h>
+#endif
 
 #include "cuda_interceptor.h"
 #include "internal/cuda_profiler_state.h"
 #include "internal/general_listener/report_snapshot.h"
 #include "internal/general_listener/socket_report_transport.h"
+#include "internal/unsafe_gum_prologue.h"
 #ifdef HAVE_MPI
 #include "internal/general_listener/mpi_report_transport.h"
 #endif
@@ -13,6 +24,10 @@
 #define PEAK_CUDA_WRAPPER_EXPORT extern "C" __attribute__((visibility("default")))
 
 extern "C" gpointer peak_general_listener_find_function(const char* symbol);
+extern "C" void peak_general_listener_exclude_current_thread(void);
+extern "C" void peak_general_listener_fast_ignore_current_thread(void);
+extern "C" void peak_general_listener_fast_unignore_current_thread(void);
+extern "C" void pthread_listener_mark_next_created_thread_helper(void);
 
 enum PeakCudaOutputAggregationMode {
     PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL = 0,
@@ -35,6 +50,35 @@ static gpointer* hook_cu_launch_cooperative_multiple_device;
 static gpointer* hook_cu_launch_ex;
 static gpointer* hook_cuda_graph_launch;
 static gpointer* hook_cu_graph_launch;
+enum PeakCudaCaptureHookIndex {
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE = 0,
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE_PTSZ,
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_RECAPTURE_TO_GRAPH,
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_RECAPTURE_TO_GRAPH_PTSZ,
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE_TO_GRAPH,
+    PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE_TO_GRAPH_PTSZ,
+    PEAK_CUDA_HOOK_RUNTIME_END_CAPTURE,
+    PEAK_CUDA_HOOK_RUNTIME_END_CAPTURE_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V1,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V1_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V2,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V2_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_RECAPTURE_TO_GRAPH,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_RECAPTURE_TO_GRAPH_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_GRAPH,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_GRAPH_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_END_CAPTURE,
+    PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_CIG,
+    PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_CIG_PTSZ,
+    PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_TO_CIG,
+    PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_TO_CIG_PTSZ,
+    PEAK_CUDA_CAPTURE_HOOK_COUNT,
+};
+static gpointer* peak_cuda_capture_hooks[PEAK_CUDA_CAPTURE_HOOK_COUNT];
+static GumInvocationListener*
+    peak_cuda_capture_listeners[PEAK_CUDA_CAPTURE_HOOK_COUNT];
+static gboolean peak_cuda_capture_hooks_ready;
 extern size_t peak_gpu_hook_address_count;
 extern char** peak_gpu_hook_strings;
 extern gboolean peak_gpu_monitor_all;
@@ -85,31 +129,285 @@ static CUresult (*original_cu_graph_launch)(
 typedef CUresult (*PeakCudaFuncGetNameFn)(const char** name,
                                           CUfunction function);
 static PeakCudaFuncGetNameFn peak_cuda_func_get_name;
-static std::once_flag peak_cuda_func_get_name_once;
-static PeakCudaProfilerState peak_cuda_profiler_state;
 static PeakEnvWarningState peak_cuda_event_pool_capacity_warning_emitted;
+static PeakEnvWarningState peak_cuda_finalization_timeout_warning_emitted;
+
+typedef CUresult (*PeakCuCtxGetCurrentFn)(CUcontext* context);
+typedef CUresult (*PeakCuCtxGetDeviceFn)(CUdevice* device);
+typedef CUresult (*PeakCuCtxPushCurrentFn)(CUcontext context);
+typedef CUresult (*PeakCuCtxPopCurrentFn)(CUcontext* context);
+typedef CUresult (*PeakCuEventRecordFn)(CUevent event, CUstream stream);
+typedef CUresult (*PeakCuStreamIsCapturingFn)(
+    CUstream stream, CUstreamCaptureStatus* status);
+typedef CUresult (*PeakCuThreadExchangeStreamCaptureModeFn)(
+    CUstreamCaptureMode* mode);
+typedef CUresult (*PeakCuGetProcAddressFn)(
+    const char* symbol, void** function, int version,
+    unsigned long long flags);
+typedef CUresult (*PeakCuGetProcAddressV2Fn)(
+    const char* symbol, void** function, int version,
+    unsigned long long flags, int* symbol_status);
+
+struct PeakCudaBackendApi {
+    void* driver_handle;
+    PeakCuCtxGetCurrentFn ctx_get_current;
+    PeakCuCtxGetDeviceFn ctx_get_device;
+    PeakCuCtxPushCurrentFn ctx_push_current;
+    PeakCuCtxPopCurrentFn ctx_pop_current;
+    PeakCuEventRecordFn event_record;
+    PeakCuStreamIsCapturingFn driver_stream_is_capturing;
+    PeakCuThreadExchangeStreamCaptureModeFn
+        driver_thread_exchange_stream_capture_mode;
+};
+
+static PeakCudaBackendApi peak_cuda_backend_api;
+
+enum PeakCudaCaptureApi {
+    PEAK_CUDA_CAPTURE_API_RUNTIME = 0,
+    PEAK_CUDA_CAPTURE_API_DRIVER,
+};
+
+enum PeakCudaCaptureOperation {
+    PEAK_CUDA_CAPTURE_OPERATION_BEGIN = 0,
+    PEAK_CUDA_CAPTURE_OPERATION_END,
+};
+
+struct PeakCudaCaptureHookDescriptor {
+    const char* symbol;
+    PeakCudaCaptureApi api;
+    PeakCudaCaptureOperation operation;
+};
+
+static constexpr size_t kPeakCudaDirectCaptureHookCapacity = 42;
+static gpointer peak_cuda_direct_capture_hooks[
+    kPeakCudaDirectCaptureHookCapacity];
+static GumInvocationListener* peak_cuda_direct_capture_listeners[
+    kPeakCudaDirectCaptureHookCapacity];
+static PeakCudaCaptureHookDescriptor peak_cuda_direct_capture_descriptors[
+    kPeakCudaDirectCaptureHookCapacity];
+static size_t peak_cuda_direct_capture_hook_count;
+
+static const PeakCudaCaptureHookDescriptor peak_cuda_capture_descriptors[] = {
+    {"cudaStreamBeginCapture", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamBeginCapture_ptsz", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamBeginRecaptureToGraph", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamBeginRecaptureToGraph_ptsz", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamBeginCaptureToGraph", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamBeginCaptureToGraph_ptsz", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cudaStreamEndCapture", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+    {"cudaStreamEndCapture_ptsz", PEAK_CUDA_CAPTURE_API_RUNTIME,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+    {"cuStreamBeginCapture", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCapture_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCapture_v2", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCapture_v2_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginRecaptureToGraph", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginRecaptureToGraph_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCaptureToGraph", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCaptureToGraph_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamEndCapture", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+    {"cuStreamEndCapture_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+    {"cuStreamBeginCaptureToCig", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamBeginCaptureToCig_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_BEGIN},
+    {"cuStreamEndCaptureToCig", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+    {"cuStreamEndCaptureToCig_ptsz", PEAK_CUDA_CAPTURE_API_DRIVER,
+     PEAK_CUDA_CAPTURE_OPERATION_END},
+};
+
+static_assert(sizeof(peak_cuda_capture_descriptors) /
+                  sizeof(peak_cuda_capture_descriptors[0]) ==
+              PEAK_CUDA_CAPTURE_HOOK_COUNT,
+              "CUDA capture hook descriptor table is incomplete");
+
+enum PeakCudaLaunchRecordKind {
+    PEAK_CUDA_LAUNCH_RECORD_NONE = 0,
+    PEAK_CUDA_LAUNCH_RECORD_KERNEL,
+    PEAK_CUDA_LAUNCH_RECORD_GRAPH,
+};
+
+struct PeakCudaLaunchRecord {
+    PeakCudaLaunchRecordKind kind;
+    char kernel_name[256];
+    std::uint64_t total_threads;
+    std::uint64_t grid_size;
+    std::uint64_t block_size;
+    CUgraphExec graph;
+    cudaError_t result;
+};
 
 struct PeakCudaEventSlot {
     cudaEvent_t start;
     cudaEvent_t end;
     gboolean initialized;
-    gboolean leased;
+    CUcontext owner_context;
+    CUdevice owner_device;
+    PeakCudaSlotLease lease;
+    PeakCudaLaunchRecord record;
 };
 
-static std::vector<PeakCudaEventSlot> peak_cuda_event_pool;
-static std::vector<size_t> peak_cuda_free_event_slots;
-static std::mutex peak_cuda_event_pool_mutex;
+struct PeakCudaActiveCapture {
+    CUcontext context;
+    CUstream stream;
+    size_t count;
+};
+
+struct PeakCudaRetainedState {
+    PeakCudaProfilerState profiler_state;
+    PeakCudaSlotAllocator slot_allocator;
+    PeakCudaPendingQueue pending_queue;
+    std::vector<PeakCudaEventSlot> event_pool;
+    std::vector<PeakCudaActiveCapture> active_captures;
+};
+
+/* A timed-out CUDA query may return after PEAK finalization. Keep every object
+ * reachable by the harvester alive until process reclamation. */
+static PeakCudaRetainedState& peak_cuda_retained_state =
+    *new PeakCudaRetainedState;
+static PeakCudaProfilerState& peak_cuda_profiler_state =
+    peak_cuda_retained_state.profiler_state;
+static PeakCudaSlotAllocator& peak_cuda_slot_allocator =
+    peak_cuda_retained_state.slot_allocator;
+static std::vector<PeakCudaEventSlot>& peak_cuda_event_pool =
+    peak_cuda_retained_state.event_pool;
+static PeakCudaPendingQueue& peak_cuda_pending_queue =
+    peak_cuda_retained_state.pending_queue;
+static std::vector<PeakCudaActiveCapture>& peak_cuda_active_captures =
+    peak_cuda_retained_state.active_captures;
+static pthread_mutex_t peak_cuda_harvester_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_cuda_harvester_cond = PTHREAD_COND_INITIALIZER;
+static pthread_t peak_cuda_harvester_thread;
+static std::atomic_bool peak_cuda_harvester_started{false};
+static std::atomic_bool peak_cuda_harvester_running{false};
+static std::atomic_bool peak_cuda_harvester_waiting{false};
+static gboolean peak_cuda_harvester_initialization_requested;
+static gboolean peak_cuda_harvester_initialization_allowed;
+static gboolean peak_cuda_harvester_initialization_done;
+static gboolean peak_cuda_harvester_capture_mode_ready;
+static std::atomic_bool peak_cuda_harvester_initialization_inflight{false};
+static std::atomic_bool peak_cuda_harvester_initialization_terminal{false};
+static pthread_mutex_t peak_cuda_capture_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_cuda_capture_cond = PTHREAD_COND_INITIALIZER;
+static std::mutex peak_cuda_capture_teardown_mutex;
+static size_t peak_cuda_capture_transitions;
+static std::atomic_bool peak_cuda_capture_blocked{false};
+static std::atomic_bool peak_cuda_capture_tracking_terminal{false};
+static constexpr size_t kPeakCudaTimingShardCount = 256;
+static constexpr size_t kPeakCudaTimingExclusiveShardCount = 192;
+struct alignas(64) PeakCudaTimingShard {
+    std::atomic_uint active{0};
+};
+static PeakCudaTimingShard
+    peak_cuda_timing_shards[kPeakCudaTimingShardCount];
+static std::atomic_uint peak_cuda_next_timing_shard{0};
+static thread_local size_t peak_cuda_timing_shard_index =
+    kPeakCudaTimingShardCount;
+static thread_local unsigned int peak_cuda_timing_depth;
+static thread_local gboolean peak_cuda_timing_shard_exclusive;
+static std::atomic_uint peak_cuda_next_slot_shard{0};
+static thread_local size_t peak_cuda_slot_shard_index =
+    PeakCudaSlotAllocator::kShardCount;
+static constexpr size_t kPeakCudaSlotExclusiveShardCount = 192;
+static thread_local gboolean peak_cuda_slot_shard_exclusive;
+static thread_local unsigned int peak_cuda_capture_wrapper_depth;
+static thread_local unsigned int peak_cuda_runtime_launch_wrapper_depth;
+struct PeakCudaThreadIdentityCache {
+    std::uint64_t epoch;
+    std::uintptr_t identity;
+    std::uintptr_t context;
+    gboolean driver_function;
+    gboolean valid;
+    PeakCudaKernelIdentity value;
+};
+static std::atomic_ullong peak_cuda_identity_epoch{1};
+static thread_local PeakCudaThreadIdentityCache peak_cuda_thread_identity;
+
+class PeakCudaRuntimeLaunchGuard {
+public:
+    PeakCudaRuntimeLaunchGuard()
+    {
+        ++peak_cuda_runtime_launch_wrapper_depth;
+    }
+
+    ~PeakCudaRuntimeLaunchGuard()
+    {
+        --peak_cuda_runtime_launch_wrapper_depth;
+    }
+
+    PeakCudaRuntimeLaunchGuard(const PeakCudaRuntimeLaunchGuard&) = delete;
+    PeakCudaRuntimeLaunchGuard& operator=(
+        const PeakCudaRuntimeLaunchGuard&) = delete;
+};
+
+static constexpr size_t kPeakCudaLifecycleShardCount = 256;
+static constexpr size_t kPeakCudaLifecycleExclusiveShardCount = 192;
+struct alignas(64) PeakCudaLifecycleShard {
+    std::atomic_uint active{0};
+};
+static PeakCudaLifecycleShard
+    peak_cuda_lifecycle_shards[kPeakCudaLifecycleShardCount];
+static std::atomic_uint peak_cuda_next_lifecycle_shard{0};
+static thread_local size_t peak_cuda_lifecycle_shard_index =
+    kPeakCudaLifecycleShardCount;
+static thread_local unsigned int peak_cuda_lifecycle_depth;
+static thread_local gboolean peak_cuda_lifecycle_shard_exclusive;
+/* Odd epochs are closed; even epochs are open. */
+static std::atomic_ullong peak_cuda_lifecycle_epoch{1};
+static constexpr size_t kPeakCudaCaptureRegistryCapacity = 1024;
 static size_t peak_cuda_event_pool_capacity = 256;
+static size_t peak_cuda_graph_identity_capacity = 1024;
+static unsigned long long peak_cuda_finalization_timeout_ms = 1000;
+static gboolean peak_cuda_finalization_complete;
+static gboolean peak_cuda_finalization_timed_out;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static std::atomic_bool peak_cuda_test_force_incomplete{false};
+static std::atomic_bool peak_cuda_test_force_query_error{false};
+static std::atomic_ullong peak_cuda_test_harvester_queries{0};
+static std::atomic_bool peak_cuda_test_pause_capture_begin_flag{false};
+static std::atomic_bool peak_cuda_test_capture_begin_waiting_flag{false};
+static std::atomic_bool peak_cuda_test_pause_cuda_section_flag{false};
+static std::atomic_uint peak_cuda_test_cuda_sections_waiting_count{0};
+static std::atomic_bool
+    peak_cuda_test_pause_lifecycle_before_increment_flag{false};
+static std::atomic_uint
+    peak_cuda_test_lifecycle_before_increment_waiting_count{0};
+static std::atomic_bool
+    peak_cuda_test_pause_lifecycle_after_admission_flag{false};
+static std::atomic_uint
+    peak_cuda_test_lifecycle_after_admission_waiting_count{0};
+#endif
+
+static constexpr size_t kPeakCudaHarvestRecordBudget = 64;
+static constexpr std::uint64_t kPeakCudaHarvestTimeBudgetNs = 1000000;
+static constexpr long kPeakCudaHarvestRetryNs = 1000000L;
+static constexpr size_t kPeakCudaWakeShard = 0;
+
+static void peak_cuda_request_harvester_stop_no_wait();
 
 static gchar*
 peak_cuda_driver_kernel_name(CUfunction function)
 {
     const char* name = NULL;
 
-    std::call_once(peak_cuda_func_get_name_once, []() {
-        peak_cuda_func_get_name = reinterpret_cast<PeakCudaFuncGetNameFn>(
-            peak_general_listener_find_function("cuFuncGetName"));
-    });
     if (peak_cuda_func_get_name == NULL ||
         peak_cuda_func_get_name(&name, function) != CUDA_SUCCESS ||
         name == NULL || name[0] == '\0') {
@@ -119,80 +417,601 @@ peak_cuda_driver_kernel_name(CUfunction function)
 }
 
 typedef struct {
-    gulong total_gpu_threads;
-    gulong max_gpu_threads;
-    gulong min_gpu_threads;
-    gulong total_kernel_call_cnt;
-    gulong max_kernel_call_cnt;
-    gulong min_kernel_call_cnt;
-    gulong total_block_size;
-    gulong max_block_size;
-    gulong min_block_size;
-    gulong total_grid_size;
-    gulong max_grid_size;
-    gulong min_grid_size;
+    std::uint64_t total_gpu_threads;
+    std::uint64_t max_gpu_threads;
+    std::uint64_t min_gpu_threads;
+    std::uint64_t total_kernel_call_cnt;
+    std::uint64_t max_kernel_call_cnt;
+    std::uint64_t min_kernel_call_cnt;
+    std::uint64_t total_block_size;
+    std::uint64_t max_block_size;
+    std::uint64_t min_block_size;
+    std::uint64_t total_grid_size;
+    std::uint64_t max_grid_size;
+    std::uint64_t min_grid_size;
     gdouble total_time;
     gdouble min_time;
     gdouble max_time;
 } KernelDimInfo;
 
 typedef struct {
-    gchar* kernel_name;
-    gulong total_threads;
-    gulong grid_size;
-    gulong block_size;
-    cudaEvent_t* start_event;
-    cudaEvent_t* end_event;
-    cudaError_t result;
-} KernelLaunchInfo;
-
-struct KernelLaunchSeries{
-    std::vector<KernelLaunchInfo> launches;
-    std::mutex mtx;
-};
-
-typedef struct {
-    gulong total_graph_call_cnt;
-    gulong max_graph_call_cnt;
-    gulong min_graph_call_cnt;
+    std::uint64_t total_graph_call_cnt;
+    std::uint64_t max_graph_call_cnt;
+    std::uint64_t min_graph_call_cnt;
     gdouble total_time;
     gdouble min_time;
     gdouble max_time;
+    CUdevice device;
 } GraphRecordInfo;
 
 typedef struct {
-    CUgraphExec_st* graph;
-    cudaEvent_t* start_event;
-    cudaEvent_t* end_event;
-    cudaError_t result;
-} GraphLaunchInfo;
+    std::uintptr_t context;
+    CUgraphExec graph;
+} PeakCudaGraphKey;
 
-struct GraphLaunchSeries{
-    std::vector<GraphLaunchInfo> launches;
-    std::mutex mtx;
-};
+static guint
+peak_cuda_graph_key_hash(gconstpointer value)
+{
+    const PeakCudaGraphKey* key =
+        static_cast<const PeakCudaGraphKey*>(value);
+    return g_direct_hash(reinterpret_cast<gconstpointer>(key->context)) ^
+           (g_direct_hash(key->graph) << 1);
+}
 
-static std::unordered_map<std::string, KernelLaunchSeries> peak_kernel_event_map;
-static std::unordered_map<CUgraphExec_st*, GraphLaunchSeries> peak_graph_event_map;
-static std::mutex peak_kernel_event_map_mutex;
-static std::mutex peak_graph_event_map_mutex;
+static gboolean
+peak_cuda_graph_key_equal(gconstpointer left, gconstpointer right)
+{
+    const PeakCudaGraphKey* a =
+        static_cast<const PeakCudaGraphKey*>(left);
+    const PeakCudaGraphKey* b =
+        static_cast<const PeakCudaGraphKey*>(right);
+    return a->context == b->context && a->graph == b->graph;
+}
 static std::mutex peak_cuda_lifecycle_mutex;
 static std::atomic_bool peak_cuda_accepting_events{false};
-static std::atomic_uint peak_cuda_in_flight{0};
 static gboolean peak_cuda_hooks_reverted;
+
+static PeakCudaLifecycleShard*
+peak_cuda_lifecycle_try_enter()
+{
+    /* The epoch loads, reader publication, epoch transition, and cold-path
+     * shard scans are all sequentially consistent. The first fixed set of
+     * worker threads owns one shard each and publishes with stores instead of
+     * contended RMWs. Threads beyond that bound retain the counter fallback.
+     * An epoch change rejects a stale reader spanning detach and reattach. */
+    unsigned long long epoch = peak_cuda_lifecycle_epoch.load(
+        std::memory_order_seq_cst);
+    if ((epoch & 1ULL) != 0) {
+        return NULL;
+    }
+    if (peak_cuda_lifecycle_depth != 0) {
+        ++peak_cuda_lifecycle_depth;
+        return &peak_cuda_lifecycle_shards[
+            peak_cuda_lifecycle_shard_index];
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (peak_cuda_test_pause_lifecycle_before_increment_flag.load(
+            std::memory_order_acquire)) {
+        peak_cuda_test_lifecycle_before_increment_waiting_count.fetch_add(
+            1, std::memory_order_release);
+        while (peak_cuda_test_pause_lifecycle_before_increment_flag.load(
+                   std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        peak_cuda_test_lifecycle_before_increment_waiting_count.fetch_sub(
+            1, std::memory_order_release);
+    }
+#endif
+    if (peak_cuda_lifecycle_shard_index == kPeakCudaLifecycleShardCount) {
+        unsigned int ticket = peak_cuda_next_lifecycle_shard.fetch_add(
+            1, std::memory_order_relaxed);
+        peak_cuda_lifecycle_shard_exclusive =
+            ticket < kPeakCudaLifecycleExclusiveShardCount;
+        peak_cuda_lifecycle_shard_index =
+            peak_cuda_lifecycle_shard_exclusive
+                ? ticket
+                : kPeakCudaLifecycleExclusiveShardCount +
+                    ((ticket - kPeakCudaLifecycleExclusiveShardCount) %
+                     (kPeakCudaLifecycleShardCount -
+                      kPeakCudaLifecycleExclusiveShardCount));
+    }
+    PeakCudaLifecycleShard* shard =
+        &peak_cuda_lifecycle_shards[peak_cuda_lifecycle_shard_index];
+    if (peak_cuda_lifecycle_shard_exclusive) {
+        shard->active.store(1, std::memory_order_seq_cst);
+    } else {
+        shard->active.fetch_add(1, std::memory_order_seq_cst);
+    }
+    if (peak_cuda_lifecycle_epoch.load(std::memory_order_seq_cst) != epoch) {
+        if (peak_cuda_lifecycle_shard_exclusive) {
+            shard->active.store(0, std::memory_order_seq_cst);
+        } else {
+            shard->active.fetch_sub(1, std::memory_order_seq_cst);
+        }
+        return NULL;
+    }
+    peak_cuda_lifecycle_depth = 1;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (peak_cuda_test_pause_lifecycle_after_admission_flag.load(
+            std::memory_order_acquire)) {
+        peak_cuda_test_lifecycle_after_admission_waiting_count.fetch_add(
+            1, std::memory_order_release);
+        while (peak_cuda_test_pause_lifecycle_after_admission_flag.load(
+                   std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        peak_cuda_test_lifecycle_after_admission_waiting_count.fetch_sub(
+            1, std::memory_order_release);
+    }
+#endif
+    return shard;
+}
+
+static void
+peak_cuda_lifecycle_leave(PeakCudaLifecycleShard* shard)
+{
+    if (shard != NULL) {
+        if (--peak_cuda_lifecycle_depth != 0) {
+            return;
+        }
+        if (peak_cuda_lifecycle_shard_exclusive) {
+            shard->active.store(0, std::memory_order_seq_cst);
+        } else {
+            shard->active.fetch_sub(1, std::memory_order_seq_cst);
+        }
+    }
+}
+
+static unsigned int
+peak_cuda_active_wrapper_count()
+{
+    unsigned int total = 0;
+    for (PeakCudaLifecycleShard& shard : peak_cuda_lifecycle_shards) {
+        unsigned int active = shard.active.load(std::memory_order_seq_cst);
+        if (active > UINT_MAX - total) {
+            return UINT_MAX;
+        }
+        total += active;
+    }
+    return total;
+}
+
+static void
+peak_cuda_lifecycle_close()
+{
+    unsigned long long epoch = peak_cuda_lifecycle_epoch.load(
+        std::memory_order_seq_cst);
+    if ((epoch & 1ULL) == 0) {
+        peak_cuda_lifecycle_epoch.store(epoch + 1,
+                                        std::memory_order_seq_cst);
+    }
+}
+
+static void
+peak_cuda_lifecycle_open()
+{
+    unsigned long long epoch = peak_cuda_lifecycle_epoch.load(
+        std::memory_order_seq_cst);
+    if ((epoch & 1ULL) != 0) {
+        peak_cuda_lifecycle_epoch.store(epoch + 1,
+                                        std::memory_order_seq_cst);
+    }
+}
 
 class PeakCudaInflightGuard {
 public:
-    PeakCudaInflightGuard()
-    {
-        peak_cuda_in_flight.fetch_add(1, std::memory_order_acq_rel);
-    }
+    PeakCudaInflightGuard() : shard_(peak_cuda_lifecycle_try_enter()) {}
 
     ~PeakCudaInflightGuard()
     {
-        peak_cuda_in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        peak_cuda_lifecycle_leave(shard_);
     }
+
+    bool entered() const { return shard_ != NULL; }
+
+private:
+    PeakCudaLifecycleShard* shard_;
 };
+
+class PeakCudaCaptureTimingGuard {
+public:
+    PeakCudaCaptureTimingGuard() : shard_(NULL) {}
+
+    bool try_enter()
+    {
+        if (shard_ != NULL) {
+            return true;
+        }
+        if (peak_cuda_capture_blocked.load(std::memory_order_acquire)) {
+            return false;
+        }
+        if (peak_cuda_timing_depth != 0) {
+            shard_ = &peak_cuda_timing_shards[
+                peak_cuda_timing_shard_index];
+            ++peak_cuda_timing_depth;
+            return true;
+        }
+        if (peak_cuda_timing_shard_index == kPeakCudaTimingShardCount) {
+            unsigned int ticket = peak_cuda_next_timing_shard.fetch_add(
+                1, std::memory_order_relaxed);
+            peak_cuda_timing_shard_exclusive =
+                ticket < kPeakCudaTimingExclusiveShardCount;
+            peak_cuda_timing_shard_index =
+                peak_cuda_timing_shard_exclusive
+                    ? ticket
+                    : kPeakCudaTimingExclusiveShardCount +
+                        ((ticket - kPeakCudaTimingExclusiveShardCount) %
+                         (kPeakCudaTimingShardCount -
+                          kPeakCudaTimingExclusiveShardCount));
+        }
+        shard_ = &peak_cuda_timing_shards[peak_cuda_timing_shard_index];
+        if (peak_cuda_timing_shard_exclusive) {
+            shard_->active.store(1, std::memory_order_seq_cst);
+        } else {
+            shard_->active.fetch_add(1, std::memory_order_seq_cst);
+        }
+        peak_cuda_timing_depth = 1;
+        if (peak_cuda_capture_blocked.load(std::memory_order_seq_cst)) {
+            release_reader();
+            return false;
+        }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (peak_cuda_test_pause_cuda_section_flag.load(
+                std::memory_order_acquire)) {
+            peak_cuda_test_cuda_sections_waiting_count.fetch_add(
+                1, std::memory_order_release);
+            while (peak_cuda_test_pause_cuda_section_flag.load(
+                       std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            peak_cuda_test_cuda_sections_waiting_count.fetch_sub(
+                1, std::memory_order_release);
+        }
+#endif
+        return true;
+    }
+
+    void leave()
+    {
+        if (shard_ == NULL) {
+            return;
+        }
+        release_reader();
+    }
+
+    ~PeakCudaCaptureTimingGuard()
+    {
+        leave();
+    }
+
+private:
+    void release_reader()
+    {
+        PeakCudaTimingShard* shard = shard_;
+        shard_ = NULL;
+        if (--peak_cuda_timing_depth != 0) {
+            return;
+        }
+        gboolean last_reader;
+        if (peak_cuda_timing_shard_exclusive) {
+            shard->active.store(0, std::memory_order_seq_cst);
+            last_reader = TRUE;
+        } else {
+            last_reader = shard->active.fetch_sub(
+                1, std::memory_order_seq_cst) == 1;
+        }
+        if (last_reader && peak_cuda_capture_blocked.load(
+                               std::memory_order_acquire)) {
+            pthread_mutex_lock(&peak_cuda_capture_mutex);
+            pthread_cond_broadcast(&peak_cuda_capture_cond);
+            pthread_mutex_unlock(&peak_cuda_capture_mutex);
+        }
+    }
+
+    PeakCudaTimingShard* shard_;
+};
+
+static gboolean
+peak_cuda_timing_sections_active()
+{
+    for (PeakCudaTimingShard& shard : peak_cuda_timing_shards) {
+        if (shard.active.load(std::memory_order_seq_cst) != 0) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+static gboolean
+peak_cuda_wait_for_capture_timing_section(
+    PeakCudaCaptureTimingGuard* guard)
+{
+    while (guard != NULL &&
+           peak_cuda_harvester_running.load(std::memory_order_acquire) &&
+           !peak_cuda_capture_tracking_terminal.load(
+               std::memory_order_acquire)) {
+        if (guard->try_enter()) {
+            return TRUE;
+        }
+        struct timespec retry = {0, kPeakCudaHarvestRetryNs};
+        (void)nanosleep(&retry, NULL);
+    }
+    return FALSE;
+}
+
+static gboolean
+peak_cuda_capture_register_locked(CUcontext context, CUstream stream)
+{
+    PeakCudaActiveCapture* free_capture = NULL;
+    for (PeakCudaActiveCapture& capture : peak_cuda_active_captures) {
+        if (capture.count != 0 && capture.context == context &&
+            capture.stream == stream) {
+            ++capture.count;
+            return TRUE;
+        }
+        if (capture.count == 0 && free_capture == NULL) {
+            free_capture = &capture;
+        }
+    }
+    if (free_capture == NULL) {
+        peak_cuda_capture_tracking_terminal.store(
+            true, std::memory_order_release);
+        peak_cuda_profiler_state.record_capture_query_failure();
+        peak_log_warn(
+            "[peak] CUDA capture registry capacity exceeded; CUDA timing remains disabled\n");
+        return FALSE;
+    }
+    free_capture->context = context;
+    free_capture->stream = stream;
+    free_capture->count = 1;
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_capture_remove_locked(CUcontext context, CUstream stream)
+{
+    for (PeakCudaActiveCapture& capture : peak_cuda_active_captures) {
+        if (capture.count != 0 && capture.context == context &&
+            capture.stream == stream) {
+            --capture.count;
+            if (capture.count == 0) {
+                capture = {};
+            }
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+static gboolean
+peak_cuda_capture_any_active_locked()
+{
+    for (const PeakCudaActiveCapture& capture : peak_cuda_active_captures) {
+        if (capture.count != 0) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+static void
+peak_cuda_capture_begin_transition()
+{
+    pthread_mutex_lock(&peak_cuda_capture_mutex);
+    ++peak_cuda_capture_transitions;
+    peak_cuda_capture_blocked.store(true, std::memory_order_seq_cst);
+    while (peak_cuda_timing_sections_active()) {
+        pthread_cond_wait(&peak_cuda_capture_cond, &peak_cuda_capture_mutex);
+    }
+    pthread_mutex_unlock(&peak_cuda_capture_mutex);
+}
+
+static void
+peak_cuda_capture_end_transition_locked()
+{
+    if (peak_cuda_capture_transitions > 0) {
+        --peak_cuda_capture_transitions;
+    }
+    if (peak_cuda_capture_transitions == 0 &&
+        !peak_cuda_capture_any_active_locked() &&
+        !peak_cuda_capture_tracking_terminal.load(
+            std::memory_order_acquire)) {
+        peak_cuda_capture_blocked.store(false, std::memory_order_seq_cst);
+        pthread_cond_broadcast(&peak_cuda_capture_cond);
+    }
+}
+
+static gboolean
+peak_cuda_capture_status(CUstream stream, CUstreamCaptureStatus* status)
+{
+    if (peak_cuda_backend_api.driver_stream_is_capturing == NULL ||
+        status == NULL) {
+        peak_cuda_profiler_state.record_capture_query_unsupported();
+        return FALSE;
+    }
+    CUresult result = peak_cuda_backend_api.driver_stream_is_capturing(
+        stream, status);
+    if (result == CUDA_ERROR_NOT_SUPPORTED) {
+        peak_cuda_profiler_state.record_capture_query_unsupported();
+        return FALSE;
+    }
+    if (result != CUDA_SUCCESS) {
+        peak_cuda_profiler_state.record_capture_query_failure();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+struct PeakCudaCaptureInvocationData {
+    CUstream stream;
+    CUcontext context;
+    CUstreamCaptureStatus before;
+    gboolean before_known;
+    gboolean outermost;
+    PeakCudaLifecycleShard* lifecycle_shard;
+    gboolean teardown_lock_held;
+    gboolean fail_closed_transition;
+};
+
+static void
+peak_cuda_capture_listener_on_enter(GumInvocationContext* context,
+                                    gpointer user_data)
+{
+    const PeakCudaCaptureHookDescriptor* descriptor =
+        static_cast<const PeakCudaCaptureHookDescriptor*>(user_data);
+    PeakCudaCaptureInvocationData* invocation =
+        GUM_IC_GET_INVOCATION_DATA(context,
+                                   PeakCudaCaptureInvocationData);
+
+    *invocation = {};
+    invocation->stream = reinterpret_cast<CUstream>(
+        gum_invocation_context_get_nth_argument(context, 0));
+    invocation->outermost = peak_cuda_capture_wrapper_depth++ == 0;
+    if (!invocation->outermost) {
+        return;
+    }
+
+    invocation->lifecycle_shard = peak_cuda_lifecycle_try_enter();
+    if (invocation->lifecycle_shard == NULL) {
+        /* The application may begin capture after finalization has closed
+         * lifecycle admission but before Gum has physically detached this
+         * listener. Without a tracked edge, retaining CUDA-owned state is the
+         * only safe teardown behavior. */
+        peak_cuda_capture_teardown_mutex.lock();
+        invocation->teardown_lock_held = TRUE;
+        peak_cuda_capture_tracking_terminal.store(
+            true, std::memory_order_release);
+        invocation->fail_closed_transition = TRUE;
+        peak_cuda_capture_begin_transition();
+        return;
+    }
+    peak_cuda_capture_begin_transition();
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (descriptor->operation == PEAK_CUDA_CAPTURE_OPERATION_BEGIN &&
+        peak_cuda_test_pause_capture_begin_flag.load(
+            std::memory_order_acquire)) {
+        peak_cuda_test_capture_begin_waiting_flag.store(
+            true, std::memory_order_release);
+        while (peak_cuda_test_pause_capture_begin_flag.load(
+                   std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        peak_cuda_test_capture_begin_waiting_flag.store(
+            false, std::memory_order_release);
+    }
+#endif
+    invocation->before = CU_STREAM_CAPTURE_STATUS_NONE;
+    invocation->before_known = peak_cuda_capture_status(
+        invocation->stream, &invocation->before);
+    if (peak_cuda_backend_api.ctx_get_current == NULL ||
+        peak_cuda_backend_api.ctx_get_current(&invocation->context) !=
+            CUDA_SUCCESS ||
+        invocation->context == NULL) {
+        invocation->context = NULL;
+        peak_cuda_profiler_state.record_context_query_failure();
+    }
+}
+
+static void
+peak_cuda_capture_listener_on_leave(GumInvocationContext* context,
+                                    gpointer user_data)
+{
+    const PeakCudaCaptureHookDescriptor* descriptor =
+        static_cast<const PeakCudaCaptureHookDescriptor*>(user_data);
+    PeakCudaCaptureInvocationData* invocation =
+        GUM_IC_GET_INVOCATION_DATA(context,
+                                   PeakCudaCaptureInvocationData);
+
+    if (!invocation->outermost) {
+        --peak_cuda_capture_wrapper_depth;
+        return;
+    }
+    if (invocation->lifecycle_shard == NULL) {
+        if (invocation->fail_closed_transition) {
+            pthread_mutex_lock(&peak_cuda_capture_mutex);
+            peak_cuda_capture_end_transition_locked();
+            pthread_mutex_unlock(&peak_cuda_capture_mutex);
+        }
+        if (invocation->teardown_lock_held) {
+            peak_cuda_capture_teardown_mutex.unlock();
+        }
+        --peak_cuda_capture_wrapper_depth;
+        return;
+    }
+
+    CUstreamCaptureStatus after = CU_STREAM_CAPTURE_STATUS_NONE;
+    gboolean after_known = peak_cuda_capture_status(
+        invocation->stream, &after);
+    int result = GPOINTER_TO_INT(
+        gum_invocation_context_get_return_value(context));
+
+    pthread_mutex_lock(&peak_cuda_capture_mutex);
+    gboolean before_active =
+        invocation->before != CU_STREAM_CAPTURE_STATUS_NONE;
+    gboolean after_active =
+        after != CU_STREAM_CAPTURE_STATUS_NONE;
+    if (!invocation->before_known || !after_known) {
+        peak_cuda_capture_tracking_terminal.store(
+            true, std::memory_order_release);
+    } else {
+        if (!before_active && after_active) {
+            if (invocation->context == NULL ||
+                !peak_cuda_capture_register_locked(
+                    invocation->context, invocation->stream)) {
+                peak_cuda_capture_tracking_terminal.store(
+                    true, std::memory_order_release);
+            }
+        } else if (before_active && !after_active) {
+            if (invocation->context == NULL ||
+                !peak_cuda_capture_remove_locked(invocation->context,
+                                                 invocation->stream)) {
+                peak_cuda_capture_tracking_terminal.store(
+                    true, std::memory_order_release);
+            }
+        }
+
+        gboolean expected_edge =
+            descriptor->operation == PEAK_CUDA_CAPTURE_OPERATION_BEGIN
+                ? (!before_active && after_active)
+                : (before_active && !after_active);
+        if (result == 0 && !expected_edge) {
+            peak_cuda_capture_tracking_terminal.store(
+                true, std::memory_order_release);
+        }
+    }
+    peak_cuda_capture_end_transition_locked();
+    pthread_mutex_unlock(&peak_cuda_capture_mutex);
+
+    --peak_cuda_capture_wrapper_depth;
+    peak_cuda_lifecycle_leave(invocation->lifecycle_shard);
+}
+
+static gboolean
+peak_cuda_capture_entry_point_is_covered(
+    gpointer entry, PeakCudaCaptureOperation operation)
+{
+    if (entry == NULL) {
+        return FALSE;
+    }
+    for (size_t index = 0; index < PEAK_CUDA_CAPTURE_HOOK_COUNT;
+         ++index) {
+        if (peak_cuda_capture_descriptors[index].operation == operation &&
+            reinterpret_cast<gpointer>(peak_cuda_capture_hooks[index]) ==
+                entry) {
+            return TRUE;
+        }
+    }
+    for (size_t index = 0;
+         index < peak_cuda_direct_capture_hook_count;
+         ++index) {
+        if (peak_cuda_direct_capture_descriptors[index].operation ==
+                operation &&
+            peak_cuda_direct_capture_hooks[index] == entry) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
 
 gboolean str_equal_function(gconstpointer a, gconstpointer b) {
     return g_strcmp0((const gchar *)a, (const gchar *)b) == 0;
@@ -200,18 +1019,37 @@ gboolean str_equal_function(gconstpointer a, gconstpointer b) {
 
 char* cu_demangle(char* mangled_name);
 
-static PeakCudaKernelIdentity
-peak_cuda_identify_kernel(gpointer identity, gboolean driver_function)
+static const PeakCudaKernelIdentity*
+peak_cuda_identify_kernel(gpointer identity, gboolean driver_function,
+                          CUcontext context = NULL)
 {
-    PeakCudaKernelIdentity cached;
+    const std::uint64_t epoch = peak_cuda_identity_epoch.load(
+        std::memory_order_acquire);
+    const std::uintptr_t identity_value =
+        reinterpret_cast<std::uintptr_t>(identity);
+    const std::uintptr_t context_value = driver_function
+        ? reinterpret_cast<std::uintptr_t>(context)
+        : 0;
+    if (peak_cuda_thread_identity.valid &&
+        peak_cuda_thread_identity.epoch == epoch &&
+        peak_cuda_thread_identity.identity == identity_value &&
+        peak_cuda_thread_identity.context == context_value &&
+        peak_cuda_thread_identity.driver_function == driver_function) {
+        return &peak_cuda_thread_identity.value;
+    }
     std::vector<std::string> targets;
     gchar* resolved_name = NULL;
     char* demangled_name = NULL;
     char* target_name = NULL;
 
     if (peak_cuda_profiler_state.cached_identity(
-            reinterpret_cast<std::uintptr_t>(identity), driver_function, &cached)) {
-        return cached;
+            identity_value, driver_function,
+            &peak_cuda_thread_identity.value, context_value)) {
+        peak_cuda_thread_identity = {
+            epoch, identity_value, context_value, driver_function, TRUE,
+            peak_cuda_thread_identity.value,
+        };
+        return &peak_cuda_thread_identity.value;
     }
     for (size_t index = 0; index < peak_gpu_hook_address_count; ++index) {
         if (peak_gpu_hook_strings[index] != NULL) {
@@ -226,31 +1064,82 @@ peak_cuda_identify_kernel(gpointer identity, gboolean driver_function)
     }
     if (resolved_name != NULL) {
         demangled_name = cu_demangle(resolved_name);
-        target_name = extract_function_name(demangled_name);
+        target_name = extract_function_name(
+            demangled_name != NULL ? demangled_name : resolved_name);
     }
-    PeakCudaKernelIdentity result = peak_cuda_profiler_state.identify(
-        reinterpret_cast<std::uintptr_t>(identity),
+    peak_cuda_thread_identity.value = peak_cuda_profiler_state.identify(
+        identity_value,
         driver_function,
-        demangled_name,
+        demangled_name != NULL ? demangled_name : resolved_name,
         target_name,
         peak_gpu_monitor_all,
-        targets);
+        targets,
+        context_value);
     g_free(resolved_name);
     free(demangled_name);
     free(target_name);
-    return result;
+    peak_cuda_thread_identity.epoch = epoch;
+    peak_cuda_thread_identity.identity = identity_value;
+    peak_cuda_thread_identity.context = context_value;
+    peak_cuda_thread_identity.driver_function = driver_function;
+    peak_cuda_thread_identity.valid = TRUE;
+    return &peak_cuda_thread_identity.value;
+}
+
+static const PeakCudaKernelIdentity*
+peak_cuda_cached_driver_identity(CUfunction function, CUcontext* context)
+{
+    const std::uint64_t epoch = peak_cuda_identity_epoch.load(
+        std::memory_order_acquire);
+    /* CUfunction is a context-owned opaque handle. Reusing the same valid
+     * handle does not change its owning context, so its thread-local identity
+     * can bypass the globally serialized current-context query on repeated
+     * launches. Lifecycle epoch changes invalidate this shortcut before hook
+     * teardown or reattachment. */
+    if (!peak_cuda_thread_identity.valid ||
+        peak_cuda_thread_identity.epoch != epoch ||
+        peak_cuda_thread_identity.identity !=
+            reinterpret_cast<std::uintptr_t>(function) ||
+        !peak_cuda_thread_identity.driver_function) {
+        return NULL;
+    }
+    *context = reinterpret_cast<CUcontext>(
+        peak_cuda_thread_identity.context);
+    return &peak_cuda_thread_identity.value;
 }
 
 char* cu_demangle(char* mangled_name) {
     return mangled_name != NULL ? cxa_demangle(mangled_name) : NULL;
 }
 
-static void update_kernel_map_info(const gchar* kernel_name, gulong total_threads, gulong grid_size, gulong block_size, gdouble elapsed_sec)
+static PeakCudaLaunchDimensions
+peak_cuda_launch_dimensions(unsigned int grid_x, unsigned int grid_y,
+                            unsigned int grid_z, unsigned int block_x,
+                            unsigned int block_y, unsigned int block_z)
 {
-    gchar* key = g_strdup(kernel_name);
-    KernelDimInfo* dim_info = (KernelDimInfo*) g_hash_table_lookup(cuda_kernel_local_dim_mapping, key);
+    PeakCudaLaunchDimensions dimensions =
+        peak_cuda_compute_launch_dimensions(
+            grid_x, grid_y, grid_z, block_x, block_y, block_z);
+    if (dimensions.overflow) {
+        peak_cuda_profiler_state.record_dimension_overflow();
+    }
+    return dimensions;
+}
+
+static void update_kernel_map_info(const gchar* kernel_name,
+                                   std::uint64_t total_threads,
+                                   std::uint64_t grid_size,
+                                   std::uint64_t block_size,
+                                   gdouble elapsed_sec)
+{
+    KernelDimInfo* dim_info = (KernelDimInfo*) g_hash_table_lookup(
+        cuda_kernel_local_dim_mapping, kernel_name);
 
     if (!dim_info) {
+        gchar* key = g_strdup(kernel_name);
+        if (key == NULL) {
+            return;
+        }
         dim_info = g_new(KernelDimInfo, 1);
         dim_info->total_gpu_threads = total_threads;
         dim_info->total_kernel_call_cnt = 1;
@@ -267,11 +1156,15 @@ static void update_kernel_map_info(const gchar* kernel_name, gulong total_thread
         dim_info->min_time = elapsed_sec;
         g_hash_table_insert(cuda_kernel_local_dim_mapping, key, dim_info);
     } else {
-        g_free(key);
-        dim_info->total_gpu_threads += total_threads;
-        dim_info->total_kernel_call_cnt++;
-        dim_info->total_block_size += block_size;
-        dim_info->total_grid_size += grid_size;
+        bool overflow = false;
+        dim_info->total_gpu_threads = peak_cuda_saturating_add_u64(
+            dim_info->total_gpu_threads, total_threads, &overflow);
+        dim_info->total_kernel_call_cnt = peak_cuda_saturating_add_u64(
+            dim_info->total_kernel_call_cnt, 1, &overflow);
+        dim_info->total_block_size = peak_cuda_saturating_add_u64(
+            dim_info->total_block_size, block_size, &overflow);
+        dim_info->total_grid_size = peak_cuda_saturating_add_u64(
+            dim_info->total_grid_size, grid_size, &overflow);
         dim_info->total_time += elapsed_sec;
         dim_info->max_gpu_threads = std::max(dim_info->max_gpu_threads, total_threads);
         dim_info->min_gpu_threads = std::min(dim_info->min_gpu_threads, total_threads);
@@ -281,10 +1174,17 @@ static void update_kernel_map_info(const gchar* kernel_name, gulong total_thread
         dim_info->min_grid_size = std::min(dim_info->min_grid_size, grid_size);
         dim_info->max_time = std::max(dim_info->max_time, elapsed_sec);
         dim_info->min_time = std::min(dim_info->min_time, elapsed_sec);
+        if (overflow) {
+            peak_cuda_profiler_state.record_dimension_overflow();
+        }
     }
 }
 
-void insert_cuda_mapping_record(gchar* kernel_name, gulong total_threads, gulong grid_size, gulong block_size, gdouble elapsed_sec)
+void insert_cuda_mapping_record(const gchar* kernel_name,
+                                std::uint64_t total_threads,
+                                std::uint64_t grid_size,
+                                std::uint64_t block_size,
+                                gdouble elapsed_sec)
 {
     g_mutex_lock(&cuda_kernel_local_dim_mapping_mutex);
     update_kernel_map_info(kernel_name != NULL ? kernel_name : "<unknown>",
@@ -292,22 +1192,46 @@ void insert_cuda_mapping_record(gchar* kernel_name, gulong total_threads, gulong
     g_mutex_unlock(&cuda_kernel_local_dim_mapping_mutex);
 }
 
-void insert_cuda_graph_record(CUgraphExec_st* graph, gdouble elapsed_sec)
+void insert_cuda_graph_record(std::uintptr_t context, CUgraphExec graph,
+                              CUdevice device, gdouble elapsed_sec)
 {
+    PeakCudaGraphKey lookup = {context, graph};
     g_mutex_lock(&cuda_graph_local_mapping_mutex);
-    GraphRecordInfo* graph_info = (GraphRecordInfo*) g_hash_table_lookup(cuda_graph_local_mapping, graph);
+    GraphRecordInfo* graph_info = (GraphRecordInfo*)
+        g_hash_table_lookup(cuda_graph_local_mapping, &lookup);
     if (!graph_info) {
-        graph_info = g_new(GraphRecordInfo, 1);
+        if (g_hash_table_size(cuda_graph_local_mapping) >=
+            peak_cuda_graph_identity_capacity) {
+            peak_cuda_profiler_state.record_identity_full();
+            g_mutex_unlock(&cuda_graph_local_mapping_mutex);
+            return;
+        }
+        PeakCudaGraphKey* key = g_try_new(PeakCudaGraphKey, 1);
+        graph_info = g_try_new(GraphRecordInfo, 1);
+        if (key == NULL || graph_info == NULL) {
+            g_free(key);
+            g_free(graph_info);
+            peak_cuda_profiler_state.record_identity_full();
+            g_mutex_unlock(&cuda_graph_local_mapping_mutex);
+            return;
+        }
+        *key = lookup;
         graph_info->total_graph_call_cnt = 1;
         graph_info->total_time = elapsed_sec;
         graph_info->max_time = elapsed_sec;
         graph_info->min_time = elapsed_sec;
-        g_hash_table_insert(cuda_graph_local_mapping, graph, graph_info);
+        graph_info->device = device;
+        g_hash_table_insert(cuda_graph_local_mapping, key, graph_info);
     } else {
-        graph_info->total_graph_call_cnt++;
+        bool overflow = false;
+        graph_info->total_graph_call_cnt = peak_cuda_saturating_add_u64(
+            graph_info->total_graph_call_cnt, 1, &overflow);
         graph_info->total_time += elapsed_sec;
         graph_info->max_time = std::max(graph_info->max_time, elapsed_sec);
         graph_info->min_time = std::min(graph_info->min_time, elapsed_sec);
+        if (overflow) {
+            peak_cuda_profiler_state.record_dimension_overflow();
+        }
     }
     g_mutex_unlock(&cuda_graph_local_mapping_mutex);
 }
@@ -323,219 +1247,852 @@ peak_cuda_parse_event_pool_capacity()
     return (size_t)peak_parse_env_unsigned(&schema);
 }
 
-static void
-peak_cuda_destroy_event_pool()
+static unsigned long long
+peak_cuda_parse_finalization_timeout_ms()
 {
-    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
-    for (PeakCudaEventSlot& slot : peak_cuda_event_pool) {
-        if (slot.start != NULL) {
-            cudaEventDestroy(slot.start);
-        }
-        if (slot.end != NULL) {
-            cudaEventDestroy(slot.end);
-        }
-    }
-    peak_cuda_event_pool.clear();
-    peak_cuda_free_event_slots.clear();
+    static const PeakEnvUnsignedSchema schema = {
+        "PEAK_CUDA_FINALIZATION_TIMEOUT_MS", "milliseconds", 1000, 1,
+        60000, false, &peak_cuda_finalization_timeout_warning_emitted, false,
+    };
+
+    return peak_parse_env_unsigned(&schema);
 }
 
-static gboolean
-peak_cuda_acquire_event_pair(cudaEvent_t** start_event, cudaEvent_t** end_event)
+static std::uint64_t
+peak_cuda_monotonic_ns()
 {
-    if (start_event == NULL || end_event == NULL ||
-        !peak_cuda_accepting_events.load(std::memory_order_acquire) ||
-        !peak_cuda_profiler_state.acquire_slot()) {
-        return FALSE;
+    struct timespec now = {};
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return 0;
     }
+    return (std::uint64_t)now.tv_sec * 1000000000ULL +
+           (std::uint64_t)now.tv_nsec;
+}
 
-    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
-    if (peak_cuda_free_event_slots.empty()) {
-        peak_cuda_profiler_state.release_slot();
+static struct timespec
+peak_cuda_realtime_after(long nanoseconds)
+{
+    struct timespec deadline = {};
+    (void)clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_nsec += nanoseconds;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec += deadline.tv_nsec / 1000000000L;
+        deadline.tv_nsec %= 1000000000L;
+    }
+    return deadline;
+}
+
+static void
+peak_cuda_resolve_backend_api()
+{
+    if (peak_cuda_backend_api.driver_handle == NULL) {
+        peak_cuda_backend_api.driver_handle =
+            dlopen("libcuda.so.1", RTLD_LAZY | RTLD_LOCAL);
+    }
+    void* driver = peak_cuda_backend_api.driver_handle;
+    peak_cuda_backend_api.ctx_get_current = driver != NULL
+        ? reinterpret_cast<PeakCuCtxGetCurrentFn>(
+              dlsym(driver, "cuCtxGetCurrent"))
+        : NULL;
+    peak_cuda_backend_api.ctx_get_device = driver != NULL
+        ? reinterpret_cast<PeakCuCtxGetDeviceFn>(
+              dlsym(driver, "cuCtxGetDevice"))
+        : NULL;
+    peak_cuda_backend_api.ctx_push_current = driver != NULL
+        ? reinterpret_cast<PeakCuCtxPushCurrentFn>(
+              dlsym(driver, "cuCtxPushCurrent_v2"))
+        : NULL;
+    peak_cuda_backend_api.ctx_pop_current = driver != NULL
+        ? reinterpret_cast<PeakCuCtxPopCurrentFn>(
+              dlsym(driver, "cuCtxPopCurrent_v2"))
+        : NULL;
+    peak_cuda_backend_api.event_record = driver != NULL
+        ? reinterpret_cast<PeakCuEventRecordFn>(
+              dlsym(driver, "cuEventRecord"))
+        : NULL;
+    peak_cuda_backend_api.driver_stream_is_capturing = driver != NULL
+        ? reinterpret_cast<PeakCuStreamIsCapturingFn>(
+              dlsym(driver, "cuStreamIsCapturing"))
+        : NULL;
+    peak_cuda_backend_api.driver_thread_exchange_stream_capture_mode =
+        driver != NULL
+            ? reinterpret_cast<PeakCuThreadExchangeStreamCaptureModeFn>(
+                  dlsym(driver, "cuThreadExchangeStreamCaptureMode"))
+            : NULL;
+    peak_cuda_func_get_name = driver != NULL
+        ? reinterpret_cast<PeakCudaFuncGetNameFn>(
+              dlsym(driver, "cuFuncGetName"))
+        : NULL;
+}
+
+struct PeakCudaContextActivation {
+    CUcontext target;
+    gboolean pushed;
+};
+
+static gboolean
+peak_cuda_activate_context(CUcontext target,
+                           PeakCudaContextActivation* activation)
+{
+    CUcontext current = NULL;
+    if (activation == NULL || target == NULL ||
+        peak_cuda_backend_api.ctx_get_current == NULL) {
+        peak_cuda_profiler_state.record_context_switch_failure();
         return FALSE;
     }
-    PeakCudaEventSlot& slot =
-        peak_cuda_event_pool[peak_cuda_free_event_slots.back()];
-    peak_cuda_free_event_slots.pop_back();
-    if (!slot.initialized) {
-        if (cudaEventCreate(&slot.start) != cudaSuccess ||
-            cudaEventCreate(&slot.end) != cudaSuccess) {
-            if (slot.start != NULL) {
-                cudaEventDestroy(slot.start);
-                slot.start = NULL;
-            }
-            if (slot.end != NULL) {
-                cudaEventDestroy(slot.end);
-                slot.end = NULL;
-            }
-            peak_cuda_free_event_slots.push_back(
-                (size_t)(&slot - peak_cuda_event_pool.data()));
-            peak_cuda_profiler_state.record_event_create_failure();
-            peak_cuda_profiler_state.release_slot();
-            return FALSE;
-        }
-        slot.initialized = TRUE;
+    if (peak_cuda_backend_api.ctx_get_current(&current) != CUDA_SUCCESS) {
+        peak_cuda_profiler_state.record_context_query_failure();
+        return FALSE;
     }
-    slot.leased = TRUE;
-    *start_event = &slot.start;
-    *end_event = &slot.end;
+    activation->target = target;
+    activation->pushed = FALSE;
+    if (current == target) {
+        return TRUE;
+    }
+    if (peak_cuda_backend_api.ctx_push_current == NULL ||
+        peak_cuda_backend_api.ctx_pop_current == NULL ||
+        peak_cuda_backend_api.ctx_push_current(target) != CUDA_SUCCESS) {
+        peak_cuda_profiler_state.record_context_switch_failure();
+        return FALSE;
+    }
+    activation->pushed = TRUE;
     return TRUE;
 }
 
 static gboolean
-peak_cuda_record_event(cudaEvent_t* event, cudaStream_t stream)
+peak_cuda_restore_context(PeakCudaContextActivation* activation)
 {
-    if (event == NULL || *event == NULL ||
-        cudaEventRecord(*event, stream) != cudaSuccess) {
+    CUcontext popped = NULL;
+    if (activation == NULL || !activation->pushed) {
+        return TRUE;
+    }
+    activation->pushed = FALSE;
+    if (peak_cuda_backend_api.ctx_pop_current == NULL ||
+        peak_cuda_backend_api.ctx_pop_current(&popped) != CUDA_SUCCESS ||
+        popped != activation->target) {
+        peak_cuda_profiler_state.record_context_restore_failure();
+        peak_cuda_accepting_events.store(false, std::memory_order_seq_cst);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_destroy_slot_events_current(PeakCudaEventSlot* slot)
+{
+    gboolean destroyed = TRUE;
+    if (slot == NULL) {
+        return TRUE;
+    }
+    if (slot->start != NULL) {
+        if (cudaEventDestroy(slot->start) == cudaSuccess) {
+            slot->start = NULL;
+        } else {
+            destroyed = FALSE;
+        }
+    }
+    if (slot->end != NULL) {
+        if (cudaEventDestroy(slot->end) == cudaSuccess) {
+            slot->end = NULL;
+        } else {
+            destroyed = FALSE;
+        }
+    }
+    if (destroyed) {
+        slot->initialized = FALSE;
+    }
+    return destroyed;
+}
+
+static gboolean
+peak_cuda_destroy_event_pool()
+{
+    std::unique_lock<std::mutex> capture_teardown_lock(
+        peak_cuda_capture_teardown_mutex, std::try_to_lock);
+    if (!capture_teardown_lock.owns_lock()) {
+        peak_log_warn(
+            "[peak] retaining CUDA event state while a stream-capture call crosses teardown\n");
+        return FALSE;
+    }
+    pthread_mutex_lock(&peak_cuda_capture_mutex);
+    gboolean capture_unsafe = peak_cuda_capture_transitions != 0 ||
+        peak_cuda_capture_any_active_locked() ||
+        peak_cuda_capture_tracking_terminal.load(
+            std::memory_order_acquire);
+    pthread_mutex_unlock(&peak_cuda_capture_mutex);
+    if (capture_unsafe) {
+        peak_log_warn(
+            "[peak] retaining CUDA event state because stream-capture quiescence is not proven\n");
+        return FALSE;
+    }
+
+    gboolean retained = FALSE;
+    for (PeakCudaEventSlot& slot : peak_cuda_event_pool) {
+        if (slot.start == NULL && slot.end == NULL) {
+            continue;
+        }
+        PeakCudaContextActivation activation = {};
+        if (!peak_cuda_activate_context(slot.owner_context, &activation)) {
+            retained = TRUE;
+            continue;
+        }
+        if (!peak_cuda_destroy_slot_events_current(&slot)) {
+            retained = TRUE;
+        }
+        if (!peak_cuda_restore_context(&activation)) {
+            retained = TRUE;
+        }
+    }
+    if (retained) {
+        peak_log_warn("[peak] retaining CUDA event state that could not be destroyed in its owning context\n");
+        return FALSE;
+    }
+    peak_cuda_event_pool.clear();
+    peak_cuda_pending_queue.reset(0);
+    peak_cuda_slot_allocator.reset(0);
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_discard_lease_current(const PeakCudaSlotLease& lease)
+{
+    if (lease.index >= peak_cuda_event_pool.size()) {
+        return FALSE;
+    }
+    PeakCudaEventSlot& slot = peak_cuda_event_pool[lease.index];
+    if (!peak_cuda_destroy_slot_events_current(&slot)) {
+        return FALSE;
+    }
+    slot.record.kind = PEAK_CUDA_LAUNCH_RECORD_NONE;
+    return peak_cuda_slot_allocator.release(lease) ? TRUE : FALSE;
+}
+
+static gboolean
+peak_cuda_pending_push(const PeakCudaSlotLease& lease)
+{
+    bool shard_was_empty = false;
+    if (!peak_cuda_pending_queue.push(lease, &shard_was_empty)) {
+        return FALSE;
+    }
+    /* The first producer shard provides low-latency wakeups; all other shards
+     * rely on the same bounded 1-ms retry and never touch shared wake state.
+     * If the helper is waiting, the mutex pairs the predicate update with
+     * pthread_cond_timedwait's atomic unlock-and-wait, preventing a lost wake
+     * without serializing launch workers. */
+    bool helper_waiting = true;
+    if (shard_was_empty && lease.shard == kPeakCudaWakeShard &&
+        peak_cuda_harvester_waiting.compare_exchange_strong(
+            helper_waiting, false, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+        pthread_mutex_lock(&peak_cuda_harvester_mutex);
+        (void)pthread_cond_signal(&peak_cuda_harvester_cond);
+        pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+    }
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_pending_pop(PeakCudaSlotLease* lease)
+{
+    return peak_cuda_pending_queue.pop(lease) ? TRUE : FALSE;
+}
+
+static void
+peak_cuda_complete_record(PeakCudaEventSlot* slot, float milliseconds)
+{
+    if (slot->record.result == cudaSuccess) {
+        if (slot->record.kind == PEAK_CUDA_LAUNCH_RECORD_KERNEL) {
+            insert_cuda_mapping_record(slot->record.kernel_name,
+                                       slot->record.total_threads,
+                                       slot->record.grid_size,
+                                       slot->record.block_size,
+                                       milliseconds / 1000.0);
+        } else if (slot->record.kind == PEAK_CUDA_LAUNCH_RECORD_GRAPH) {
+            insert_cuda_graph_record(slot->lease.context,
+                                     slot->record.graph,
+                                     slot->owner_device,
+                                     milliseconds / 1000.0);
+        }
+    }
+    peak_cuda_profiler_state.record_launch_completed();
+}
+
+enum PeakCudaHarvestOutcome {
+    PEAK_CUDA_HARVEST_RETAIN = 0,
+    PEAK_CUDA_HARVEST_RETRY,
+    PEAK_CUDA_HARVEST_RELEASE,
+};
+
+static PeakCudaHarvestOutcome
+peak_cuda_harvest_one_current(const PeakCudaSlotLease& lease)
+{
+    if (lease.index >= peak_cuda_event_pool.size()) {
+        return PEAK_CUDA_HARVEST_RETAIN;
+    }
+    if (!peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+        return PEAK_CUDA_HARVEST_RETAIN;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (peak_cuda_test_force_incomplete.load(std::memory_order_relaxed)) {
+        return PEAK_CUDA_HARVEST_RETRY;
+    }
+#endif
+    PeakCudaCaptureTimingGuard capture_guard;
+    if (!capture_guard.try_enter()) {
+        return PEAK_CUDA_HARVEST_RETRY;
+    }
+    PeakCudaEventSlot& slot = peak_cuda_event_pool[lease.index];
+
+    cudaError_t query;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (peak_cuda_test_force_query_error.exchange(
+            false, std::memory_order_relaxed)) {
+        query = cudaErrorInvalidResourceHandle;
+    } else
+#endif
+    {
+        query = cudaEventQuery(slot.end);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        peak_cuda_test_harvester_queries.fetch_add(
+            1, std::memory_order_relaxed);
+#endif
+    }
+    if (!peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+        return PEAK_CUDA_HARVEST_RETAIN;
+    }
+    if (query == cudaErrorNotReady) {
+        return PEAK_CUDA_HARVEST_RETRY;
+    }
+    if (query != cudaSuccess) {
+        peak_cuda_profiler_state.record_event_query_failure();
+        gboolean destroyed = peak_cuda_destroy_slot_events_current(&slot);
+        if (destroyed) {
+            slot.record.kind = PEAK_CUDA_LAUNCH_RECORD_NONE;
+            return PEAK_CUDA_HARVEST_RELEASE;
+        }
+        return PEAK_CUDA_HARVEST_RETAIN;
+    }
+
+    if (slot.start != NULL && slot.end != NULL) {
+        float ms = 0.0f;
+        if (cudaEventElapsedTime(&ms, slot.start, slot.end) != cudaSuccess) {
+            peak_cuda_profiler_state.record_elapsed_time_failure();
+        } else {
+            peak_cuda_complete_record(&slot, ms);
+        }
+    }
+
+    slot.record.kind = PEAK_CUDA_LAUNCH_RECORD_NONE;
+    return PEAK_CUDA_HARVEST_RELEASE;
+}
+
+static gboolean
+peak_cuda_harvest_pass()
+{
+    std::uint64_t started_ns = peak_cuda_monotonic_ns();
+    PeakCudaContextActivation activation = {};
+    CUcontext batch_context = NULL;
+    PeakCudaSlotLease leases[kPeakCudaHarvestRecordBudget] = {};
+    PeakCudaHarvestOutcome outcomes[kPeakCudaHarvestRecordBudget] = {};
+    size_t outcome_count = 0;
+
+    for (size_t checked = 0;
+         checked < kPeakCudaHarvestRecordBudget; ++checked) {
+        if (!peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+            break;
+        }
+        PeakCudaSlotLease lease = {};
+        if (!peak_cuda_pending_pop(&lease)) {
+            break;
+        }
+        CUcontext lease_context =
+            reinterpret_cast<CUcontext>(lease.context);
+        if (batch_context == NULL) {
+            if (!peak_cuda_activate_context(lease_context, &activation)) {
+                break;
+            }
+            batch_context = lease_context;
+        } else if (lease_context != batch_context) {
+            /* Keep one owning context current for the whole bounded pass.
+             * A later pass will service a different context without adding
+             * push/pop traffic to every completed launch. */
+            (void)peak_cuda_pending_queue.requeue_local(lease);
+            break;
+        }
+        leases[outcome_count] = lease;
+        outcomes[outcome_count] = peak_cuda_harvest_one_current(lease);
+        ++outcome_count;
+        std::uint64_t now_ns = peak_cuda_monotonic_ns();
+        if (started_ns != 0 && now_ns != 0 &&
+            now_ns - started_ns >= kPeakCudaHarvestTimeBudgetNs) {
+            break;
+        }
+    }
+
+    gboolean restored = peak_cuda_restore_context(&activation);
+    if (restored) {
+        for (size_t index = 0; index < outcome_count; ++index) {
+            if (outcomes[index] == PEAK_CUDA_HARVEST_RELEASE) {
+                (void)peak_cuda_slot_allocator.release(leases[index]);
+            } else if (outcomes[index] == PEAK_CUDA_HARVEST_RETRY &&
+                       peak_cuda_harvester_running.load(
+                           std::memory_order_acquire)) {
+                /* Keep retries on the consumer-local list. The producer head
+                 * remains empty, so a later application submission can wake
+                 * the bounded retry wait with one shard transition. */
+                (void)peak_cuda_pending_queue.requeue_local(leases[index]);
+            }
+        }
+    }
+    return TRUE;
+}
+
+static void
+peak_cuda_pin_harvester_to_last_allowed_cpu()
+{
+#if defined(__linux__)
+    cpu_set_t allowed;
+    if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) {
+        return;
+    }
+    for (int cpu = CPU_SETSIZE - 1; cpu >= 0; --cpu) {
+        if (!CPU_ISSET(cpu, &allowed)) {
+            continue;
+        }
+        cpu_set_t selected;
+        CPU_ZERO(&selected);
+        CPU_SET(cpu, &selected);
+        (void)pthread_setaffinity_np(
+            pthread_self(), sizeof(selected), &selected);
+        return;
+    }
+#endif
+}
+
+static void*
+peak_cuda_harvester_main(void*)
+{
+    /* Keep the helper off the low-numbered CPUs most launch-worker pools
+     * select first. This changes only the helper's affinity and remains a
+     * best-effort hint when the application uses the complete allowed set. */
+    peak_cuda_pin_harvester_to_last_allowed_cpu();
+    peak_general_listener_exclude_current_thread();
+    peak_general_listener_fast_ignore_current_thread();
+
+    pthread_mutex_lock(&peak_cuda_harvester_mutex);
+    while (peak_cuda_harvester_running.load(std::memory_order_acquire) &&
+           peak_cuda_harvester_initialization_allowed &&
+           !peak_cuda_harvester_initialization_requested) {
+        pthread_cond_wait(&peak_cuda_harvester_cond,
+                          &peak_cuda_harvester_mutex);
+    }
+    gboolean initialize_capture_mode =
+        peak_cuda_harvester_running.load(std::memory_order_acquire) &&
+        peak_cuda_harvester_initialization_allowed;
+    if (initialize_capture_mode) {
+        peak_cuda_harvester_initialization_inflight.store(
+            true, std::memory_order_release);
+    }
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+    if (!initialize_capture_mode) {
+        peak_general_listener_fast_unignore_current_thread();
+        return NULL;
+    }
+
+    cudaError_t capture_mode_result = cudaSuccess;
+    CUresult driver_capture_mode_result = CUDA_SUCCESS;
+    PeakCudaCaptureTimingGuard capture_guard;
+    gboolean capture_section_ready =
+        peak_cuda_wait_for_capture_timing_section(&capture_guard);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    gboolean force_capture_mode_failure =
+        g_strcmp0(g_getenv("PEAK_TEST_FAIL_CUDA_HARVESTER_CAPTURE_MODE"),
+                  "1") == 0;
+#endif
+    if (!capture_section_ready) {
+        capture_mode_result = cudaErrorUnknown;
+        driver_capture_mode_result = CUDA_ERROR_UNKNOWN;
+    }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    else if (force_capture_mode_failure) {
+        capture_mode_result = cudaErrorUnknown;
+        driver_capture_mode_result = CUDA_ERROR_UNKNOWN;
+    }
+#endif
+    else
+    {
+        cudaStreamCaptureMode runtime_mode = cudaStreamCaptureModeRelaxed;
+        capture_mode_result =
+            cudaThreadExchangeStreamCaptureMode(&runtime_mode);
+        if (peak_cuda_backend_api
+                .driver_thread_exchange_stream_capture_mode == NULL) {
+            driver_capture_mode_result = CUDA_ERROR_NOT_SUPPORTED;
+        } else {
+            CUstreamCaptureMode driver_mode =
+                CU_STREAM_CAPTURE_MODE_RELAXED;
+            driver_capture_mode_result = peak_cuda_backend_api
+                .driver_thread_exchange_stream_capture_mode(&driver_mode);
+        }
+    }
+    capture_guard.leave();
+    gboolean capture_api_ready =
+        capture_mode_result == cudaSuccess &&
+        driver_capture_mode_result == CUDA_SUCCESS;
+
+    pthread_mutex_lock(&peak_cuda_harvester_mutex);
+    peak_cuda_harvester_initialization_inflight.store(
+        false, std::memory_order_release);
+    gboolean capture_mode_ready =
+        capture_api_ready &&
+        peak_cuda_harvester_running.load(std::memory_order_acquire) &&
+        peak_cuda_harvester_initialization_allowed;
+    peak_cuda_harvester_capture_mode_ready = capture_mode_ready;
+    peak_cuda_harvester_initialization_done = TRUE;
+    if (!capture_api_ready) {
+        peak_cuda_harvester_running.store(false, std::memory_order_release);
+        peak_cuda_harvester_initialization_terminal.store(
+            true, std::memory_order_release);
+    }
+    if (capture_mode_ready) {
+        peak_cuda_accepting_events.store(true, std::memory_order_seq_cst);
+    }
+    pthread_cond_broadcast(&peak_cuda_harvester_cond);
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+
+    if (!capture_mode_ready) {
+        if (!capture_api_ready) {
+            peak_log_warn(
+                "[peak] CUDA event harvester could not enter relaxed stream-capture mode (runtime status %d, Driver status %d); CUDA timing remains disabled\n",
+                (int)capture_mode_result, (int)driver_capture_mode_result);
+        }
+        peak_general_listener_fast_unignore_current_thread();
+        return NULL;
+    }
+
+    for (;;) {
+        (void)peak_cuda_harvest_pass();
+        if (!peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        struct timespec retry = peak_cuda_realtime_after(
+            kPeakCudaHarvestRetryNs);
+        pthread_mutex_lock(&peak_cuda_harvester_mutex);
+        if (peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+            peak_cuda_harvester_waiting.store(true,
+                                               std::memory_order_release);
+            (void)pthread_cond_timedwait(&peak_cuda_harvester_cond,
+                                         &peak_cuda_harvester_mutex,
+                                         &retry);
+            peak_cuda_harvester_waiting.store(false,
+                                               std::memory_order_release);
+        }
+        pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+    }
+    peak_general_listener_fast_unignore_current_thread();
+    return NULL;
+}
+
+static gboolean
+peak_cuda_start_harvester()
+{
+    pthread_mutex_lock(&peak_cuda_harvester_mutex);
+    peak_cuda_harvester_running.store(true, std::memory_order_release);
+    peak_cuda_harvester_waiting.store(false, std::memory_order_relaxed);
+    peak_cuda_harvester_initialization_requested = FALSE;
+    peak_cuda_harvester_initialization_allowed = TRUE;
+    peak_cuda_harvester_initialization_done = FALSE;
+    peak_cuda_harvester_capture_mode_ready = FALSE;
+    peak_cuda_harvester_initialization_inflight.store(
+        false, std::memory_order_release);
+    peak_cuda_harvester_initialization_terminal.store(
+        false, std::memory_order_release);
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+    pthread_listener_mark_next_created_thread_helper();
+    if (pthread_create(&peak_cuda_harvester_thread, NULL,
+                       peak_cuda_harvester_main, NULL) != 0) {
+        pthread_mutex_lock(&peak_cuda_harvester_mutex);
+        peak_cuda_harvester_running.store(false, std::memory_order_release);
+        peak_cuda_harvester_initialization_terminal.store(
+            true, std::memory_order_release);
+        pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+        peak_log_warn("[peak] failed to start CUDA event harvester; CUDA timing remains disabled\n");
+        return FALSE;
+    }
+    peak_cuda_harvester_started.store(true, std::memory_order_release);
+    return TRUE;
+}
+
+static void
+peak_cuda_request_harvester_initialization()
+{
+    if (peak_cuda_harvester_initialization_terminal.load(
+            std::memory_order_acquire) ||
+        !peak_cuda_harvester_started.load(std::memory_order_acquire)) {
+        return;
+    }
+    if (pthread_mutex_trylock(&peak_cuda_harvester_mutex) != 0) {
+        return;
+    }
+    if (peak_cuda_harvester_initialization_allowed &&
+        !peak_cuda_harvester_initialization_done &&
+        peak_cuda_harvester_running.load(std::memory_order_acquire)) {
+        peak_cuda_harvester_initialization_requested = TRUE;
+        pthread_cond_broadcast(&peak_cuda_harvester_cond);
+    }
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+}
+
+static void
+peak_cuda_disable_harvester_initialization()
+{
+    pthread_mutex_lock(&peak_cuda_harvester_mutex);
+    peak_cuda_harvester_initialization_allowed = FALSE;
+    peak_cuda_harvester_initialization_terminal.store(
+        true, std::memory_order_release);
+    peak_cuda_accepting_events.store(false, std::memory_order_seq_cst);
+    if (!peak_cuda_harvester_initialization_done) {
+        peak_cuda_harvester_running.store(false, std::memory_order_release);
+    }
+    pthread_cond_broadcast(&peak_cuda_harvester_cond);
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+}
+
+static void
+peak_cuda_request_harvester_stop()
+{
+    if (!peak_cuda_harvester_started.load(std::memory_order_acquire)) {
+        return;
+    }
+    pthread_mutex_lock(&peak_cuda_harvester_mutex);
+    peak_cuda_harvester_running.store(false, std::memory_order_release);
+    pthread_cond_broadcast(&peak_cuda_harvester_cond);
+    pthread_mutex_unlock(&peak_cuda_harvester_mutex);
+}
+
+static void
+peak_cuda_request_harvester_stop_no_wait()
+{
+    if (!peak_cuda_harvester_started.load(std::memory_order_acquire)) {
+        return;
+    }
+    peak_cuda_harvester_running.store(false, std::memory_order_release);
+    /* Timeout cleanup never joins this helper. A broadcast is safe without
+     * acquiring the ring mutex; a lost wake only leaves process-retained state
+     * for operating-system reclamation. */
+    (void)pthread_cond_broadcast(&peak_cuda_harvester_cond);
+}
+
+static void
+peak_cuda_stop_harvester()
+{
+    if (!peak_cuda_harvester_started.load(std::memory_order_acquire)) {
+        return;
+    }
+    peak_cuda_request_harvester_stop();
+    (void)pthread_join(peak_cuda_harvester_thread, NULL);
+    peak_cuda_harvester_started.store(false, std::memory_order_release);
+}
+
+enum PeakCudaLaunchBackend {
+    PEAK_CUDA_LAUNCH_BACKEND_RUNTIME = 0,
+    PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+};
+
+struct PeakCudaTimingLease {
+    PeakCudaSlotLease lease;
+    cudaEvent_t start;
+    cudaEvent_t end;
+};
+
+static gboolean
+peak_cuda_current_context(CUcontext* context)
+{
+    if (context == NULL || peak_cuda_backend_api.ctx_get_current == NULL ||
+        peak_cuda_backend_api.ctx_get_current(context) != CUDA_SUCCESS ||
+        *context == NULL) {
+        peak_cuda_profiler_state.record_context_query_failure();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static size_t
+peak_cuda_current_slot_shard()
+{
+    if (peak_cuda_slot_shard_index == PeakCudaSlotAllocator::kShardCount) {
+        const size_t ticket = peak_cuda_next_slot_shard.fetch_add(
+            1, std::memory_order_relaxed);
+        peak_cuda_slot_shard_exclusive =
+            ticket < kPeakCudaSlotExclusiveShardCount;
+        peak_cuda_slot_shard_index = peak_cuda_slot_shard_exclusive
+            ? ticket
+            : kPeakCudaSlotExclusiveShardCount +
+                  ((ticket - kPeakCudaSlotExclusiveShardCount) %
+                   (PeakCudaSlotAllocator::kShardCount -
+                    kPeakCudaSlotExclusiveShardCount));
+    }
+    return peak_cuda_slot_shard_index;
+}
+
+static void
+peak_cuda_record_launch_observed()
+{
+    peak_cuda_profiler_state.record_launch_observed(
+        peak_cuda_current_slot_shard(), peak_cuda_slot_shard_exclusive);
+}
+
+static gboolean
+peak_cuda_acquire_timing(PeakCudaLaunchBackend backend,
+                         cudaStream_t stream,
+                         CUcontext known_context,
+                         PeakCudaCaptureTimingGuard* capture_guard,
+                         PeakCudaTimingLease* timing)
+{
+    CUcontext context = known_context;
+    if (capture_guard == NULL || timing == NULL) {
+        return FALSE;
+    }
+    if (!capture_guard->try_enter()) {
+        if (peak_cuda_capture_tracking_terminal.load(
+                std::memory_order_acquire)) {
+            peak_cuda_profiler_state.record_capture_query_failure();
+        } else {
+            peak_cuda_profiler_state.record_stream_capture_skip();
+        }
+        return FALSE;
+    }
+    if (!peak_cuda_accepting_events.load(std::memory_order_acquire)) {
+        peak_cuda_request_harvester_initialization();
+        peak_cuda_profiler_state.record_harvester_unavailable();
+        capture_guard->leave();
+        return FALSE;
+    }
+    (void)backend;
+    (void)stream;
+    if (context == NULL && !peak_cuda_current_context(&context)) {
+        capture_guard->leave();
+        return FALSE;
+    }
+
+    PeakCudaSlotLease lease = {};
+    bool admission_closed = false;
+    if (!peak_cuda_slot_allocator.acquire_if_accepting(
+            reinterpret_cast<std::uintptr_t>(context),
+            peak_cuda_current_slot_shard(),
+            peak_cuda_accepting_events, &lease, &admission_closed)) {
+        if (!admission_closed) {
+            peak_cuda_profiler_state.record_pool_full();
+        }
+        capture_guard->leave();
+        return FALSE;
+    }
+    if (lease.index >= peak_cuda_event_pool.size()) {
+        (void)peak_cuda_slot_allocator.release(lease);
+        peak_cuda_profiler_state.record_pool_full();
+        capture_guard->leave();
+        return FALSE;
+    }
+
+    PeakCudaEventSlot& slot = peak_cuda_event_pool[lease.index];
+    slot.lease = lease;
+    if (!slot.initialized) {
+        slot.owner_context = context;
+        slot.owner_device = -1;
+        if (peak_cuda_backend_api.ctx_get_device != NULL) {
+            if (peak_cuda_backend_api.ctx_get_device(&slot.owner_device) !=
+                CUDA_SUCCESS) {
+                peak_cuda_profiler_state.record_context_query_failure();
+            }
+        }
+        if (cudaEventCreate(&slot.start) != cudaSuccess ||
+            cudaEventCreate(&slot.end) != cudaSuccess) {
+            peak_cuda_profiler_state.record_event_create_failure();
+            if (peak_cuda_destroy_slot_events_current(&slot)) {
+                (void)peak_cuda_slot_allocator.release(lease);
+            }
+            capture_guard->leave();
+            return FALSE;
+        }
+        slot.initialized = TRUE;
+    } else if (slot.owner_context != context) {
+        peak_cuda_profiler_state.record_context_query_failure();
+        capture_guard->leave();
+        return FALSE;
+    }
+
+    timing->lease = lease;
+    timing->start = slot.start;
+    timing->end = slot.end;
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_record_event(PeakCudaLaunchBackend backend,
+                       cudaEvent_t event, cudaStream_t stream)
+{
+    gboolean recorded = FALSE;
+    if (event != NULL && backend == PEAK_CUDA_LAUNCH_BACKEND_DRIVER &&
+        peak_cuda_backend_api.event_record != NULL) {
+        recorded = peak_cuda_backend_api.event_record(
+            reinterpret_cast<CUevent>(event),
+            reinterpret_cast<CUstream>(stream)) == CUDA_SUCCESS;
+    } else if (event != NULL) {
+        recorded = cudaEventRecord(event, stream) == cudaSuccess;
+    }
+    if (!recorded) {
         peak_cuda_profiler_state.record_timing_error();
         return FALSE;
     }
     return TRUE;
 }
 
-static void
-peak_cuda_release_event_pair(cudaEvent_t* start_event, cudaEvent_t* end_event)
+static gboolean
+peak_cuda_publish_timing(const PeakCudaTimingLease& timing)
 {
-    (void)end_event;
-    if (start_event == NULL) {
-        return;
+    if (!peak_cuda_pending_push(timing.lease)) {
+        peak_cuda_profiler_state.record_pool_full();
+        (void)peak_cuda_discard_lease_current(timing.lease);
+        return FALSE;
     }
-    std::lock_guard<std::mutex> lock(peak_cuda_event_pool_mutex);
-    for (size_t index = 0; index < peak_cuda_event_pool.size(); ++index) {
-        PeakCudaEventSlot& slot = peak_cuda_event_pool[index];
-        if (&slot.start == start_event && slot.leased) {
-            slot.leased = FALSE;
-            peak_cuda_free_event_slots.push_back(index);
-            peak_cuda_profiler_state.release_slot();
-            return;
-        }
-    }
+    peak_cuda_profiler_state.record_launch_accepted(
+        timing.lease.shard,
+        timing.lease.shard < kPeakCudaSlotExclusiveShardCount);
+    return TRUE;
 }
 
-static void peak_cuda_release_kernel_launch(KernelLaunchInfo* launch,
-                                            gboolean record_elapsed)
+static gboolean
+peak_cuda_commit_kernel_timing(
+    const PeakCudaTimingLease& timing, const char* kernel_name,
+    const PeakCudaLaunchDimensions& dimensions, cudaError_t result)
 {
-    if (launch == NULL) {
-        return;
+    if (timing.lease.index >= peak_cuda_event_pool.size()) {
+        return FALSE;
     }
-
-    if (record_elapsed &&
-        launch->start_event != NULL &&
-        launch->end_event != NULL &&
-        *(launch->start_event) != NULL &&
-        *(launch->end_event) != NULL) {
-        float ms = 0.0f;
-        if (cudaEventElapsedTime(&ms, *(launch->start_event),
-                                 *(launch->end_event)) != cudaSuccess) {
-            peak_cuda_profiler_state.record_timing_error();
-        } else if (launch->result == cudaSuccess) {
-            insert_cuda_mapping_record(
-                launch->kernel_name,
-                launch->total_threads,
-                launch->grid_size,
-                launch->block_size,
-                ms / 1000.0
-            );
-        }
-    }
-
-    peak_cuda_release_event_pair(launch->start_event, launch->end_event);
-    launch->start_event = NULL;
-    launch->end_event = NULL;
-    g_free(launch->kernel_name);
-    launch->kernel_name = NULL;
+    PeakCudaEventSlot& slot = peak_cuda_event_pool[timing.lease.index];
+    slot.record.kind = PEAK_CUDA_LAUNCH_RECORD_KERNEL;
+    g_strlcpy(slot.record.kernel_name,
+              kernel_name != NULL ? kernel_name : "<unknown-cuda-kernel>",
+              sizeof(slot.record.kernel_name));
+    slot.record.total_threads = dimensions.total_threads;
+    slot.record.grid_size = dimensions.grid_size;
+    slot.record.block_size = dimensions.block_size;
+    slot.record.result = result;
+    return peak_cuda_publish_timing(timing);
 }
 
-static void peak_cuda_release_graph_launch(GraphLaunchInfo* launch,
-                                           gboolean record_elapsed)
+static gboolean
+peak_cuda_commit_graph_timing(const PeakCudaTimingLease& timing,
+                              CUgraphExec graph, cudaError_t result)
 {
-    if (launch == NULL) {
-        return;
+    if (timing.lease.index >= peak_cuda_event_pool.size()) {
+        return FALSE;
     }
-
-    if (record_elapsed &&
-        launch->start_event != NULL &&
-        launch->end_event != NULL &&
-        *(launch->start_event) != NULL &&
-        *(launch->end_event) != NULL) {
-        float ms = 0.0f;
-        if (cudaEventElapsedTime(&ms, *(launch->start_event),
-                                 *(launch->end_event)) != cudaSuccess) {
-            peak_cuda_profiler_state.record_timing_error();
-        } else if (launch->result == cudaSuccess) {
-            insert_cuda_graph_record(launch->graph, ms / 1000.0);
-        }
-    }
-
-    peak_cuda_release_event_pair(launch->start_event, launch->end_event);
-    launch->start_event = NULL;
-    launch->end_event = NULL;
-}
-
-static void peak_cuda_enqueue_kernel_launch(const gchar* kernel_name,
-                                            KernelLaunchInfo* info)
-{
-    const gchar* key = (kernel_name != NULL) ? kernel_name : "<unknown-cuda-kernel>";
-    gboolean accepted = FALSE;
-
-    {
-        std::lock_guard<std::mutex> map_lock(peak_kernel_event_map_mutex);
-        if (peak_cuda_accepting_events.load(std::memory_order_acquire)) {
-            auto& series = peak_kernel_event_map[key];
-            std::lock_guard<std::mutex> lock(series.mtx);
-            series.launches.push_back(*info);
-            accepted = TRUE;
-        }
-    }
-
-    if (!accepted) {
-        peak_cuda_release_kernel_launch(info, FALSE);
-    }
-}
-
-static void peak_cuda_enqueue_graph_launch(CUgraphExec_st* graph,
-                                           GraphLaunchInfo* info)
-{
-    gboolean accepted = FALSE;
-
-    {
-        std::lock_guard<std::mutex> map_lock(peak_graph_event_map_mutex);
-        if (peak_cuda_accepting_events.load(std::memory_order_acquire)) {
-            auto& series = peak_graph_event_map[graph];
-            std::lock_guard<std::mutex> lock(series.mtx);
-            series.launches.push_back(*info);
-            accepted = TRUE;
-        }
-    }
-
-    if (!accepted) {
-        peak_cuda_release_graph_launch(info, FALSE);
-    }
-}
-
-static void peak_cuda_drain_kernel_event_map(gboolean record_elapsed)
-{
-    std::lock_guard<std::mutex> map_lock(peak_kernel_event_map_mutex);
-    for (auto& [_, series] : peak_kernel_event_map) {
-        std::lock_guard<std::mutex> lock(series.mtx);
-        for (auto& launch : series.launches) {
-            peak_cuda_release_kernel_launch(&launch, record_elapsed);
-        }
-        series.launches.clear();
-    }
-    peak_kernel_event_map.clear();
-}
-
-static void peak_cuda_drain_graph_event_map(gboolean record_elapsed)
-{
-    std::lock_guard<std::mutex> map_lock(peak_graph_event_map_mutex);
-    for (auto& [_, series] : peak_graph_event_map) {
-        std::lock_guard<std::mutex> lock(series.mtx);
-        for (auto& launch : series.launches) {
-            peak_cuda_release_graph_launch(&launch, record_elapsed);
-        }
-        series.launches.clear();
-    }
-    peak_graph_event_map.clear();
+    PeakCudaEventSlot& slot = peak_cuda_event_pool[timing.lease.index];
+    slot.record.kind = PEAK_CUDA_LAUNCH_RECORD_GRAPH;
+    slot.record.graph = graph;
+    slot.record.result = result;
+    return peak_cuda_publish_timing(timing);
 }
 
 static void peak_cuda_clear_hook_pointers()
@@ -550,6 +2107,153 @@ static void peak_cuda_clear_hook_pointers()
     hook_cu_launch_ex = NULL;
     hook_cuda_graph_launch = NULL;
     hook_cu_graph_launch = NULL;
+    for (size_t index = 0; index < PEAK_CUDA_CAPTURE_HOOK_COUNT; ++index) {
+        peak_cuda_capture_hooks[index] = NULL;
+        if (peak_cuda_capture_listeners[index] != NULL) {
+            g_object_unref(peak_cuda_capture_listeners[index]);
+            peak_cuda_capture_listeners[index] = NULL;
+        }
+    }
+    for (size_t index = 0;
+         index < peak_cuda_direct_capture_hook_count;
+         ++index) {
+        peak_cuda_direct_capture_hooks[index] = NULL;
+        if (peak_cuda_direct_capture_listeners[index] != NULL) {
+            g_object_unref(peak_cuda_direct_capture_listeners[index]);
+            peak_cuda_direct_capture_listeners[index] = NULL;
+        }
+        peak_cuda_direct_capture_descriptors[index] = {};
+    }
+    peak_cuda_direct_capture_hook_count = 0;
+    peak_cuda_capture_hooks_ready = FALSE;
+}
+
+static gboolean
+peak_cuda_timing_requested()
+{
+    return peak_gpu_monitor_all || peak_gpu_hook_address_count > 0;
+}
+
+static gboolean
+peak_cuda_has_timed_hook()
+{
+    return hook_cuda_launch != NULL ||
+           hook_cuda_launch_cooperative != NULL ||
+           hook_cuda_launch_exc != NULL ||
+           hook_cu_launch != NULL ||
+           hook_cu_launch_cooperative != NULL ||
+           hook_cu_launch_ex != NULL ||
+           hook_cuda_graph_launch != NULL ||
+           hook_cu_graph_launch != NULL;
+}
+
+static void
+peak_cuda_log_incomplete_records(unsigned int active_wrappers)
+{
+    static constexpr size_t kDiagnosticLimit = 16;
+
+    if (active_wrappers != 0) {
+        peak_log_warn(
+            "[peak] CUDA finalization retained %u active launch wrapper(s); their contexts are still application-owned\n",
+            active_wrappers);
+        return;
+    }
+
+    PeakCudaSlotLease leases[kDiagnosticLimit] = {};
+    size_t affected = 0;
+    if (!peak_cuda_slot_allocator.try_snapshot_active_leases(
+            leases, kDiagnosticLimit, &affected)) {
+        peak_log_warn(
+            "[peak] CUDA incomplete event diagnostics unavailable because slot ownership is busy\n");
+        return;
+    }
+    size_t logged = std::min(affected, kDiagnosticLimit);
+    for (size_t index = 0; index < logged; ++index) {
+        if (leases[index].index >= peak_cuda_event_pool.size()) {
+            continue;
+        }
+        const PeakCudaEventSlot& slot =
+            peak_cuda_event_pool[leases[index].index];
+        peak_log_warn(
+            "[peak] CUDA incomplete event context=%p device=%d\n",
+            reinterpret_cast<void*>(leases[index].context),
+            slot.owner_device);
+    }
+    if (affected > logged) {
+        peak_log_warn(
+            "[peak] CUDA incomplete event diagnostics omitted=%zu\n",
+            affected - logged);
+    }
+}
+
+static void
+peak_cuda_finalize_pending()
+{
+    if (peak_cuda_finalization_complete || peak_cuda_finalization_timed_out) {
+        return;
+    }
+
+    peak_cuda_lifecycle_close();
+    std::uint64_t started_ns = peak_cuda_monotonic_ns();
+    peak_cuda_disable_harvester_initialization();
+    std::uint64_t timeout_ns = peak_cuda_finalization_timeout_ms * 1000000ULL;
+    std::uint64_t deadline_ns = started_ns >
+        std::numeric_limits<std::uint64_t>::max() - timeout_ns
+            ? std::numeric_limits<std::uint64_t>::max()
+            : started_ns + timeout_ns;
+    struct timespec pause = {0, kPeakCudaHarvestRetryNs};
+    size_t deadline_incomplete = 0;
+    unsigned int deadline_wrappers = 0;
+    gboolean deadline_initialization_inflight = FALSE;
+
+    for (;;) {
+        unsigned int wrappers = peak_cuda_active_wrapper_count();
+        size_t active_slots = peak_cuda_slot_allocator.active_count();
+        gboolean initialization_inflight =
+            peak_cuda_harvester_initialization_inflight.load(
+                std::memory_order_acquire);
+        if (active_slots == 0 && wrappers == 0 &&
+            !initialization_inflight) {
+            peak_cuda_finalization_complete = TRUE;
+            break;
+        }
+        std::uint64_t now_ns = peak_cuda_monotonic_ns();
+        if (now_ns == 0 || now_ns >= deadline_ns) {
+            break;
+        }
+        (void)nanosleep(&pause, NULL);
+    }
+
+    if (!peak_cuda_finalization_complete) {
+        /* Close the helper before taking the cutoff snapshot. It may have
+         * released the last lease at the deadline boundary; in that case the
+         * no-CUDA-after-release invariant makes a normal join safe. */
+        peak_cuda_request_harvester_stop_no_wait();
+        deadline_wrappers = peak_cuda_active_wrapper_count();
+        deadline_incomplete = peak_cuda_slot_allocator.active_count();
+        deadline_initialization_inflight =
+            peak_cuda_harvester_initialization_inflight.load(
+                std::memory_order_acquire);
+        if (deadline_incomplete == 0 && deadline_wrappers == 0 &&
+            !deadline_initialization_inflight) {
+            peak_cuda_finalization_complete = TRUE;
+        }
+    }
+
+    if (peak_cuda_finalization_complete) {
+        peak_cuda_stop_harvester();
+    } else {
+        /* A CUDA query may itself be stuck; never extend the deadline by
+         * joining the helper. Retain its bounded state for process cleanup. */
+        peak_cuda_profiler_state.record_finalization_timeout(
+            deadline_incomplete);
+        peak_cuda_finalization_timed_out = TRUE;
+        peak_log_warn(
+            "[peak] CUDA finalization_timeout=1 finalization_incomplete=%zu helper_initialization_inflight=%d; retaining incomplete event state\n",
+            deadline_incomplete,
+            deadline_initialization_inflight ? 1 : 0);
+        peak_cuda_log_incomplete_records(deadline_wrappers);
+    }
 }
 
 PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel(
@@ -557,44 +2261,46 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel(
     void** args, size_t sharedMem, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
-    PeakCudaKernelIdentity identity =
+    if (!in_flight.entered()) {
+        return original_cuda_launch_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    const PeakCudaKernelIdentity* identity =
         peak_cuda_identify_kernel((gpointer)func, FALSE);
-    if (!identity.target_match) {
+    if (!identity->target_match) {
         return original_cuda_launch_kernel(
             func, gridDim, blockDim, args, sharedMem, stream);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
-    gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
-    gulong block_size = blockDim.x * blockDim.y * blockDim.z;
+    PeakCudaRuntimeLaunchGuard runtime_launch;
+    auto call_original = [&]() {
+        return original_cuda_launch_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    };
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDim.x, gridDim.y, gridDim.z,
+        blockDim.x, blockDim.y, blockDim.z);
 
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
-        return original_cuda_launch_kernel(
-            func, gridDim, blockDim, args, sharedMem, stream);
+    PeakCudaCaptureTimingGuard capture_guard;
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                  stream, NULL, &capture_guard, &timing)) {
+        return call_original();
     }
-    if (!peak_cuda_record_event(start, stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cuda_launch_kernel(
-            func, gridDim, blockDim, args, sharedMem, stream);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.start, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
+        return call_original();
     }
-    cudaError_t result = original_cuda_launch_kernel(func, gridDim, blockDim, args, sharedMem, stream);
-    if (!peak_cuda_record_event(end, stream)) {
-        peak_cuda_release_event_pair(start, end);
+    cudaError_t result = call_original();
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.end, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, result);
     return result;
 }
 
@@ -603,44 +2309,46 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel(
     void** args, size_t sharedMem, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
-    PeakCudaKernelIdentity identity =
+    if (!in_flight.entered()) {
+        return original_cuda_launch_cooperative_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    }
+    const PeakCudaKernelIdentity* identity =
         peak_cuda_identify_kernel((gpointer)func, FALSE);
-    if (!identity.target_match) {
+    if (!identity->target_match) {
         return original_cuda_launch_cooperative_kernel(
             func, gridDim, blockDim, args, sharedMem, stream);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
-    gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
-    gulong block_size = blockDim.x * blockDim.y * blockDim.z;
+    PeakCudaRuntimeLaunchGuard runtime_launch;
+    auto call_original = [&]() {
+        return original_cuda_launch_cooperative_kernel(
+            func, gridDim, blockDim, args, sharedMem, stream);
+    };
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDim.x, gridDim.y, gridDim.z,
+        blockDim.x, blockDim.y, blockDim.z);
 
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
-        return original_cuda_launch_cooperative_kernel(
-            func, gridDim, blockDim, args, sharedMem, stream);
+    PeakCudaCaptureTimingGuard capture_guard;
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                  stream, NULL, &capture_guard, &timing)) {
+        return call_original();
     }
-    if (!peak_cuda_record_event(start, stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cuda_launch_cooperative_kernel(
-            func, gridDim, blockDim, args, sharedMem, stream);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.start, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
+        return call_original();
     }
-    cudaError_t result = original_cuda_launch_cooperative_kernel(func, gridDim, blockDim, args, sharedMem, stream);
-    if (!peak_cuda_record_event(end, stream)) {
-        peak_cuda_release_event_pair(start, end);
+    cudaError_t result = call_original();
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.end, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, result);
     return result;
 }
 
@@ -648,50 +2356,15 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_cooperative_kernel_multipl
     struct cudaLaunchParams* launchParamsList, unsigned int numDevices, unsigned int flags)
 {
     PeakCudaInflightGuard in_flight;
-    const void* func = launchParamsList->func;
-    dim3 gridDim = launchParamsList->gridDim;
-    dim3 blockDim = launchParamsList->blockDim;
-    cudaStream_t stream = launchParamsList->stream;
-
-    PeakCudaKernelIdentity identity =
-        peak_cuda_identify_kernel((gpointer)func, FALSE);
-    if (!identity.target_match) {
+    if (!in_flight.entered()) {
         return original_cuda_launch_cooperative_kernel_multiple_device(
             launchParamsList, numDevices, flags);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
-    gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
-    gulong block_size = blockDim.x * blockDim.y * blockDim.z;
-
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
-        return original_cuda_launch_cooperative_kernel_multiple_device(
-            launchParamsList, numDevices, flags);
-    }
-    if (!peak_cuda_record_event(start, stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cuda_launch_cooperative_kernel_multiple_device(
-            launchParamsList, numDevices, flags);
-    }
-    cudaError_t result = original_cuda_launch_cooperative_kernel_multiple_device(launchParamsList, numDevices, flags);
-    if (!peak_cuda_record_event(end, stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return result;
-    }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    return result;
+    PeakCudaRuntimeLaunchGuard runtime_launch;
+    peak_cuda_record_launch_observed();
+    peak_cuda_profiler_state.record_unsupported_multi_device();
+    return original_cuda_launch_cooperative_kernel_multiple_device(
+        launchParamsList, numDevices, flags);
 }
 
 PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel_exc(
@@ -699,48 +2372,63 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_launch_kernel_exc(
     const void* func, void** args)
 {
     PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cuda_launch_kernel_exc(config, func, args);
+    }
+    if (config == NULL) {
+        return original_cuda_launch_kernel_exc(config, func, args);
+    }
     dim3 gridDim = config->gridDim;
     dim3 blockDim = config->blockDim;
     cudaStream_t stream = config->stream;
 
-    PeakCudaKernelIdentity identity =
+    const PeakCudaKernelIdentity* identity =
         peak_cuda_identify_kernel((gpointer)func, FALSE);
-    if (!identity.target_match) {
+    if (!identity->target_match) {
         return original_cuda_launch_kernel_exc(config, func, args);
     }
-    const gchar* kernel_label = identity.name.c_str();
-
-
-    gulong total_threads = (gridDim.x * blockDim.x) * (gridDim.y * blockDim.y) * (gridDim.z * blockDim.z);
-    gulong grid_size = gridDim.x * gridDim.y * gridDim.z;
-    gulong block_size = blockDim.x * blockDim.y * blockDim.z;
-
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+    PeakCudaRuntimeLaunchGuard runtime_launch;
+    auto call_original = [&]() {
         return original_cuda_launch_kernel_exc(config, func, args);
+    };
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDim.x, gridDim.y, gridDim.z,
+        blockDim.x, blockDim.y, blockDim.z);
+
+    PeakCudaCaptureTimingGuard capture_guard;
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                  stream, NULL, &capture_guard, &timing)) {
+        return call_original();
     }
-    if (!peak_cuda_record_event(start, stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cuda_launch_kernel_exc(config, func, args);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.start, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
+        return call_original();
     }
-    cudaError_t result = original_cuda_launch_kernel_exc(config, func, args);
-    if (!peak_cuda_record_event(end, stream)) {
-        peak_cuda_release_event_pair(start, end);
+    cudaError_t result = call_original();
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.end, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, result);
     return result;
+}
+
+static void
+peak_cuda_record_blocked_driver_launch(gboolean known_target)
+{
+    /* Kernel identity filtering runs before the capture writer gate so the
+     * non-target fast path does not enter that gate. Graph launches are
+     * always profiling targets. */
+    if (known_target || peak_gpu_monitor_all) {
+        peak_cuda_record_launch_observed();
+        peak_cuda_profiler_state.record_stream_capture_skip();
+    }
 }
 
 PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel(
@@ -749,29 +2437,61 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel(
     unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ,
     unsigned int sharedMemBytes, CUstream hStream, void** kernelParams, void** extra)
 {
-    PeakCudaInflightGuard in_flight;
-    PeakCudaKernelIdentity identity =
-        peak_cuda_identify_kernel((gpointer)func, TRUE);
-    if (!identity.target_match) {
+    if (peak_cuda_runtime_launch_wrapper_depth != 0) {
         return original_cu_launch_kernel(
             func, gridDimX, gridDimY, gridDimZ,
             blockDimX, blockDimY, blockDimZ,
             sharedMemBytes, hStream, kernelParams, extra);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
-    gulong grid_size = gridDimX * gridDimY * gridDimZ;
-    gulong block_size = blockDimX * blockDimY * blockDimZ;
+    PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams, extra);
+    }
+    CUcontext context = NULL;
+    const PeakCudaKernelIdentity* identity =
+        peak_cuda_cached_driver_identity(func, &context);
+    if (identity == NULL) {
+        if (!peak_cuda_current_context(&context)) {
+            return original_cu_launch_kernel(
+                func, gridDimX, gridDimY, gridDimZ,
+                blockDimX, blockDimY, blockDimZ,
+                sharedMemBytes, hStream, kernelParams, extra);
+        }
+        identity = peak_cuda_identify_kernel((gpointer)func, TRUE, context);
+    }
+    if (!identity->target_match) {
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams, extra);
+    }
+    PeakCudaCaptureTimingGuard capture_guard;
+    if (!capture_guard.try_enter()) {
+        peak_cuda_record_blocked_driver_launch(TRUE);
+        return original_cu_launch_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams, extra);
+    }
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ);
 
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                  (cudaStream_t)hStream, context,
+                                  &capture_guard, &timing)) {
         return original_cu_launch_kernel(
             func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
             blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
     }
-    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.start, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return original_cu_launch_kernel(
             func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
             blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
@@ -779,21 +2499,13 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel(
     CUresult result = original_cu_launch_kernel(func, gridDimX, gridDimY, gridDimZ,
                                                 blockDimX, blockDimY, blockDimZ,
                                                 sharedMemBytes, hStream, kernelParams, extra);
-    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.end, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, (cudaError_t)result);
     return result;
 }
 
@@ -803,29 +2515,61 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel(
     unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ,
     unsigned int sharedMemBytes, CUstream hStream, void** kernelParams)
 {
-    PeakCudaInflightGuard in_flight;
-    PeakCudaKernelIdentity identity =
-        peak_cuda_identify_kernel((gpointer)func, TRUE);
-    if (!identity.target_match) {
+    if (peak_cuda_runtime_launch_wrapper_depth != 0) {
         return original_cu_launch_cooperative_kernel(
             func, gridDimX, gridDimY, gridDimZ,
             blockDimX, blockDimY, blockDimZ,
             sharedMemBytes, hStream, kernelParams);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
-    gulong grid_size = gridDimX * gridDimY * gridDimZ;
-    gulong block_size = blockDimX * blockDimY * blockDimZ;
+    PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams);
+    }
+    CUcontext context = NULL;
+    const PeakCudaKernelIdentity* identity =
+        peak_cuda_cached_driver_identity(func, &context);
+    if (identity == NULL) {
+        if (!peak_cuda_current_context(&context)) {
+            return original_cu_launch_cooperative_kernel(
+                func, gridDimX, gridDimY, gridDimZ,
+                blockDimX, blockDimY, blockDimZ,
+                sharedMemBytes, hStream, kernelParams);
+        }
+        identity = peak_cuda_identify_kernel((gpointer)func, TRUE, context);
+    }
+    if (!identity->target_match) {
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams);
+    }
+    PeakCudaCaptureTimingGuard capture_guard;
+    if (!capture_guard.try_enter()) {
+        peak_cuda_record_blocked_driver_launch(TRUE);
+        return original_cu_launch_cooperative_kernel(
+            func, gridDimX, gridDimY, gridDimZ,
+            blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, hStream, kernelParams);
+    }
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ);
 
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                  (cudaStream_t)hStream, context,
+                                  &capture_guard, &timing)) {
         return original_cu_launch_cooperative_kernel(
             func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
             blockDimZ, sharedMemBytes, hStream, kernelParams);
     }
-    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.start, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return original_cu_launch_cooperative_kernel(
             func, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
             blockDimZ, sharedMemBytes, hStream, kernelParams);
@@ -835,21 +2579,13 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel(
                                                 blockDimX, blockDimY, blockDimZ,
                                                 sharedMemBytes, hStream, kernelParams);
 
-    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.end, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, (cudaError_t)result);
     return result;
 }
 
@@ -857,63 +2593,37 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_cooperative_kernel_multiple_dev
     CUDA_LAUNCH_PARAMS* launchParamsList,
     unsigned int numDevices, unsigned int flags)
 {
+    if (peak_cuda_runtime_launch_wrapper_depth != 0) {
+        return original_cu_launch_cooperative_kernel_multiple_device(
+            launchParamsList, numDevices, flags);
+    }
     PeakCudaInflightGuard in_flight;
-    CUfunction func = launchParamsList->function;
-    unsigned int gridDimX = launchParamsList->gridDimX;
-    unsigned int gridDimY = launchParamsList->gridDimY;
-    unsigned int gridDimZ = launchParamsList->gridDimZ;
-    unsigned int blockDimX = launchParamsList->blockDimX;
-    unsigned int blockDimY = launchParamsList->blockDimY;
-    unsigned int blockDimZ = launchParamsList->blockDimZ;
-    CUstream hStream = launchParamsList->hStream;
-
-    PeakCudaKernelIdentity identity =
-        peak_cuda_identify_kernel((gpointer)func, TRUE);
-    if (!identity.target_match) {
+    if (!in_flight.entered()) {
         return original_cu_launch_cooperative_kernel_multiple_device(
             launchParamsList, numDevices, flags);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
-    gulong grid_size = gridDimX * gridDimY * gridDimZ;
-    gulong block_size = blockDimX * blockDimY * blockDimZ;
-
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
-        return original_cu_launch_cooperative_kernel_multiple_device(
-            launchParamsList, numDevices, flags);
-    }
-    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cu_launch_cooperative_kernel_multiple_device(
-            launchParamsList, numDevices, flags);
-    }
-    CUresult result = original_cu_launch_cooperative_kernel_multiple_device(
-                                    launchParamsList, numDevices, flags);
-    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
-        return result;
-    }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
-    return result;
+    peak_cuda_record_launch_observed();
+    peak_cuda_profiler_state.record_unsupported_multi_device();
+    return original_cu_launch_cooperative_kernel_multiple_device(
+        launchParamsList, numDevices, flags);
 }
 
 PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel_ex(
     const CUlaunchConfig* config, CUfunction func,
     void** kernelParams, void** extra)
 {
+    if (peak_cuda_runtime_launch_wrapper_depth != 0) {
+        return original_cu_launch_kernel_ex(
+            config, func, kernelParams, extra);
+    }
     PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cu_launch_kernel_ex(
+            config, func, kernelParams, extra);
+    }
+    if (config == NULL) {
+        return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
+    }
     unsigned int gridDimX = config->gridDimX;
     unsigned int gridDimY = config->gridDimY;
     unsigned int gridDimZ = config->gridDimZ;
@@ -922,41 +2632,49 @@ PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_launch_kernel_ex(
     unsigned int blockDimZ = config->blockDimZ;
     CUstream hStream = config->hStream;
 
-    PeakCudaKernelIdentity identity =
-        peak_cuda_identify_kernel((gpointer)func, TRUE);
-    if (!identity.target_match) {
+    CUcontext context = NULL;
+    const PeakCudaKernelIdentity* identity =
+        peak_cuda_cached_driver_identity(func, &context);
+    if (identity == NULL) {
+        if (!peak_cuda_current_context(&context)) {
+            return original_cu_launch_kernel_ex(config, func,
+                                                kernelParams, extra);
+        }
+        identity = peak_cuda_identify_kernel((gpointer)func, TRUE, context);
+    }
+    if (!identity->target_match) {
         return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
     }
-    const gchar* kernel_label = identity.name.c_str();
-    gulong total_threads = (gridDimX * blockDimX) * (gridDimY * blockDimY) * (gridDimZ * blockDimZ);
-    gulong grid_size = gridDimX * gridDimY * gridDimZ;
-    gulong block_size = blockDimX * blockDimY * blockDimZ;
+    PeakCudaCaptureTimingGuard capture_guard;
+    if (!capture_guard.try_enter()) {
+        peak_cuda_record_blocked_driver_launch(TRUE);
+        return original_cu_launch_kernel_ex(config, func,
+                                            kernelParams, extra);
+    }
+    const gchar* kernel_label = identity->name.data();
+    peak_cuda_record_launch_observed();
+    PeakCudaLaunchDimensions dimensions = peak_cuda_launch_dimensions(
+        gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ);
 
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                  (cudaStream_t)hStream, context,
+                                  &capture_guard, &timing)) {
         return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
     }
-    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.start, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return original_cu_launch_kernel_ex(config, func, kernelParams, extra);
     }
     CUresult result = original_cu_launch_kernel_ex(config, func, kernelParams, extra);
-    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.end, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    KernelLaunchInfo info = {
-        .kernel_name = g_strdup(kernel_label),
-        .total_threads = total_threads,
-        .grid_size = grid_size,
-        .block_size = block_size,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_kernel_launch(kernel_label, &info);
+    (void)peak_cuda_commit_kernel_timing(
+        timing, kernel_label, dimensions, (cudaError_t)result);
     return result;
 }
 
@@ -964,96 +2682,574 @@ PEAK_CUDA_WRAPPER_EXPORT cudaError_t peak_cuda_graph_launch(
     cudaGraphExec_t graphExec, cudaStream_t stream)
 {
     PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cuda_graph_launch(graphExec, stream);
+    }
+    PeakCudaRuntimeLaunchGuard runtime_launch;
+    auto call_original = [&]() {
+        return original_cuda_graph_launch(graphExec, stream);
+    };
     /* Graph executable handles are rank-local; profile them locally only. */
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
-        return original_cuda_graph_launch(graphExec, stream);
+    peak_cuda_record_launch_observed();
+    PeakCudaCaptureTimingGuard capture_guard;
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                  stream, NULL, &capture_guard, &timing)) {
+        return call_original();
     }
-    if (!peak_cuda_record_event(start, (cudaStream_t)stream)) {
-        peak_cuda_release_event_pair(start, end);
-        return original_cuda_graph_launch(graphExec, stream);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.start, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
+        return call_original();
     }
-    cudaError_t result = original_cuda_graph_launch(graphExec, stream);
-    if (!peak_cuda_record_event(end, (cudaStream_t)stream)) {
-        peak_cuda_release_event_pair(start, end);
+    cudaError_t result = call_original();
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_RUNTIME,
+                                timing.end, stream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    GraphLaunchInfo info = {
-        .graph = graphExec,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_graph_launch(graphExec, &info);
-
+    (void)peak_cuda_commit_graph_timing(timing, graphExec, result);
     return result;
 }
 
 PEAK_CUDA_WRAPPER_EXPORT CUresult peak_cu_graph_launch(
     CUgraphExec hGraphExec, CUstream hStream)
 {
-    PeakCudaInflightGuard in_flight;
-    /* Graph executable handles are rank-local; profile them locally only. */
-    cudaEvent_t* start = NULL;
-    cudaEvent_t* end = NULL;
-    if (!peak_cuda_acquire_event_pair(&start, &end)) {
+    if (peak_cuda_runtime_launch_wrapper_depth != 0) {
         return original_cu_graph_launch(hGraphExec, hStream);
     }
-    if (!peak_cuda_record_event(start, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    PeakCudaInflightGuard in_flight;
+    if (!in_flight.entered()) {
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
+    /* Graph executable handles are rank-local; profile them locally only. */
+    PeakCudaCaptureTimingGuard capture_guard;
+    if (!capture_guard.try_enter()) {
+        peak_cuda_record_blocked_driver_launch(TRUE);
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
+    CUcontext context = NULL;
+    if (!peak_cuda_current_context(&context)) {
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
+    peak_cuda_record_launch_observed();
+    PeakCudaTimingLease timing = {};
+    if (!peak_cuda_acquire_timing(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                  (cudaStream_t)hStream, context,
+                                  &capture_guard, &timing)) {
+        return original_cu_graph_launch(hGraphExec, hStream);
+    }
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.start, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return original_cu_graph_launch(hGraphExec, hStream);
     }
     CUresult result = original_cu_graph_launch(hGraphExec, hStream);
-    if (!peak_cuda_record_event(end, (cudaStream_t)hStream)) {
-        peak_cuda_release_event_pair(start, end);
+    if (!peak_cuda_record_event(PEAK_CUDA_LAUNCH_BACKEND_DRIVER,
+                                timing.end, (cudaStream_t)hStream)) {
+        (void)peak_cuda_discard_lease_current(timing.lease);
         return result;
     }
-
-    GraphLaunchInfo info = {
-        .graph = hGraphExec,
-        .start_event = start,
-        .end_event = end,
-        .result = (cudaError_t)result
-    };
-    peak_cuda_enqueue_graph_launch(hGraphExec, &info);
-
+    (void)peak_cuda_commit_graph_timing(
+        timing, hGraphExec, (cudaError_t)result);
     return result;
+}
+
+#if defined(__linux__) && defined(__aarch64__)
+static gboolean
+peak_cuda_capture_entry_is_arm64_branch(gpointer address)
+{
+    guint8* copy = NULL;
+    gsize bytes_read = 0;
+    guint32 instruction = 0;
+
+    if (address == NULL) {
+        return FALSE;
+    }
+    copy = gum_memory_read(address, sizeof(instruction), &bytes_read);
+    if (copy == NULL || bytes_read != sizeof(instruction)) {
+        g_free(copy);
+        return FALSE;
+    }
+    memcpy(&instruction, copy, sizeof(instruction));
+    g_free(copy);
+    return (instruction & UINT32_C(0xfc000000)) ==
+           UINT32_C(0x14000000);
+}
+#endif
+
+static gboolean
+peak_cuda_driver_typed_replacements_are_isolated()
+{
+#if !defined(GUM_PEAK_REDIRECT_RESOLVER_API_VERSION)
+    return FALSE;
+#else
+    struct PeakCudaResolvedEntry {
+        const char* symbol;
+        gpointer canonical;
+    };
+    static const char* timed_symbols[] = {
+        "cuLaunchKernel",
+        "cuLaunchCooperativeKernel",
+        "cuLaunchCooperativeKernelMultiDevice",
+        "cuLaunchKernelEx",
+        "cuGraphLaunch",
+    };
+    PeakCudaResolvedEntry timed[G_N_ELEMENTS(timed_symbols)] = {};
+    size_t timed_count = 0;
+    for (const char* symbol : timed_symbols) {
+        gpointer address = peak_general_listener_find_function(symbol);
+        if (address == NULL) {
+            continue;
+        }
+        gpointer canonical = NULL;
+        if (!gum_interceptor_peak_resolve_redirect_chain(
+                cuda_interceptor, address, &canonical) ||
+            canonical == NULL) {
+            peak_log_warn(
+                "[peak] could not resolve CUDA Driver entry %s; Driver launch timing remains disabled\n",
+                symbol);
+            return FALSE;
+        }
+        if (canonical != address) {
+            peak_log_warn(
+                "[peak] CUDA Driver entry %s redirects through a dispatcher; Driver launch timing remains disabled\n",
+                symbol);
+            return FALSE;
+        }
+        timed[timed_count++] = {symbol, canonical};
+    }
+
+    for (size_t left = 0; left < timed_count; ++left) {
+        for (size_t right = left + 1; right < timed_count; ++right) {
+            if (timed[left].canonical == timed[right].canonical) {
+                peak_log_warn(
+                    "[peak] CUDA Driver entries %s and %s share a dispatcher; Driver launch timing remains disabled\n",
+                    timed[left].symbol, timed[right].symbol);
+                return FALSE;
+            }
+        }
+    }
+
+    auto non_timed_entry_is_isolated =
+        [&](const char* symbol) -> gboolean {
+            gpointer address = peak_general_listener_find_function(symbol);
+            if (address == NULL) {
+                return TRUE;
+            }
+            gpointer canonical = NULL;
+            if (!gum_interceptor_peak_resolve_redirect_chain(
+                    cuda_interceptor, address, &canonical) ||
+                canonical == NULL) {
+                peak_log_warn(
+                    "[peak] could not resolve CUDA Driver support entry %s; Driver launch timing remains disabled\n",
+                    symbol);
+                return FALSE;
+            }
+            for (size_t index = 0; index < timed_count; ++index) {
+                if (address == timed[index].canonical ||
+                    canonical == timed[index].canonical) {
+                    peak_log_warn(
+                        "[peak] CUDA Driver entries %s and %s share an implementation; Driver launch timing remains disabled\n",
+                        timed[index].symbol, symbol);
+                    return FALSE;
+                }
+            }
+            return TRUE;
+        };
+
+    static const char* support_symbols[] = {
+        "cuCtxGetCurrent",
+        "cuCtxGetDevice",
+        "cuCtxPushCurrent_v2",
+        "cuCtxPopCurrent_v2",
+        "cuStreamIsCapturing",
+        "cuThreadExchangeStreamCaptureMode",
+        "cuFuncGetName",
+        "cuDriverGetVersion",
+        "cuGetProcAddress",
+        "cuGetProcAddress_v2",
+    };
+    for (const char* symbol : support_symbols) {
+        if (!non_timed_entry_is_isolated(symbol)) {
+            return FALSE;
+        }
+    }
+    for (const PeakCudaCaptureHookDescriptor& descriptor :
+         peak_cuda_capture_descriptors) {
+        if (descriptor.api == PEAK_CUDA_CAPTURE_API_DRIVER &&
+            !non_timed_entry_is_isolated(descriptor.symbol)) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+#endif
+}
+
+static GumAttachReturn
+peak_cuda_attach_capture_entry(gpointer target,
+                               GumInvocationListener* listener)
+{
+    PeakGumTargetAttachPlan plan = {};
+    peak_gum_target_attach_plan(target, &plan);
+
+#if defined(__linux__) && defined(__aarch64__)
+    if (peak_cuda_capture_entry_is_arm64_branch(target)) {
+#if defined(GUM_PEAK_EXACT_ATTACH_API_VERSION)
+        /* NVIDIA Driver exports are one-instruction tail branches. Keep each
+         * lifecycle listener at its ABI-specific public entry instead of
+         * letting Gum merge the entries at their shared dispatcher. */
+        plan = {};
+        plan.mutation_address = target;
+        plan.mutation_guard_size = sizeof(guint32);
+        plan.attach_exact_entry = TRUE;
+#else
+        return GUM_ATTACH_WRONG_SIGNATURE;
+#endif
+    }
+#endif
+
+    return peak_gum_interceptor_attach_target(cuda_interceptor,
+                                              target,
+                                              listener,
+                                              &plan);
+}
+
+static gboolean
+peak_cuda_install_capture_hook(PeakCudaCaptureHookIndex index,
+                               gboolean* present)
+{
+    const PeakCudaCaptureHookDescriptor* descriptor =
+        &peak_cuda_capture_descriptors[index];
+    gpointer* target = static_cast<gpointer*>(
+        peak_general_listener_find_function(descriptor->symbol));
+    *present = target != NULL;
+    if (target == NULL) {
+        return FALSE;
+    }
+
+    for (size_t previous = 0; previous < index; ++previous) {
+        if (peak_cuda_capture_hooks[previous] != target) {
+            continue;
+        }
+        if (peak_cuda_capture_descriptors[previous].operation !=
+            descriptor->operation) {
+            peak_log_warn(
+                "[peak] CUDA capture lifecycle entries %s and %s share an address but have opposite operations; CUDA timing remains disabled\n",
+                peak_cuda_capture_descriptors[previous].symbol,
+                descriptor->symbol);
+            return FALSE;
+        }
+        peak_cuda_capture_hooks[index] = target;
+        return TRUE;
+    }
+
+    GumInvocationListener* listener = gum_make_call_listener(
+        peak_cuda_capture_listener_on_enter,
+        peak_cuda_capture_listener_on_leave,
+        const_cast<PeakCudaCaptureHookDescriptor*>(descriptor),
+        NULL);
+    if (listener == NULL) {
+        peak_log_warn(
+            "[peak] could not allocate CUDA capture lifecycle listener %s\n",
+            descriptor->symbol);
+        return FALSE;
+    }
+    GumAttachReturn result = peak_cuda_attach_capture_entry(target, listener);
+    if (result != GUM_ATTACH_OK) {
+        peak_log_warn(
+            "[peak] could not install CUDA capture lifecycle listener %s (status %d)\n",
+            descriptor->symbol, (int)result);
+        g_object_unref(listener);
+        return FALSE;
+    }
+    peak_cuda_capture_hooks[index] = target;
+    peak_cuda_capture_listeners[index] = listener;
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_install_direct_capture_hook(
+    gpointer entry, const char* symbol,
+    PeakCudaCaptureOperation operation)
+{
+    for (size_t index = 0; index < PEAK_CUDA_CAPTURE_HOOK_COUNT;
+         ++index) {
+        if (reinterpret_cast<gpointer>(peak_cuda_capture_hooks[index]) !=
+            entry) {
+            continue;
+        }
+        return peak_cuda_capture_descriptors[index].operation == operation;
+    }
+    for (size_t index = 0;
+         index < peak_cuda_direct_capture_hook_count;
+         ++index) {
+        if (peak_cuda_direct_capture_hooks[index] != entry) {
+            continue;
+        }
+        return peak_cuda_direct_capture_descriptors[index].operation ==
+            operation;
+    }
+    if (peak_cuda_direct_capture_hook_count >=
+        kPeakCudaDirectCaptureHookCapacity) {
+        return FALSE;
+    }
+
+    size_t index = peak_cuda_direct_capture_hook_count;
+    PeakCudaCaptureHookDescriptor* descriptor =
+        &peak_cuda_direct_capture_descriptors[index];
+    *descriptor = {symbol, PEAK_CUDA_CAPTURE_API_DRIVER, operation};
+    GumInvocationListener* listener = gum_make_call_listener(
+        peak_cuda_capture_listener_on_enter,
+        peak_cuda_capture_listener_on_leave,
+        descriptor,
+        NULL);
+    if (listener == NULL) {
+        *descriptor = {};
+        return FALSE;
+    }
+    GumAttachReturn result = peak_cuda_attach_capture_entry(entry, listener);
+    if (result != GUM_ATTACH_OK) {
+        g_object_unref(listener);
+        *descriptor = {};
+        return FALSE;
+    }
+    peak_cuda_direct_capture_hooks[index] = entry;
+    peak_cuda_direct_capture_listeners[index] = listener;
+    ++peak_cuda_direct_capture_hook_count;
+    return TRUE;
+}
+
+static gboolean
+peak_cuda_capture_entry_point_census(gboolean* available_out)
+{
+    struct PeakCudaCaptureQuery {
+        const char* symbol;
+        int introduction_version;
+        PeakCudaCaptureOperation operation;
+        gboolean requires_v2;
+    };
+    static const PeakCudaCaptureQuery queries[] = {
+        {"cuStreamBeginCapture", 10000,
+         PEAK_CUDA_CAPTURE_OPERATION_BEGIN, FALSE},
+        {"cuStreamBeginCapture", 10010,
+         PEAK_CUDA_CAPTURE_OPERATION_BEGIN, FALSE},
+        {"cuStreamEndCapture", 10000,
+         PEAK_CUDA_CAPTURE_OPERATION_END, FALSE},
+        {"cuStreamBeginCaptureToGraph", 12030,
+         PEAK_CUDA_CAPTURE_OPERATION_BEGIN, TRUE},
+        {"cuStreamBeginCaptureToCig", 13010,
+         PEAK_CUDA_CAPTURE_OPERATION_BEGIN, TRUE},
+        {"cuStreamEndCaptureToCig", 13010,
+         PEAK_CUDA_CAPTURE_OPERATION_END, TRUE},
+        {"cuStreamBeginRecaptureToGraph", 13030,
+         PEAK_CUDA_CAPTURE_OPERATION_BEGIN, TRUE},
+    };
+    static const unsigned long long flags[] = {0, 1, 2};
+    typedef CUresult (*PeakCuDriverGetVersionFn)(int* version);
+
+    *available_out = FALSE;
+    if (peak_cuda_backend_api.driver_handle == NULL) {
+        return TRUE;
+    }
+    PeakCuGetProcAddressV2Fn get_v2 =
+        reinterpret_cast<PeakCuGetProcAddressV2Fn>(dlsym(
+            peak_cuda_backend_api.driver_handle,
+            "cuGetProcAddress_v2"));
+    PeakCuGetProcAddressFn get_v1 =
+        reinterpret_cast<PeakCuGetProcAddressFn>(dlsym(
+            peak_cuda_backend_api.driver_handle,
+            "cuGetProcAddress"));
+    if (get_v2 == NULL && get_v1 == NULL) {
+        return TRUE;
+    }
+    *available_out = TRUE;
+    PeakCuDriverGetVersionFn get_driver_version =
+        reinterpret_cast<PeakCuDriverGetVersionFn>(dlsym(
+            peak_cuda_backend_api.driver_handle,
+            "cuDriverGetVersion"));
+    int driver_version = 0;
+    if (get_driver_version == NULL ||
+        get_driver_version(&driver_version) != CUDA_SUCCESS ||
+        driver_version <= 0) {
+        peak_log_warn(
+            "[peak] could not determine the CUDA Driver version for capture entry-point validation; CUDA timing remains disabled\n");
+        return FALSE;
+    }
+    gboolean begin_covered = FALSE;
+    gboolean end_covered = FALSE;
+
+    for (const PeakCudaCaptureQuery& query : queries) {
+        if (query.introduction_version > driver_version) {
+            continue;
+        }
+        if (get_v2 == NULL && query.requires_v2) {
+            continue;
+        }
+        int versions[] = {query.introduction_version, driver_version};
+        for (size_t version_index = 0;
+             version_index < G_N_ELEMENTS(versions);
+             ++version_index) {
+            if (version_index != 0 &&
+                versions[version_index] == versions[0]) {
+                continue;
+            }
+            for (unsigned long long flag : flags) {
+                void* entry = NULL;
+                CUresult result;
+                int symbol_status = 0;
+                if (get_v2 != NULL) {
+                    result = get_v2(query.symbol, &entry,
+                                    versions[version_index], flag,
+                                    &symbol_status);
+                } else {
+                    result = get_v1(query.symbol, &entry,
+                                    versions[version_index], flag);
+                }
+                if (result != CUDA_SUCCESS) {
+                    peak_log_warn(
+                        "[peak] CUDA capture entry-point query failed for %s version=%d flags=%llu status=%d; CUDA timing remains disabled\n",
+                        query.symbol, versions[version_index], flag,
+                        (int)result);
+                    return FALSE;
+                }
+                if (entry == NULL) {
+                    if (get_v2 != NULL && symbol_status != 0 &&
+                        symbol_status != 1 && symbol_status != 2) {
+                        peak_log_warn(
+                            "[peak] CUDA capture entry-point query returned an unknown symbol status for %s; CUDA timing remains disabled\n",
+                            query.symbol);
+                        return FALSE;
+                    }
+                    if (get_v2 == NULL || symbol_status == 0) {
+                        peak_log_warn(
+                            "[peak] CUDA capture entry-point query returned no pointer for %s; CUDA timing remains disabled\n",
+                            query.symbol);
+                        return FALSE;
+                    }
+                    continue;
+                }
+                if ((get_v2 != NULL && symbol_status != 0) ||
+                    (!peak_cuda_capture_entry_point_is_covered(
+                         entry, query.operation) &&
+                     !peak_cuda_install_direct_capture_hook(
+                         entry, query.symbol, query.operation))) {
+                    peak_log_warn(
+                        "[peak] CUDA capture entry-point query returned an uninstrumented pointer for %s version=%d flags=%llu; CUDA timing remains disabled\n",
+                        query.symbol, versions[version_index], flag);
+                    return FALSE;
+                }
+                if (query.operation ==
+                    PEAK_CUDA_CAPTURE_OPERATION_BEGIN) {
+                    begin_covered = TRUE;
+                } else {
+                    end_covered = TRUE;
+                }
+            }
+        }
+    }
+    if (!begin_covered || !end_covered) {
+        peak_log_warn(
+            "[peak] CUDA capture entry-point census did not cover both begin and end operations; CUDA timing remains disabled\n");
+        return FALSE;
+    }
+    return TRUE;
 }
 
 extern "C" int cuda_interceptor_attach()
 {
     std::lock_guard<std::mutex> lifecycle_lock(peak_cuda_lifecycle_mutex);
-    peak_cuda_accepting_events.store(false, std::memory_order_release);
-    cuda_kernel_local_dim_mapping = g_hash_table_new_full(g_str_hash, str_equal_function, NULL, g_free);
+    if (!peak_cuda_timing_requested()) {
+        return GUM_REPLACE_OK;
+    }
+    if (cuda_kernel_local_dim_mapping != NULL ||
+        cuda_graph_local_mapping != NULL ||
+        peak_cuda_harvester_started.load(std::memory_order_acquire) ||
+        peak_cuda_finalization_timed_out) {
+        peak_log_warn(
+            "[peak] refusing to reinitialize active or retained CUDA profiler state\n");
+        return -1;
+    }
+    peak_cuda_lifecycle_close();
+    peak_cuda_accepting_events.store(false, std::memory_order_seq_cst);
+    peak_cuda_stop_harvester();
+    if (!peak_cuda_destroy_event_pool()) {
+        return -1;
+    }
+    cuda_kernel_local_dim_mapping = g_hash_table_new_full(
+        g_str_hash, str_equal_function, g_free, g_free);
     g_mutex_init(&cuda_kernel_local_dim_mapping_mutex);
-    cuda_graph_local_mapping = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free);
+    cuda_graph_local_mapping = g_hash_table_new_full(
+        peak_cuda_graph_key_hash, peak_cuda_graph_key_equal, g_free, g_free);
     g_mutex_init(&cuda_graph_local_mapping_mutex);
 
     GumReplaceReturn replace_check = GUM_REPLACE_OK;
     GumReplaceReturn hook_replace_check = GUM_REPLACE_OK;
+    gboolean capture_hook_present[PEAK_CUDA_CAPTURE_HOOK_COUNT] = {};
+    gboolean runtime_capture_hook_install_failed = FALSE;
+    gboolean driver_capture_hook_install_failed = FALSE;
     if (cuda_interceptor == NULL) {
         cuda_interceptor = gum_interceptor_obtain();
     }
     peak_cuda_hooks_reverted = FALSE;
     peak_cuda_clear_hook_pointers();
-
-    gum_interceptor_begin_transaction(cuda_interceptor);
-
-    peak_cuda_destroy_event_pool();
     peak_cuda_event_pool_capacity = peak_cuda_parse_event_pool_capacity();
+    peak_cuda_graph_identity_capacity = peak_cuda_event_pool_capacity * 4;
+    peak_cuda_finalization_timeout_ms =
+        peak_cuda_parse_finalization_timeout_ms();
     peak_cuda_profiler_state.reset(peak_cuda_event_pool_capacity,
                                    peak_cuda_event_pool_capacity * 4);
-    {
-        std::lock_guard<std::mutex> event_lock(peak_cuda_event_pool_mutex);
-        peak_cuda_event_pool.reserve(peak_cuda_event_pool_capacity);
-        peak_cuda_free_event_slots.reserve(peak_cuda_event_pool_capacity);
-        for (size_t i = 0; i < peak_cuda_event_pool_capacity; ++i) {
-            peak_cuda_event_pool.push_back({NULL, NULL, FALSE, FALSE});
-            peak_cuda_free_event_slots.push_back(i);
-        }
+    peak_cuda_identity_epoch.fetch_add(1, std::memory_order_acq_rel);
+    peak_cuda_slot_allocator.reset(peak_cuda_event_pool_capacity);
+    peak_cuda_pending_queue.reset(peak_cuda_event_pool_capacity);
+    peak_cuda_event_pool.assign(peak_cuda_event_pool_capacity, {});
+    pthread_mutex_lock(&peak_cuda_capture_mutex);
+    peak_cuda_active_captures.assign(
+        kPeakCudaCaptureRegistryCapacity, {});
+    peak_cuda_capture_transitions = 0;
+    peak_cuda_capture_tracking_terminal.store(
+        false, std::memory_order_release);
+    peak_cuda_capture_blocked.store(false, std::memory_order_seq_cst);
+    for (PeakCudaTimingShard& shard : peak_cuda_timing_shards) {
+        shard.active.store(0, std::memory_order_relaxed);
     }
+    pthread_mutex_unlock(&peak_cuda_capture_mutex);
+    peak_cuda_finalization_complete = FALSE;
+    peak_cuda_finalization_timed_out = FALSE;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_cuda_test_force_incomplete.store(false, std::memory_order_relaxed);
+    peak_cuda_test_force_query_error.store(false,
+                                           std::memory_order_relaxed);
+    peak_cuda_test_harvester_queries.store(
+        0, std::memory_order_relaxed);
+    peak_cuda_test_pause_capture_begin_flag.store(
+        false, std::memory_order_relaxed);
+    peak_cuda_test_capture_begin_waiting_flag.store(
+        false, std::memory_order_relaxed);
+    peak_cuda_test_pause_cuda_section_flag.store(
+        false, std::memory_order_relaxed);
+    peak_cuda_test_cuda_sections_waiting_count.store(
+        0, std::memory_order_relaxed);
+    peak_cuda_test_pause_lifecycle_before_increment_flag.store(
+        false, std::memory_order_relaxed);
+    peak_cuda_test_lifecycle_before_increment_waiting_count.store(
+        0, std::memory_order_relaxed);
+    peak_cuda_test_pause_lifecycle_after_admission_flag.store(
+        false, std::memory_order_relaxed);
+    peak_cuda_test_lifecycle_after_admission_waiting_count.store(
+        0, std::memory_order_relaxed);
+#endif
+    /* Publish immutable Driver entry points before any replacement wrapper can
+     * run. GPU timing was explicitly requested, so this attach-time lookup is
+     * never paid by CPU-only profiling. */
+    peak_cuda_resolve_backend_api();
+    gboolean driver_typed_replacements_are_isolated =
+        peak_cuda_driver_typed_replacements_are_isolated();
+    if (!driver_typed_replacements_are_isolated) {
+        peak_log_warn(
+            "[peak] CUDA Driver exports share an ABI-generic dispatcher; Driver launch timing remains disabled\n");
+    }
+    gum_interceptor_begin_transaction(cuda_interceptor);
 
     hook_cuda_launch =
         (gpointer*) peak_general_listener_find_function("cudaLaunchKernel");
@@ -1119,8 +3315,9 @@ extern "C" int cuda_interceptor_attach()
         }
     }
 
-    hook_cu_launch =
-        (gpointer*) peak_general_listener_find_function("cuLaunchKernel");
+    hook_cu_launch = driver_typed_replacements_are_isolated
+        ? (gpointer*) peak_general_listener_find_function("cuLaunchKernel")
+        : NULL;
     if (hook_cu_launch) {
         hook_replace_check = gum_interceptor_replace_fast(
             cuda_interceptor, hook_cu_launch,
@@ -1135,8 +3332,10 @@ extern "C" int cuda_interceptor_attach()
         }
     }
 
-    hook_cu_launch_cooperative =
-        (gpointer*) peak_general_listener_find_function("cuLaunchCooperativeKernel");
+    hook_cu_launch_cooperative = driver_typed_replacements_are_isolated
+        ? (gpointer*) peak_general_listener_find_function(
+            "cuLaunchCooperativeKernel")
+        : NULL;
     if (hook_cu_launch_cooperative) {
         hook_replace_check = gum_interceptor_replace_fast(
             cuda_interceptor, hook_cu_launch_cooperative,
@@ -1152,7 +3351,10 @@ extern "C" int cuda_interceptor_attach()
     }
 
     hook_cu_launch_cooperative_multiple_device =
-        (gpointer*) peak_general_listener_find_function("cuLaunchCooperativeKernelMultiDevice");
+        driver_typed_replacements_are_isolated
+            ? (gpointer*) peak_general_listener_find_function(
+                "cuLaunchCooperativeKernelMultiDevice")
+            : NULL;
     if (hook_cu_launch_cooperative_multiple_device) {
         hook_replace_check = gum_interceptor_replace_fast(
             cuda_interceptor, hook_cu_launch_cooperative_multiple_device,
@@ -1167,8 +3369,9 @@ extern "C" int cuda_interceptor_attach()
         }
     }
 
-    hook_cu_launch_ex =
-        (gpointer*) peak_general_listener_find_function("cuLaunchKernelEx");
+    hook_cu_launch_ex = driver_typed_replacements_are_isolated
+        ? (gpointer*) peak_general_listener_find_function("cuLaunchKernelEx")
+        : NULL;
     if (hook_cu_launch_ex) {
         hook_replace_check = gum_interceptor_replace_fast(
             cuda_interceptor, hook_cu_launch_ex,
@@ -1199,8 +3402,9 @@ extern "C" int cuda_interceptor_attach()
         }
     }
 
-    hook_cu_graph_launch =
-        (gpointer*) peak_general_listener_find_function("cuGraphLaunch");
+    hook_cu_graph_launch = driver_typed_replacements_are_isolated
+        ? (gpointer*) peak_general_listener_find_function("cuGraphLaunch")
+        : NULL;
     if (hook_cu_graph_launch) {
         hook_replace_check = gum_interceptor_replace_fast(
             cuda_interceptor, hook_cu_graph_launch,
@@ -1215,8 +3419,134 @@ extern "C" int cuda_interceptor_attach()
         }
     }
 
+    /* Each Runtime launch reaches its corresponding typed Driver entry point.
+     * Keep one timing replacement for every pair that is independently
+     * available, while retaining the Runtime replacement for any missing
+     * Driver entry instead of making unrelated legacy APIs block the fast
+     * path. */
+    if (driver_typed_replacements_are_isolated) {
+        if (hook_cuda_launch != NULL && hook_cu_launch != NULL) {
+            gum_interceptor_revert(cuda_interceptor, hook_cuda_launch);
+            hook_cuda_launch = NULL;
+        }
+        if (hook_cuda_launch_cooperative != NULL &&
+            hook_cu_launch_cooperative != NULL) {
+            gum_interceptor_revert(cuda_interceptor,
+                                   hook_cuda_launch_cooperative);
+            hook_cuda_launch_cooperative = NULL;
+        }
+        if (hook_cuda_launch_cooperative_multiple_device != NULL &&
+            hook_cu_launch_cooperative_multiple_device != NULL) {
+            gum_interceptor_revert(
+                cuda_interceptor,
+                hook_cuda_launch_cooperative_multiple_device);
+            hook_cuda_launch_cooperative_multiple_device = NULL;
+        }
+        if (hook_cuda_launch_exc != NULL && hook_cu_launch_ex != NULL) {
+            gum_interceptor_revert(cuda_interceptor, hook_cuda_launch_exc);
+            hook_cuda_launch_exc = NULL;
+        }
+        if (hook_cuda_graph_launch != NULL &&
+            hook_cu_graph_launch != NULL) {
+            gum_interceptor_revert(cuda_interceptor,
+                                   hook_cuda_graph_launch);
+            hook_cuda_graph_launch = NULL;
+        }
+    }
+
+    for (size_t hook_index = 0;
+         hook_index < PEAK_CUDA_CAPTURE_HOOK_COUNT;
+         ++hook_index) {
+        PeakCudaCaptureHookIndex index =
+            static_cast<PeakCudaCaptureHookIndex>(hook_index);
+        if (!driver_typed_replacements_are_isolated &&
+            peak_cuda_capture_descriptors[index].api ==
+                PEAK_CUDA_CAPTURE_API_DRIVER) {
+            continue;
+        }
+        gboolean present = FALSE;
+        gboolean installed = peak_cuda_install_capture_hook(
+            index, &present);
+        capture_hook_present[index] = present;
+        if (present && !installed) {
+            if (peak_cuda_capture_descriptors[index].api ==
+                PEAK_CUDA_CAPTURE_API_RUNTIME) {
+                runtime_capture_hook_install_failed = TRUE;
+            } else {
+                driver_capture_hook_install_failed = TRUE;
+            }
+        }
+    }
+
+    gboolean runtime_timing_hook =
+        hook_cuda_launch != NULL ||
+        hook_cuda_launch_cooperative != NULL ||
+        hook_cuda_launch_exc != NULL ||
+        hook_cuda_graph_launch != NULL;
+    gboolean driver_timing_hook =
+        hook_cu_launch != NULL ||
+        hook_cu_launch_cooperative != NULL ||
+        hook_cu_launch_ex != NULL ||
+        hook_cu_graph_launch != NULL;
+    gboolean runtime_capture_required_ready =
+        peak_cuda_capture_hooks[PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE] != NULL &&
+        peak_cuda_capture_hooks[
+            PEAK_CUDA_HOOK_RUNTIME_BEGIN_CAPTURE_PTSZ] != NULL &&
+        peak_cuda_capture_hooks[PEAK_CUDA_HOOK_RUNTIME_END_CAPTURE] != NULL &&
+        peak_cuda_capture_hooks[
+            PEAK_CUDA_HOOK_RUNTIME_END_CAPTURE_PTSZ] != NULL;
+    gboolean driver_capture_required_ready =
+        peak_cuda_capture_hooks[
+            PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V2] != NULL &&
+        peak_cuda_capture_hooks[
+            PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_V2_PTSZ] != NULL &&
+        peak_cuda_capture_hooks[PEAK_CUDA_HOOK_DRIVER_END_CAPTURE] != NULL &&
+        peak_cuda_capture_hooks[
+            PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_PTSZ] != NULL;
+    gboolean cig_pairs_ready =
+        capture_hook_present[
+            PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_CIG] ==
+            capture_hook_present[
+                PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_TO_CIG] &&
+        capture_hook_present[
+            PEAK_CUDA_HOOK_DRIVER_BEGIN_CAPTURE_TO_CIG_PTSZ] ==
+            capture_hook_present[
+                PEAK_CUDA_HOOK_DRIVER_END_CAPTURE_TO_CIG_PTSZ];
+    gboolean any_timing_hook = runtime_timing_hook || driver_timing_hook;
+    gboolean capture_entry_point_census_available = FALSE;
+    gboolean capture_entry_points_ready = !any_timing_hook ||
+        peak_cuda_capture_entry_point_census(
+            &capture_entry_point_census_available);
+    if (capture_entry_point_census_available &&
+        capture_entry_points_ready) {
+        driver_capture_required_ready = TRUE;
+    }
+    if (!capture_entry_points_ready) {
+        peak_cuda_profiler_state.record_capture_query_unsupported();
+    }
+    peak_cuda_capture_hooks_ready = !any_timing_hook ||
+        (runtime_capture_required_ready &&
+         driver_capture_required_ready && cig_pairs_ready &&
+         capture_entry_points_ready &&
+         !runtime_capture_hook_install_failed &&
+         !driver_capture_hook_install_failed);
+
+    peak_cuda_lifecycle_open();
     gum_interceptor_end_transaction(cuda_interceptor);
-    peak_cuda_accepting_events.store(true, std::memory_order_release);
+    if (peak_cuda_has_timed_hook() && peak_cuda_capture_hooks_ready) {
+        (void)peak_cuda_start_harvester();
+    } else if (peak_cuda_has_timed_hook()) {
+        peak_cuda_harvester_initialization_terminal.store(
+            true, std::memory_order_release);
+        peak_log_warn(
+            "[peak] CUDA capture lifecycle interception is incomplete (runtime=%d driver=%d optional_pairs=%d entry_points=%d runtime_failure=%d driver_failure=%d); CUDA timing remains disabled\n",
+            (int)runtime_capture_required_ready,
+            (int)driver_capture_required_ready,
+            (int)cig_pairs_ready,
+            (int)capture_entry_points_ready,
+            (int)runtime_capture_hook_install_failed,
+            (int)driver_capture_hook_install_failed);
+    }
 
     return replace_check;
 }
@@ -1228,7 +3558,8 @@ extern "C" void cuda_interceptor_dettach()
         return;
     }
 
-    peak_cuda_accepting_events.store(false, std::memory_order_release);
+    peak_cuda_lifecycle_close();
+    peak_cuda_disable_harvester_initialization();
     if (!peak_cuda_hooks_reverted) {
         gum_interceptor_begin_transaction(cuda_interceptor);
         if (hook_cuda_launch) {
@@ -1261,6 +3592,22 @@ extern "C" void cuda_interceptor_dettach()
         if (hook_cu_graph_launch) {
             gum_interceptor_revert(cuda_interceptor, hook_cu_graph_launch);
         }
+        for (size_t index = 0; index < PEAK_CUDA_CAPTURE_HOOK_COUNT;
+             ++index) {
+            if (peak_cuda_capture_listeners[index] != NULL) {
+                gum_interceptor_detach(
+                    cuda_interceptor, peak_cuda_capture_listeners[index]);
+            }
+        }
+        for (size_t index = 0;
+             index < peak_cuda_direct_capture_hook_count;
+             ++index) {
+            if (peak_cuda_direct_capture_listeners[index] != NULL) {
+                gum_interceptor_detach(
+                    cuda_interceptor,
+                    peak_cuda_direct_capture_listeners[index]);
+            }
+        }
         gum_interceptor_end_transaction(cuda_interceptor);
 
         if (!gum_interceptor_flush(cuda_interceptor)) {
@@ -1272,7 +3619,7 @@ extern "C" void cuda_interceptor_dettach()
         peak_cuda_clear_hook_pointers();
     }
 
-    unsigned int active_cuda_wrappers = peak_cuda_in_flight.load(std::memory_order_acquire);
+    unsigned int active_cuda_wrappers = peak_cuda_active_wrapper_count();
     if (active_cuda_wrappers != 0) {
         peak_log_warn("[peak] CUDA interceptor teardown observed %u active wrapper(s); keeping all CUDA state alive for cleanup retry\n",
                    active_cuda_wrappers);
@@ -1284,10 +3631,14 @@ extern "C" void cuda_interceptor_dettach()
         return;
     }
 
-    peak_cuda_drain_kernel_event_map(FALSE);
-    peak_cuda_drain_graph_event_map(FALSE);
-
-    peak_cuda_destroy_event_pool();
+    peak_cuda_finalize_pending();
+    if (peak_cuda_finalization_timed_out) {
+        peak_log_warn("[peak] retaining CUDA interceptor state after bounded finalization timeout\n");
+        return;
+    }
+    if (!peak_cuda_destroy_event_pool()) {
+        return;
+    }
 
     if (cuda_kernel_local_dim_mapping != NULL) {
         g_hash_table_destroy(cuda_kernel_local_dim_mapping);
@@ -1313,6 +3664,7 @@ static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
     GHashTableIter iter;
     gpointer key, value;
 
+    g_mutex_lock(&cuda_graph_local_mapping_mutex);
     g_hash_table_iter_init(&iter, hashTable);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
         GraphRecordInfo* graph_info = (GraphRecordInfo*) value;
@@ -1345,7 +3697,9 @@ static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
             (row_width - 26) / 2, "",
             (row_width - 26 + 1) / 2, "");
         peak_log_report("%s\n", row_separator);
-        peak_log_report("| %*s | %*s | %*s | %*s | %*s |\n",
+        peak_log_report("| %*s | %*s | %*s | %*s | %*s | %*s | %*s |\n",
+            max_col_width, "Context",
+            max_col_width, "Device",
             max_col_width, "Graph",
             max_col_width, "Calls",
             max_col_width, "Total(s)",
@@ -1355,10 +3709,14 @@ static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
 
         g_hash_table_iter_init(&iter, hashTable);
         while (g_hash_table_iter_next(&iter, &key, &value)) {
+            PeakCudaGraphKey* graph_key = (PeakCudaGraphKey*) key;
             GraphRecordInfo* graph_info = (GraphRecordInfo*) value;
-            peak_log_report("| %p | %*lu | %*.6f | %*.6f | %*.6f |\n",
-                key,
-                max_col_width, graph_info->total_graph_call_cnt,
+            peak_log_report("| %p | %*d | %p | %*" G_GUINT64_FORMAT
+                            " | %*.6f | %*.6f | %*.6f |\n",
+                reinterpret_cast<void*>(graph_key->context),
+                max_col_width, graph_info->device,
+                reinterpret_cast<void*>(graph_key->graph),
+                max_col_width, (guint64)graph_info->total_graph_call_cnt,
                 max_col_width, graph_info->total_time,
                 max_col_width, graph_info->max_time,
                 max_col_width, graph_info->min_time);
@@ -1368,17 +3726,13 @@ static void cuda_interceptor_print_graph_result(GHashTable* hashTable)
         free(space_separator);
         free(row_separator);
     }
-}
-
-static void cuda_sync_kernel_event() {
-    cudaDeviceSynchronize();
-    peak_cuda_drain_kernel_event_map(TRUE);
-    peak_cuda_drain_graph_event_map(TRUE);
+    g_mutex_unlock(&cuda_graph_local_mapping_mutex);
 }
 
 static PeakReportSnapshot*
 peak_cuda_build_report_snapshot()
 {
+    static constexpr size_t kCounterCount = 21;
     std::vector<std::pair<std::string, KernelDimInfo>> kernels;
     PeakReportSnapshot* snapshot;
     size_t index = 0;
@@ -1396,10 +3750,11 @@ peak_cuda_build_report_snapshot()
               [](const auto& left, const auto& right) {
                   return left.first < right.first;
               });
-    if (kernels.size() > (SIZE_MAX - 4) / 4) {
+    if (kernels.size() > (SIZE_MAX - kCounterCount) / 4) {
         return NULL;
     }
-    snapshot = peak_report_snapshot_create(kernels.size() * 4 + 4);
+    snapshot = peak_report_snapshot_create(
+        kernels.size() * 4 + kCounterCount);
     if (snapshot == NULL || !peak_report_snapshot_set_program(snapshot, "CUDA")) {
         peak_report_snapshot_destroy(snapshot);
         return NULL;
@@ -1422,36 +3777,82 @@ peak_cuda_build_report_snapshot()
             snapshot->instrumented[index++] = 1;
         }
         index -= 4;
-        snapshot->num_calls[index] = info.total_kernel_call_cnt;
+        snapshot->num_calls[index] = (unsigned long)std::min<std::uint64_t>(
+            info.total_kernel_call_cnt, ULONG_MAX);
         snapshot->total_time[index] = info.total_time;
         snapshot->max_total_time[index] = info.max_time;
         snapshot->min_total_time[index++] = info.min_time;
-        snapshot->num_calls[index] = info.total_gpu_threads;
+        snapshot->num_calls[index] = (unsigned long)std::min<std::uint64_t>(
+            info.total_gpu_threads, ULONG_MAX);
         snapshot->max_total_time[index] = (double)info.max_gpu_threads;
         snapshot->min_total_time[index++] = (double)info.min_gpu_threads;
-        snapshot->num_calls[index] = info.total_block_size;
+        snapshot->num_calls[index] = (unsigned long)std::min<std::uint64_t>(
+            info.total_block_size, ULONG_MAX);
         snapshot->max_total_time[index] = (double)info.max_block_size;
         snapshot->min_total_time[index++] = (double)info.min_block_size;
-        snapshot->num_calls[index] = info.total_grid_size;
+        snapshot->num_calls[index] = (unsigned long)std::min<std::uint64_t>(
+            info.total_grid_size, ULONG_MAX);
         snapshot->max_total_time[index] = (double)info.max_grid_size;
         snapshot->min_total_time[index++] = (double)info.min_grid_size;
     }
     PeakCudaProfilerCounters counters = peak_cuda_profiler_state.counters();
-    const gchar* drops[] = {"CUDA profiler drops [pool_full]",
-                            "CUDA profiler drops [identity_full]",
-                            "CUDA profiler drops [event_create]",
-                            "CUDA profiler drops [timing_error]"};
-    const guint64 values[] = {counters.dropped_pool_full,
-                              counters.dropped_identity_full,
-                              counters.dropped_event_create,
-                              counters.dropped_timing_error};
-    for (size_t drop = 0; drop < G_N_ELEMENTS(drops); ++drop) {
-        if (!peak_report_snapshot_set_name(snapshot, index, drops[drop])) {
+    PeakCudaSlotAllocatorCounters slots = peak_cuda_slot_allocator.counters();
+    const gchar* counter_names[kCounterCount] = {
+        "CUDA profiler counter [observed]",
+        "CUDA profiler counter [accepted]",
+        "CUDA profiler counter [completed]",
+        "CUDA profiler counter [pool_high_water]",
+        "CUDA profiler counter [pool_full]",
+        "CUDA profiler counter [identity_full]",
+        "CUDA profiler counter [event_create_failed]",
+        "CUDA profiler counter [timing_error]",
+        "CUDA profiler counter [harvester_unavailable]",
+        "CUDA profiler counter [stream_capture_skipped]",
+        "CUDA profiler counter [capture_query_failed]",
+        "CUDA profiler counter [capture_query_unsupported]",
+        "CUDA profiler counter [unsupported_multi_device]",
+        "CUDA profiler counter [event_query_failed]",
+        "CUDA profiler counter [elapsed_failed]",
+        "CUDA profiler counter [context_query_failed]",
+        "CUDA profiler counter [context_switch_failed]",
+        "CUDA profiler counter [context_restore_failed]",
+        "CUDA profiler counter [finalization_timeout]",
+        "CUDA profiler counter [finalization_incomplete]",
+        "CUDA profiler counter [dimension_overflow]",
+    };
+    const std::uint64_t counter_values[kCounterCount] = {
+        counters.observed_launches,
+        counters.accepted_launches,
+        counters.completed_launches,
+        slots.high_water_slots,
+        counters.dropped_pool_full,
+        counters.dropped_identity_full,
+        counters.dropped_event_create,
+        counters.dropped_timing_error,
+        counters.dropped_harvester_unavailable,
+        counters.dropped_stream_capture,
+        counters.dropped_capture_query,
+        counters.dropped_capture_query_unsupported,
+        counters.dropped_unsupported_multi_device,
+        counters.dropped_event_query,
+        counters.dropped_elapsed_time,
+        counters.dropped_context_query,
+        counters.dropped_context_switch,
+        counters.dropped_context_restore,
+        counters.finalization_timeouts,
+        counters.finalization_incomplete,
+        counters.dropped_dimension_overflow,
+    };
+    for (size_t counter = 0; counter < kCounterCount; ++counter) {
+        if (!peak_report_snapshot_set_name(
+                snapshot, index, counter_names[counter])) {
             peak_report_snapshot_destroy(snapshot);
             return NULL;
         }
         snapshot->instrumented[index] = 1;
-        snapshot->num_calls[index++] = (gulong)values[drop];
+        snapshot->num_calls[index++] =
+            (unsigned long)std::min<std::uint64_t>(
+                counter_values[counter], ULONG_MAX);
     }
     return snapshot;
 }
@@ -1462,7 +3863,54 @@ peak_cuda_render_report_snapshot(const PeakReportSnapshot* snapshot)
     const size_t prefix_length = strlen("CUDA kernel: ");
     const size_t suffix_length = strlen(" [time]");
     gboolean have_output = FALSE;
-    guint64 drops[4] = {0, 0, 0, 0};
+    enum PeakCudaReportCounter {
+        PEAK_CUDA_COUNTER_OBSERVED = 0,
+        PEAK_CUDA_COUNTER_ACCEPTED,
+        PEAK_CUDA_COUNTER_COMPLETED,
+        PEAK_CUDA_COUNTER_POOL_HIGH_WATER,
+        PEAK_CUDA_COUNTER_POOL_FULL,
+        PEAK_CUDA_COUNTER_IDENTITY_FULL,
+        PEAK_CUDA_COUNTER_EVENT_CREATE_FAILED,
+        PEAK_CUDA_COUNTER_TIMING_ERROR,
+        PEAK_CUDA_COUNTER_HARVESTER_UNAVAILABLE,
+        PEAK_CUDA_COUNTER_STREAM_CAPTURE_SKIPPED,
+        PEAK_CUDA_COUNTER_CAPTURE_QUERY_FAILED,
+        PEAK_CUDA_COUNTER_CAPTURE_QUERY_UNSUPPORTED,
+        PEAK_CUDA_COUNTER_UNSUPPORTED_MULTI_DEVICE,
+        PEAK_CUDA_COUNTER_EVENT_QUERY_FAILED,
+        PEAK_CUDA_COUNTER_ELAPSED_FAILED,
+        PEAK_CUDA_COUNTER_CONTEXT_QUERY_FAILED,
+        PEAK_CUDA_COUNTER_CONTEXT_SWITCH_FAILED,
+        PEAK_CUDA_COUNTER_CONTEXT_RESTORE_FAILED,
+        PEAK_CUDA_COUNTER_FINALIZATION_TIMEOUT,
+        PEAK_CUDA_COUNTER_FINALIZATION_INCOMPLETE,
+        PEAK_CUDA_COUNTER_DIMENSION_OVERFLOW,
+        PEAK_CUDA_COUNTER_COUNT,
+    };
+    const gchar* counter_suffixes[PEAK_CUDA_COUNTER_COUNT] = {
+        "[observed]",
+        "[accepted]",
+        "[completed]",
+        "[pool_high_water]",
+        "[pool_full]",
+        "[identity_full]",
+        "[event_create_failed]",
+        "[timing_error]",
+        "[harvester_unavailable]",
+        "[stream_capture_skipped]",
+        "[capture_query_failed]",
+        "[capture_query_unsupported]",
+        "[unsupported_multi_device]",
+        "[event_query_failed]",
+        "[elapsed_failed]",
+        "[context_query_failed]",
+        "[context_switch_failed]",
+        "[context_restore_failed]",
+        "[finalization_timeout]",
+        "[finalization_incomplete]",
+        "[dimension_overflow]",
+    };
+    guint64 counters[PEAK_CUDA_COUNTER_COUNT] = {};
 
     if (snapshot == NULL) {
         return FALSE;
@@ -1497,23 +3945,182 @@ peak_cuda_render_report_snapshot(const PeakReportSnapshot* snapshot)
     }
     for (size_t i = 0; i < snapshot->hook_count; ++i) {
         const gchar* name = snapshot->names[i];
-        if (name == NULL) continue;
-        for (size_t drop = 0; drop < G_N_ELEMENTS(drops); ++drop) {
-            const gchar* suffixes[] = {"[pool_full]", "[identity_full]",
-                                       "[event_create]", "[timing_error]"};
-            if (g_str_has_suffix(name, suffixes[drop])) {
-                drops[drop] = snapshot->num_calls[i];
+        if (name == NULL) {
+            continue;
+        }
+        for (size_t counter = 0; counter < PEAK_CUDA_COUNTER_COUNT;
+             ++counter) {
+            if (g_str_has_suffix(name, counter_suffixes[counter])) {
+                counters[counter] = snapshot->num_calls[i];
+                break;
             }
         }
     }
-    if (drops[0] != 0 || drops[1] != 0 || drops[2] != 0 || drops[3] != 0) {
-        peak_log_report("[peak] CUDA profiler drops: pool_full=%" G_GUINT64_FORMAT
-                        " identity_full=%" G_GUINT64_FORMAT " event_create=%"
-                        G_GUINT64_FORMAT " timing_error=%" G_GUINT64_FORMAT "\n",
-                        drops[0], drops[1], drops[2], drops[3]);
-    }
+    peak_log_report(
+        "[peak] CUDA profiler samples: observed=%" G_GUINT64_FORMAT
+        " accepted=%" G_GUINT64_FORMAT " completed=%" G_GUINT64_FORMAT
+        " pool_high_water=%" G_GUINT64_FORMAT "\n",
+        counters[PEAK_CUDA_COUNTER_OBSERVED],
+        counters[PEAK_CUDA_COUNTER_ACCEPTED],
+        counters[PEAK_CUDA_COUNTER_COMPLETED],
+        counters[PEAK_CUDA_COUNTER_POOL_HIGH_WATER]);
+    peak_log_report(
+        "[peak] CUDA profiler drops: pool_full=%" G_GUINT64_FORMAT
+        " identity_full=%" G_GUINT64_FORMAT
+        " event_create_failed=%" G_GUINT64_FORMAT
+        " timing_error=%" G_GUINT64_FORMAT
+        " harvester_unavailable=%" G_GUINT64_FORMAT
+        " stream_capture_skipped=%" G_GUINT64_FORMAT
+        " capture_query_failed=%" G_GUINT64_FORMAT
+        " capture_query_unsupported=%" G_GUINT64_FORMAT
+        " unsupported_multi_device=%" G_GUINT64_FORMAT
+        " event_query_failed=%" G_GUINT64_FORMAT
+        " elapsed_failed=%" G_GUINT64_FORMAT
+        " context_query_failed=%" G_GUINT64_FORMAT
+        " context_switch_failed=%" G_GUINT64_FORMAT
+        " context_restore_failed=%" G_GUINT64_FORMAT
+        " dimension_overflow=%" G_GUINT64_FORMAT "\n",
+        counters[PEAK_CUDA_COUNTER_POOL_FULL],
+        counters[PEAK_CUDA_COUNTER_IDENTITY_FULL],
+        counters[PEAK_CUDA_COUNTER_EVENT_CREATE_FAILED],
+        counters[PEAK_CUDA_COUNTER_TIMING_ERROR],
+        counters[PEAK_CUDA_COUNTER_HARVESTER_UNAVAILABLE],
+        counters[PEAK_CUDA_COUNTER_STREAM_CAPTURE_SKIPPED],
+        counters[PEAK_CUDA_COUNTER_CAPTURE_QUERY_FAILED],
+        counters[PEAK_CUDA_COUNTER_CAPTURE_QUERY_UNSUPPORTED],
+        counters[PEAK_CUDA_COUNTER_UNSUPPORTED_MULTI_DEVICE],
+        counters[PEAK_CUDA_COUNTER_EVENT_QUERY_FAILED],
+        counters[PEAK_CUDA_COUNTER_ELAPSED_FAILED],
+        counters[PEAK_CUDA_COUNTER_CONTEXT_QUERY_FAILED],
+        counters[PEAK_CUDA_COUNTER_CONTEXT_SWITCH_FAILED],
+        counters[PEAK_CUDA_COUNTER_CONTEXT_RESTORE_FAILED],
+        counters[PEAK_CUDA_COUNTER_DIMENSION_OVERFLOW]);
+    peak_log_report(
+        "[peak] CUDA profiler finalization: finalization_timeout=%"
+        G_GUINT64_FORMAT " finalization_incomplete=%" G_GUINT64_FORMAT "\n",
+        counters[PEAK_CUDA_COUNTER_FINALIZATION_TIMEOUT],
+        counters[PEAK_CUDA_COUNTER_FINALIZATION_INCOMPLETE]);
     return TRUE;
 }
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_force_incomplete_events(int enabled)
+{
+    peak_cuda_test_force_incomplete.store(
+        enabled != 0, std::memory_order_relaxed);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_force_query_error_once(int enabled)
+{
+    peak_cuda_test_force_query_error.store(
+        enabled != 0, std::memory_order_relaxed);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT unsigned long long
+peak_cuda_test_harvester_query_count(void)
+{
+    return peak_cuda_test_harvester_queries.load(
+        std::memory_order_relaxed);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT int
+peak_cuda_test_harvester_ready(void)
+{
+    return peak_cuda_accepting_events.load(std::memory_order_acquire) ? 1 : 0;
+}
+
+PEAK_CUDA_WRAPPER_EXPORT unsigned long long
+peak_cuda_test_active_slot_count(void)
+{
+    return peak_cuda_slot_allocator.active_count();
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_pause_capture_begin(int enabled)
+{
+    peak_cuda_test_pause_capture_begin_flag.store(
+        enabled != 0, std::memory_order_release);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT int
+peak_cuda_test_capture_begin_waiting(void)
+{
+    return peak_cuda_test_capture_begin_waiting_flag.load(
+               std::memory_order_acquire)
+        ? 1
+        : 0;
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_pause_cuda_section(int enabled)
+{
+    peak_cuda_test_pause_cuda_section_flag.store(
+        enabled != 0, std::memory_order_release);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT unsigned int
+peak_cuda_test_cuda_sections_waiting(void)
+{
+    return peak_cuda_test_cuda_sections_waiting_count.load(
+        std::memory_order_acquire);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT int
+peak_cuda_test_capture_blocked(void)
+{
+    return peak_cuda_capture_blocked.load(
+               std::memory_order_acquire)
+        ? 1
+        : 0;
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_pause_lifecycle_before_increment(int enabled)
+{
+    peak_cuda_test_pause_lifecycle_before_increment_flag.store(
+        enabled != 0, std::memory_order_release);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT unsigned int
+peak_cuda_test_lifecycle_before_increment_waiting(void)
+{
+    return peak_cuda_test_lifecycle_before_increment_waiting_count.load(
+        std::memory_order_acquire);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_pause_lifecycle_after_admission(int enabled)
+{
+    peak_cuda_test_pause_lifecycle_after_admission_flag.store(
+        enabled != 0, std::memory_order_release);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT unsigned int
+peak_cuda_test_lifecycle_after_admission_waiting(void)
+{
+    return peak_cuda_test_lifecycle_after_admission_waiting_count.load(
+        std::memory_order_acquire);
+}
+
+PEAK_CUDA_WRAPPER_EXPORT int
+peak_cuda_test_lifecycle_closing(void)
+{
+    return (peak_cuda_lifecycle_epoch.load(std::memory_order_seq_cst) & 1ULL)
+        != 0 ? 1 : 0;
+}
+
+PEAK_CUDA_WRAPPER_EXPORT void
+peak_cuda_test_finalize(void)
+{
+    std::lock_guard<std::mutex> lifecycle_lock(peak_cuda_lifecycle_mutex);
+    if (cuda_kernel_local_dim_mapping != NULL &&
+        cuda_graph_local_mapping != NULL) {
+        peak_cuda_finalize_pending();
+    }
+}
+#endif
 
 extern "C" void cuda_interceptor_print_with_mpi_job_policy(
     int aggregation_mode, int active_mpi_job) {
@@ -1522,8 +4129,7 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
         cuda_graph_local_mapping == NULL) {
         return;
     }
-    peak_cuda_accepting_events.store(false, std::memory_order_release);
-    cuda_sync_kernel_event();
+    peak_cuda_finalize_pending();
     PeakReportSnapshot* local = peak_cuda_build_report_snapshot();
     if (local != NULL) {
 #ifdef HAVE_MPI

--- a/src/cuda_profiler_state.cpp
+++ b/src/cuda_profiler_state.cpp
@@ -1,22 +1,624 @@
 #include "internal/cuda_profiler_state.h"
 
 #include <algorithm>
+#include <cstring>
+#include <limits>
 
 namespace {
 constexpr const char* kUnknownKernelName = "<unknown>";
-constexpr std::size_t kMaximumKernelNameLength = 255;
+constexpr std::size_t kInvalidSlot = std::numeric_limits<std::size_t>::max();
+constexpr std::uint32_t kInvalidSlotIndex =
+    std::numeric_limits<std::uint32_t>::max();
+constexpr unsigned char kSlotUnassigned = 0;
+constexpr unsigned char kSlotLeased = 1;
+constexpr unsigned char kSlotFree = 2;
+
+std::uint64_t
+pack_free_head(std::uint32_t index, std::uint32_t tag)
+{
+    return (static_cast<std::uint64_t>(tag) << 32) | index;
+}
+
+std::uint32_t
+free_head_index(std::uint64_t head)
+{
+    return static_cast<std::uint32_t>(head);
+}
+
+std::uint32_t
+free_head_tag(std::uint64_t head)
+{
+    return static_cast<std::uint32_t>(head >> 32);
+}
+
+PeakCudaKernelIdentity
+make_kernel_identity(const char* name, bool target_match)
+{
+    PeakCudaKernelIdentity result = {};
+    const char* source = name != nullptr && name[0] != '\0'
+        ? name
+        : kUnknownKernelName;
+    std::size_t length = std::min(
+        std::strlen(source), result.name.size() - 1);
+    std::memcpy(result.name.data(), source, length);
+    result.name[length] = '\0';
+    result.target_match = target_match;
+    return result;
+}
+
+std::uint64_t
+saturating_multiply(std::uint64_t left, std::uint64_t right, bool* overflow)
+{
+    if (left != 0 &&
+        right > std::numeric_limits<std::uint64_t>::max() / left) {
+        if (overflow != nullptr) {
+            *overflow = true;
+        }
+        return std::numeric_limits<std::uint64_t>::max();
+    }
+    return left * right;
+}
+}
+
+std::uint64_t
+peak_cuda_saturating_add_u64(std::uint64_t left, std::uint64_t right,
+                             bool* overflow)
+{
+    if (right > std::numeric_limits<std::uint64_t>::max() - left) {
+        if (overflow != nullptr) {
+            *overflow = true;
+        }
+        return std::numeric_limits<std::uint64_t>::max();
+    }
+    return left + right;
+}
+
+PeakCudaLaunchDimensions
+peak_cuda_compute_launch_dimensions(
+    unsigned int grid_x, unsigned int grid_y, unsigned int grid_z,
+    unsigned int block_x, unsigned int block_y, unsigned int block_z)
+{
+    bool overflow = false;
+    std::uint64_t grid_size = saturating_multiply(
+        static_cast<std::uint64_t>(grid_x),
+        static_cast<std::uint64_t>(grid_y), &overflow);
+    grid_size = saturating_multiply(
+        grid_size, static_cast<std::uint64_t>(grid_z), &overflow);
+    std::uint64_t block_size = saturating_multiply(
+        static_cast<std::uint64_t>(block_x),
+        static_cast<std::uint64_t>(block_y), &overflow);
+    block_size = saturating_multiply(
+        block_size, static_cast<std::uint64_t>(block_z), &overflow);
+    std::uint64_t total_threads = saturating_multiply(
+        grid_size, block_size, &overflow);
+    return {total_threads, grid_size, block_size, overflow};
+}
+
+PeakCudaSlotAllocator::PeakCudaSlotAllocator(std::size_t capacity)
+    : capacity_(0),
+      context_capacity_(0),
+      next_unassigned_(0),
+      assigned_slots_(0),
+      context_count_(0),
+      generation_seed_(0)
+{
+    reset(capacity);
+}
+
+void
+PeakCudaSlotAllocator::reset(std::size_t capacity)
+{
+    if (capacity >= kInvalidSlotIndex) {
+        capacity = kInvalidSlotIndex - 1;
+    }
+    capacity_ = capacity;
+    context_capacity_ = std::min<std::size_t>(capacity, kShardCount);
+    slots_.reset(capacity == 0 ? nullptr : new Slot[capacity]);
+    contexts_.reset(context_capacity_ == 0
+                        ? nullptr
+                        : new std::atomic<std::uintptr_t>[context_capacity_]);
+    const std::size_t head_count = context_capacity_ * kShardCount;
+    free_heads_.reset(head_count == 0
+                          ? nullptr
+                          : new FreeHead[head_count]);
+    generation_seed_ += UINT64_C(1) << 32;
+    for (std::size_t index = 0; index < capacity_; ++index) {
+        slots_[index].next_free.store(kInvalidSlotIndex,
+                                     std::memory_order_relaxed);
+        slots_[index].generation.store(generation_seed_,
+                                      std::memory_order_relaxed);
+        slots_[index].context = 0;
+        slots_[index].shard = 0;
+        slots_[index].state.store(kSlotUnassigned,
+                                  std::memory_order_relaxed);
+    }
+    for (std::size_t index = 0; index < context_capacity_; ++index) {
+        contexts_[index].store(0, std::memory_order_relaxed);
+    }
+    for (std::size_t index = 0; index < head_count; ++index) {
+        free_heads_[index].value.store(
+            pack_free_head(kInvalidSlotIndex, 0),
+            std::memory_order_relaxed);
+    }
+    next_unassigned_.store(0, std::memory_order_relaxed);
+    assigned_slots_.store(0, std::memory_order_relaxed);
+    context_count_.store(0, std::memory_order_relaxed);
+    for (std::size_t shard = 0; shard < kShardCount; ++shard) {
+        counter_shards_[shard].active.store(0,
+                                             std::memory_order_relaxed);
+        counter_shards_[shard].handoff.store(0,
+                                              std::memory_order_relaxed);
+        counter_shards_[shard].high_water.store(
+            0, std::memory_order_relaxed);
+    }
+}
+
+bool
+PeakCudaSlotAllocator::acquire(std::uintptr_t context,
+                               PeakCudaSlotLease* lease)
+{
+    return acquire(context, 0, lease);
+}
+
+bool
+PeakCudaSlotAllocator::acquire(std::uintptr_t context, std::size_t shard,
+                               PeakCudaSlotLease* lease)
+{
+    if (lease == nullptr || context == 0 || context_capacity_ == 0) {
+        return false;
+    }
+    shard %= kShardCount;
+    const std::size_t bucket = find_or_claim_context(context);
+    if (bucket == kInvalidSlot) {
+        return false;
+    }
+    if (pop_free(bucket, shard, lease) ||
+        reserve_unassigned(bucket, context, shard, lease)) {
+        return true;
+    }
+    for (std::size_t offset = 1; offset < kShardCount; ++offset) {
+        if (pop_free(bucket, (shard + offset) % kShardCount, lease)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+PeakCudaSlotAllocator::acquire_if_accepting(
+    std::uintptr_t context, const std::atomic_bool& accepting,
+    PeakCudaSlotLease* lease, bool* admission_closed)
+{
+    return acquire_if_accepting(context, 0, accepting, lease,
+                                admission_closed);
+}
+
+bool
+PeakCudaSlotAllocator::acquire_if_accepting(
+    std::uintptr_t context, std::size_t shard,
+    const std::atomic_bool& accepting,
+    PeakCudaSlotLease* lease, bool* admission_closed)
+{
+    if (admission_closed != nullptr) {
+        *admission_closed = false;
+    }
+    if (lease == nullptr ||
+        !accepting.load(std::memory_order_seq_cst)) {
+        if (admission_closed != nullptr) {
+            *admission_closed = true;
+        }
+        return false;
+    }
+    if (!acquire(context, shard, lease)) {
+        return false;
+    }
+    if (!accepting.load(std::memory_order_seq_cst)) {
+        (void)release(*lease);
+        if (admission_closed != nullptr) {
+            *admission_closed = true;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool
+PeakCudaSlotAllocator::release(const PeakCudaSlotLease& lease)
+{
+    if (lease.index >= capacity_) {
+        return false;
+    }
+    Slot& slot = slots_[lease.index];
+    if (slot.context != lease.context || slot.shard != lease.shard ||
+        slot.generation.load(std::memory_order_acquire) !=
+            lease.generation) {
+        return false;
+    }
+    counter_shards_[lease.shard].handoff.fetch_add(
+        1, std::memory_order_relaxed);
+    unsigned char expected = kSlotLeased;
+    if (!slot.state.compare_exchange_strong(
+            expected, kSlotFree, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+        counter_shards_[lease.shard].handoff.fetch_sub(
+            1, std::memory_order_relaxed);
+        return false;
+    }
+    const std::size_t bucket = context_index(lease.context);
+    if (bucket == kInvalidSlot) {
+        slot.state.store(kSlotLeased, std::memory_order_release);
+        counter_shards_[lease.shard].handoff.fetch_sub(
+            1, std::memory_order_relaxed);
+        return false;
+    }
+    counter_shards_[lease.shard].active.fetch_sub(
+        1, std::memory_order_relaxed);
+    push_free(bucket, lease.shard, static_cast<std::uint32_t>(lease.index));
+    counter_shards_[lease.shard].handoff.fetch_sub(
+        1, std::memory_order_release);
+    return true;
+}
+
+std::size_t
+PeakCudaSlotAllocator::active_count() const noexcept
+{
+    std::size_t total = 0;
+    for (std::size_t shard = 0; shard < kShardCount; ++shard) {
+        total += counter_shards_[shard].active.load(
+            std::memory_order_acquire);
+        total += counter_shards_[shard].handoff.load(
+            std::memory_order_acquire);
+    }
+    return total;
+}
+
+std::size_t
+PeakCudaSlotAllocator::snapshot_active_leases(
+    PeakCudaSlotLease* leases, std::size_t lease_capacity) const
+{
+    std::size_t active = 0;
+    for (std::size_t index = 0; index < capacity_; ++index) {
+        const Slot& slot = slots_[index];
+        if (slot.state.load(std::memory_order_acquire) != kSlotLeased) {
+            continue;
+        }
+        if (leases != nullptr && active < lease_capacity) {
+            leases[active] = {
+                index,
+                slot.generation.load(std::memory_order_acquire),
+                slot.context,
+                slot.shard,
+            };
+        }
+        ++active;
+    }
+    return active;
+}
+
+bool
+PeakCudaSlotAllocator::try_snapshot_active_leases(
+    PeakCudaSlotLease* leases, std::size_t lease_capacity,
+    std::size_t* active) const
+{
+    const std::size_t count = snapshot_active_leases(leases,
+                                                      lease_capacity);
+    if (active != nullptr) {
+        *active = count;
+    }
+    return true;
+}
+
+PeakCudaSlotAllocatorCounters
+PeakCudaSlotAllocator::counters() const
+{
+    std::size_t active = 0;
+    std::size_t high_water = 0;
+    for (std::size_t shard = 0; shard < kShardCount; ++shard) {
+        active += counter_shards_[shard].active.load(
+            std::memory_order_relaxed);
+        high_water += counter_shards_[shard].high_water.load(
+            std::memory_order_relaxed);
+    }
+    return {
+        capacity_,
+        assigned_slots_.load(std::memory_order_relaxed),
+        context_count_.load(std::memory_order_relaxed),
+        active,
+        high_water,
+    };
+}
+
+std::size_t
+PeakCudaSlotAllocator::find_or_claim_context(std::uintptr_t context)
+{
+    const std::size_t start = std::hash<std::uintptr_t>()(context) %
+                              context_capacity_;
+    for (std::size_t offset = 0; offset < context_capacity_; ++offset) {
+        const std::size_t index = (start + offset) % context_capacity_;
+        std::uintptr_t current = contexts_[index].load(
+            std::memory_order_acquire);
+        if (current == context) {
+            return index;
+        }
+        if (current == 0 && contexts_[index].compare_exchange_strong(
+                                current, context,
+                                std::memory_order_acq_rel,
+                                std::memory_order_acquire)) {
+            context_count_.fetch_add(1, std::memory_order_relaxed);
+            return index;
+        }
+        if (current == context) {
+            return index;
+        }
+    }
+    return kInvalidSlot;
+}
+
+std::size_t
+PeakCudaSlotAllocator::context_index(std::uintptr_t context) const
+{
+    if (context == 0 || context_capacity_ == 0) {
+        return kInvalidSlot;
+    }
+    const std::size_t start = std::hash<std::uintptr_t>()(context) %
+                              context_capacity_;
+    for (std::size_t offset = 0; offset < context_capacity_; ++offset) {
+        const std::size_t index = (start + offset) % context_capacity_;
+        const std::uintptr_t current = contexts_[index].load(
+            std::memory_order_acquire);
+        if (current == context) {
+            return index;
+        }
+        if (current == 0) {
+            return kInvalidSlot;
+        }
+    }
+    return kInvalidSlot;
+}
+
+bool
+PeakCudaSlotAllocator::pop_free(std::size_t context_index,
+                                std::size_t shard,
+                                PeakCudaSlotLease* lease)
+{
+    std::atomic<std::uint64_t>& head =
+        free_heads_[context_index * kShardCount + shard].value;
+    std::uint64_t current = head.load(std::memory_order_acquire);
+    for (;;) {
+        const std::uint32_t index = free_head_index(current);
+        if (index == kInvalidSlotIndex) {
+            return false;
+        }
+        const std::uint32_t next = slots_[index].next_free.load(
+            std::memory_order_relaxed);
+        const std::uint64_t desired = pack_free_head(
+            next, free_head_tag(current) + 1);
+        if (!head.compare_exchange_weak(current, desired,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire)) {
+            continue;
+        }
+        unsigned char expected = kSlotFree;
+        if (!slots_[index].state.compare_exchange_strong(
+                expected, kSlotLeased, std::memory_order_acq_rel,
+                std::memory_order_acquire)) {
+            return false;
+        }
+        const std::uint64_t generation =
+            slots_[index].generation.fetch_add(
+                1, std::memory_order_relaxed) + 1;
+        record_active_acquire(slots_[index].shard);
+        *lease = {index, generation, slots_[index].context,
+                  slots_[index].shard};
+        return true;
+    }
+}
+
+void
+PeakCudaSlotAllocator::push_free(std::size_t context_index,
+                                 std::size_t shard,
+                                 std::uint32_t index)
+{
+    std::atomic<std::uint64_t>& head =
+        free_heads_[context_index * kShardCount + shard].value;
+    std::uint64_t current = head.load(std::memory_order_relaxed);
+    do {
+        slots_[index].next_free.store(free_head_index(current),
+                                     std::memory_order_relaxed);
+    } while (!head.compare_exchange_weak(
+        current, pack_free_head(index, free_head_tag(current) + 1),
+        std::memory_order_release, std::memory_order_relaxed));
+}
+
+bool
+PeakCudaSlotAllocator::reserve_unassigned(
+    std::size_t context_bucket, std::uintptr_t context, std::size_t shard,
+    PeakCudaSlotLease* lease)
+{
+    (void)context_bucket;
+    std::size_t index = next_unassigned_.load(std::memory_order_relaxed);
+    while (index < capacity_ &&
+           !next_unassigned_.compare_exchange_weak(
+               index, index + 1, std::memory_order_acq_rel,
+               std::memory_order_relaxed)) {
+    }
+    if (index >= capacity_) {
+        return false;
+    }
+    Slot& slot = slots_[index];
+    slot.context = context;
+    slot.shard = static_cast<std::uint16_t>(shard);
+    const std::uint64_t generation = slot.generation.fetch_add(
+        1, std::memory_order_relaxed) + 1;
+    slot.state.store(kSlotLeased, std::memory_order_release);
+    assigned_slots_.fetch_add(1, std::memory_order_relaxed);
+    record_active_acquire(shard);
+    *lease = {index, generation, context, shard};
+    return true;
+}
+
+void
+PeakCudaSlotAllocator::record_active_acquire(std::size_t shard)
+{
+    const std::size_t active = counter_shards_[shard].active.fetch_add(
+        1, std::memory_order_relaxed) + 1;
+    std::size_t high_water = counter_shards_[shard].high_water.load(
+        std::memory_order_relaxed);
+    while (high_water < active &&
+           !counter_shards_[shard].high_water.compare_exchange_weak(
+               high_water, active, std::memory_order_relaxed,
+               std::memory_order_relaxed)) {
+    }
+}
+
+PeakCudaPendingQueue::PeakCudaPendingQueue(std::size_t capacity)
+    : capacity_(0), dequeue_shard_(0)
+{
+    reset(capacity);
+}
+
+void
+PeakCudaPendingQueue::reset(std::size_t capacity)
+{
+    if (capacity >= kInvalidSlotIndex) {
+        capacity = kInvalidSlotIndex - 1;
+    }
+    capacity_ = capacity;
+    next_.reset(capacity == 0
+                    ? nullptr
+                    : new std::atomic<std::uint32_t>[capacity]);
+    leases_.reset(capacity == 0 ? nullptr
+                                : new PeakCudaSlotLease[capacity]);
+    for (std::size_t index = 0; index < capacity_; ++index) {
+        next_[index].store(kInvalidSlotIndex, std::memory_order_relaxed);
+        leases_[index] = {};
+    }
+    for (std::size_t shard = 0;
+         shard < PeakCudaSlotAllocator::kShardCount; ++shard) {
+        shards_[shard].head.store(pack_free_head(kInvalidSlotIndex, 0),
+                                  std::memory_order_relaxed);
+        local_heads_[shard] = kInvalidSlotIndex;
+    }
+    dequeue_shard_ = 0;
+}
+
+bool
+PeakCudaPendingQueue::push(const PeakCudaSlotLease& lease,
+                           bool* shard_was_empty)
+{
+    if (shard_was_empty != nullptr) {
+        *shard_was_empty = false;
+    }
+    if (lease.index >= capacity_ ||
+        lease.shard >= PeakCudaSlotAllocator::kShardCount) {
+        return false;
+    }
+    leases_[lease.index] = lease;
+    std::atomic<std::uint64_t>& head = shards_[lease.shard].head;
+    std::uint64_t current = head.load(std::memory_order_relaxed);
+    do {
+        next_[lease.index].store(free_head_index(current),
+                                 std::memory_order_relaxed);
+    } while (!head.compare_exchange_weak(
+        current,
+        pack_free_head(static_cast<std::uint32_t>(lease.index),
+                       free_head_tag(current) + 1),
+        std::memory_order_release, std::memory_order_relaxed));
+    if (shard_was_empty != nullptr) {
+        *shard_was_empty = free_head_index(current) == kInvalidSlotIndex;
+    }
+    return true;
+}
+
+bool
+PeakCudaPendingQueue::pop(PeakCudaSlotLease* lease)
+{
+    if (lease == nullptr || capacity_ == 0) {
+        return false;
+    }
+    for (std::size_t offset = 0;
+         offset < PeakCudaSlotAllocator::kShardCount; ++offset) {
+        const std::size_t shard =
+            (dequeue_shard_ + offset) % PeakCudaSlotAllocator::kShardCount;
+        std::uint32_t index = local_heads_[shard];
+        if (index == kInvalidSlotIndex) {
+            std::atomic<std::uint64_t>& head = shards_[shard].head;
+            std::uint64_t current = head.load(std::memory_order_acquire);
+            while (free_head_index(current) != kInvalidSlotIndex) {
+                const std::uint64_t desired = pack_free_head(
+                    kInvalidSlotIndex, free_head_tag(current) + 1);
+                if (head.compare_exchange_weak(
+                        current, desired, std::memory_order_acq_rel,
+                        std::memory_order_acquire)) {
+                    break;
+                }
+            }
+            std::uint32_t detached = free_head_index(current);
+            std::uint32_t reversed = kInvalidSlotIndex;
+            while (detached != kInvalidSlotIndex) {
+                const std::uint32_t next = next_[detached].load(
+                    std::memory_order_relaxed);
+                next_[detached].store(reversed, std::memory_order_relaxed);
+                reversed = detached;
+                detached = next;
+            }
+            local_heads_[shard] = reversed;
+            index = reversed;
+        }
+        if (index != kInvalidSlotIndex) {
+            local_heads_[shard] = next_[index].load(
+                std::memory_order_relaxed);
+            *lease = leases_[index];
+            dequeue_shard_ = (shard + 1) %
+                             PeakCudaSlotAllocator::kShardCount;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+PeakCudaPendingQueue::requeue_local(const PeakCudaSlotLease& lease)
+{
+    if (lease.index >= capacity_ ||
+        lease.shard >= PeakCudaSlotAllocator::kShardCount) {
+        return false;
+    }
+    leases_[lease.index] = lease;
+    next_[lease.index].store(local_heads_[lease.shard],
+                             std::memory_order_relaxed);
+    local_heads_[lease.shard] = static_cast<std::uint32_t>(lease.index);
+    return true;
 }
 
 PeakCudaProfilerState::PeakCudaProfilerState(std::size_t capacity)
-    : capacity_(capacity),
-      identity_capacity_(capacity),
-      active_slots_(0),
-      high_water_slots_(0),
+    : identity_capacity_(capacity),
+      completed_launches_(0),
       dropped_pool_full_(0),
       dropped_identity_full_(0),
       dropped_event_create_(0),
-      dropped_timing_error_(0)
+      dropped_timing_error_(0),
+      dropped_harvester_unavailable_(0),
+      dropped_stream_capture_(0),
+      dropped_capture_query_(0),
+      dropped_capture_query_unsupported_(0),
+      dropped_unsupported_multi_device_(0),
+      dropped_event_query_(0),
+      dropped_elapsed_time_(0),
+      dropped_context_query_(0),
+      dropped_context_switch_(0),
+      dropped_context_restore_(0),
+      finalization_timeouts_(0),
+      finalization_incomplete_(0),
+      dropped_dimension_overflow_(0)
 {
+    for (std::size_t shard = 0;
+         shard < PeakCudaSlotAllocator::kShardCount; ++shard) {
+        launch_counter_shards_[shard].observed.store(
+            0, std::memory_order_relaxed);
+        launch_counter_shards_[shard].accepted.store(
+            0, std::memory_order_relaxed);
+    }
 }
 
 void
@@ -26,14 +628,32 @@ PeakCudaProfilerState::reset(std::size_t capacity,
     std::lock_guard<std::mutex> lock(mutex_);
 
     identities_.clear();
-    capacity_ = capacity;
     identity_capacity_ = identity_capacity == 0 ? capacity : identity_capacity;
-    active_slots_ = 0;
-    high_water_slots_ = 0;
-    dropped_pool_full_ = 0;
-    dropped_identity_full_ = 0;
-    dropped_event_create_ = 0;
-    dropped_timing_error_ = 0;
+    for (std::size_t shard = 0;
+         shard < PeakCudaSlotAllocator::kShardCount; ++shard) {
+        launch_counter_shards_[shard].observed.store(
+            0, std::memory_order_relaxed);
+        launch_counter_shards_[shard].accepted.store(
+            0, std::memory_order_relaxed);
+    }
+    completed_launches_.store(0, std::memory_order_relaxed);
+    dropped_pool_full_.store(0, std::memory_order_relaxed);
+    dropped_identity_full_.store(0, std::memory_order_relaxed);
+    dropped_event_create_.store(0, std::memory_order_relaxed);
+    dropped_timing_error_.store(0, std::memory_order_relaxed);
+    dropped_harvester_unavailable_.store(0, std::memory_order_relaxed);
+    dropped_stream_capture_.store(0, std::memory_order_relaxed);
+    dropped_capture_query_.store(0, std::memory_order_relaxed);
+    dropped_capture_query_unsupported_.store(0, std::memory_order_relaxed);
+    dropped_unsupported_multi_device_.store(0, std::memory_order_relaxed);
+    dropped_event_query_.store(0, std::memory_order_relaxed);
+    dropped_elapsed_time_.store(0, std::memory_order_relaxed);
+    dropped_context_query_.store(0, std::memory_order_relaxed);
+    dropped_context_switch_.store(0, std::memory_order_relaxed);
+    dropped_context_restore_.store(0, std::memory_order_relaxed);
+    finalization_timeouts_.store(0, std::memory_order_relaxed);
+    finalization_incomplete_.store(0, std::memory_order_relaxed);
+    dropped_dimension_overflow_.store(0, std::memory_order_relaxed);
 }
 
 PeakCudaKernelIdentity
@@ -43,10 +663,11 @@ PeakCudaProfilerState::identify(
     const char* display_name,
     const char* target_name,
     bool monitor_all,
-    const std::vector<std::string>& targets)
+    const std::vector<std::string>& targets,
+    std::uintptr_t context)
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    const PeakCudaIdentityKey key = {identity, driver_function};
+    const PeakCudaIdentityKey key = {identity, driver_function, context};
     const auto existing = identities_.find(key);
 
     if (existing != identities_.end()) {
@@ -54,19 +675,11 @@ PeakCudaProfilerState::identify(
     }
 
     if (identities_.size() >= identity_capacity_) {
-        ++dropped_identity_full_;
-        return {kUnknownKernelName, monitor_all};
+        record_identity_full();
+        return make_kernel_identity(kUnknownKernelName, monitor_all);
     }
 
-    PeakCudaKernelIdentity result = {
-        display_name != nullptr && display_name[0] != '\0'
-            ? display_name
-            : kUnknownKernelName,
-        false,
-    };
-    if (result.name.size() > kMaximumKernelNameLength) {
-        result.name.resize(kMaximumKernelNameLength);
-    }
+    PeakCudaKernelIdentity result = make_kernel_identity(display_name, false);
     result.target_match = monitor_all ||
                           (target_name != nullptr && target_name[0] != '\0' &&
                            target_matches(target_name, targets));
@@ -78,10 +691,12 @@ bool
 PeakCudaProfilerState::cached_identity(
     std::uintptr_t identity,
     bool driver_function,
-    PeakCudaKernelIdentity* result) const
+    PeakCudaKernelIdentity* result,
+    std::uintptr_t context) const
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    const auto existing = identities_.find({identity, driver_function});
+    const auto existing = identities_.find(
+        {identity, driver_function, context});
 
     if (existing == identities_.end()) {
         return false;
@@ -92,42 +707,144 @@ PeakCudaProfilerState::cached_identity(
     return true;
 }
 
-bool
-PeakCudaProfilerState::acquire_slot()
+void
+PeakCudaProfilerState::record_launch_observed(std::size_t shard,
+                                              bool exclusive)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (active_slots_ >= capacity_) {
-        ++dropped_pool_full_;
-        return false;
+    std::atomic<std::uint64_t>& observed =
+        launch_counter_shards_[shard % PeakCudaSlotAllocator::kShardCount]
+            .observed;
+    if (exclusive) {
+        observed.store(observed.load(std::memory_order_relaxed) + 1,
+                       std::memory_order_relaxed);
+    } else {
+        observed.fetch_add(1, std::memory_order_relaxed);
     }
-    ++active_slots_;
-    high_water_slots_ = std::max(high_water_slots_, active_slots_);
-    return true;
 }
 
 void
-PeakCudaProfilerState::release_slot()
+PeakCudaProfilerState::record_launch_accepted(std::size_t shard,
+                                              bool exclusive)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (active_slots_ != 0) {
-        --active_slots_;
+    std::atomic<std::uint64_t>& accepted =
+        launch_counter_shards_[shard % PeakCudaSlotAllocator::kShardCount]
+            .accepted;
+    if (exclusive) {
+        accepted.store(accepted.load(std::memory_order_relaxed) + 1,
+                       std::memory_order_relaxed);
+    } else {
+        accepted.fetch_add(1, std::memory_order_relaxed);
     }
+}
+
+void
+PeakCudaProfilerState::record_launch_completed()
+{
+    completed_launches_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_pool_full()
+{
+    dropped_pool_full_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_identity_full()
+{
+    dropped_identity_full_.fetch_add(1, std::memory_order_relaxed);
 }
 
 void
 PeakCudaProfilerState::record_event_create_failure()
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    ++dropped_event_create_;
+    dropped_event_create_.fetch_add(1, std::memory_order_relaxed);
 }
 
 void
 PeakCudaProfilerState::record_timing_error()
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    ++dropped_timing_error_;
+    dropped_timing_error_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_harvester_unavailable()
+{
+    dropped_harvester_unavailable_.fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_stream_capture_skip()
+{
+    dropped_stream_capture_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_capture_query_failure()
+{
+    dropped_capture_query_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_capture_query_unsupported()
+{
+    dropped_capture_query_unsupported_.fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_unsupported_multi_device()
+{
+    dropped_unsupported_multi_device_.fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_event_query_failure()
+{
+    dropped_event_query_.fetch_add(1, std::memory_order_relaxed);
+    dropped_timing_error_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_elapsed_time_failure()
+{
+    dropped_elapsed_time_.fetch_add(1, std::memory_order_relaxed);
+    dropped_timing_error_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_context_query_failure()
+{
+    dropped_context_query_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_context_switch_failure()
+{
+    dropped_context_switch_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_context_restore_failure()
+{
+    dropped_context_restore_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_finalization_timeout(
+    std::size_t incomplete_records)
+{
+    finalization_timeouts_.fetch_add(1, std::memory_order_relaxed);
+    finalization_incomplete_.fetch_add(
+        incomplete_records, std::memory_order_relaxed);
+}
+
+void
+PeakCudaProfilerState::record_dimension_overflow()
+{
+    dropped_dimension_overflow_.fetch_add(1, std::memory_order_relaxed);
 }
 
 PeakCudaProfilerCounters
@@ -135,17 +852,55 @@ PeakCudaProfilerState::counters() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    return {
-        capacity_,
-        identity_capacity_,
-        identities_.size(),
-        active_slots_,
-        high_water_slots_,
-        dropped_pool_full_,
-        dropped_identity_full_,
-        dropped_event_create_,
-        dropped_timing_error_,
-    };
+    PeakCudaProfilerCounters result = {};
+    result.identity_capacity = identity_capacity_;
+    result.cached_identities = identities_.size();
+    for (std::size_t shard = 0;
+         shard < PeakCudaSlotAllocator::kShardCount; ++shard) {
+        result.observed_launches +=
+            launch_counter_shards_[shard].observed.load(
+            std::memory_order_relaxed);
+        result.accepted_launches +=
+            launch_counter_shards_[shard].accepted.load(
+            std::memory_order_relaxed);
+    }
+    result.completed_launches =
+        completed_launches_.load(std::memory_order_relaxed);
+    result.dropped_pool_full =
+        dropped_pool_full_.load(std::memory_order_relaxed);
+    result.dropped_identity_full =
+        dropped_identity_full_.load(std::memory_order_relaxed);
+    result.dropped_event_create =
+        dropped_event_create_.load(std::memory_order_relaxed);
+    result.dropped_timing_error =
+        dropped_timing_error_.load(std::memory_order_relaxed);
+    result.dropped_harvester_unavailable =
+        dropped_harvester_unavailable_.load(std::memory_order_relaxed);
+    result.dropped_stream_capture =
+        dropped_stream_capture_.load(std::memory_order_relaxed);
+    result.dropped_capture_query =
+        dropped_capture_query_.load(std::memory_order_relaxed);
+    result.dropped_capture_query_unsupported =
+        dropped_capture_query_unsupported_.load(std::memory_order_relaxed);
+    result.dropped_unsupported_multi_device =
+        dropped_unsupported_multi_device_.load(std::memory_order_relaxed);
+    result.dropped_event_query =
+        dropped_event_query_.load(std::memory_order_relaxed);
+    result.dropped_elapsed_time =
+        dropped_elapsed_time_.load(std::memory_order_relaxed);
+    result.dropped_context_query =
+        dropped_context_query_.load(std::memory_order_relaxed);
+    result.dropped_context_switch =
+        dropped_context_switch_.load(std::memory_order_relaxed);
+    result.dropped_context_restore =
+        dropped_context_restore_.load(std::memory_order_relaxed);
+    result.finalization_timeouts =
+        finalization_timeouts_.load(std::memory_order_relaxed);
+    result.finalization_incomplete =
+        finalization_incomplete_.load(std::memory_order_relaxed);
+    result.dropped_dimension_overflow =
+        dropped_dimension_overflow_.load(std::memory_order_relaxed);
+    return result;
 }
 
 bool

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
 endif()
 
 set(PEAK_CUDA_TEST_LIBRARIES)
+set(PEAK_CUDA_DRIVER_TEST_LIBRARY)
 if (CUDAToolkit_FOUND)
     message(STATUS "CUDA Toolkit found: ${CUDAToolkit_VERSION}")
     add_definitions(-DHAVE_CUDA)
@@ -26,11 +27,15 @@ if (CUDAToolkit_FOUND)
     if (TARGET CUDA::cudart)
         list(APPEND PEAK_CUDA_TEST_LIBRARIES CUDA::cudart)
     endif()
+    if (TARGET CUDA::cuda_driver)
+        set(PEAK_CUDA_DRIVER_TEST_LIBRARY CUDA::cuda_driver)
+    endif()
 elseif (CUDA_FOUND)
     message(STATUS "Legacy CUDA found: ${CUDA_VERSION}")
     add_definitions(-DHAVE_CUDA)
     include_directories(${CUDA_INCLUDE_DIRS})
     list(APPEND PEAK_CUDA_TEST_LIBRARIES ${CUDA_LIBRARIES})
+    set(PEAK_CUDA_DRIVER_TEST_LIBRARY ${CUDA_CUDA_LIBRARY})
 else()
     message(STATUS "CUDA not found. Skipping CUDA tests.")
     return()
@@ -38,6 +43,18 @@ endif()
 
 find_package(OpenMP QUIET)
 find_package(MPI QUIET COMPONENTS CXX)
+
+function(peak_add_cuda_fixture target source)
+    add_executable(${target} ${source})
+    set_source_files_properties(${source} PROPERTIES LANGUAGE CUDA)
+    set_target_properties(${target} PROPERTIES CUDA_ARCHITECTURES all)
+    target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(${target}
+        PRIVATE
+            Threads::Threads
+            ${PEAK_CUDA_TEST_LIBRARIES}
+            ${ARGN})
+endfunction()
 
 # Executable: test_pthread
 add_executable(test_pthread test_pthread.cu)
@@ -69,4 +86,94 @@ if (MPI_CXX_FOUND AND OpenMP_C_FOUND)
     )
 else()
     message(STATUS "Skipping CUDA OpenMP/MPI test because OpenMP C or MPI CXX was not found")
+endif()
+
+peak_add_cuda_fixture(test_cuda_event_recycling test_event_recycling.cu)
+if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
+    peak_add_cuda_fixture(test_cuda_stream_capture test_stream_capture.cu
+        ${PEAK_CUDA_DRIVER_TEST_LIBRARY})
+    peak_add_cuda_fixture(test_cuda_multi_context test_multi_context.cu
+        ${PEAK_CUDA_DRIVER_TEST_LIBRARY} ${CMAKE_DL_LIBS})
+else()
+    message(STATUS
+        "Skipping CUDA Driver fixtures because the Driver library was not found")
+endif()
+peak_add_cuda_fixture(test_cuda_finalization_deadline
+    test_finalization_deadline.cu ${CMAKE_DL_LIBS})
+if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
+    peak_add_cuda_fixture(benchmark_cuda_launch_overhead
+        benchmark_launch_overhead.cu
+        ${PEAK_CUDA_DRIVER_TEST_LIBRARY} ${CMAKE_DL_LIBS})
+else()
+    message(STATUS
+        "Skipping CUDA launch benchmark because the Driver library was not found")
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND Python3_EXECUTABLE)
+    add_test(NAME test_cuda_event_recycling_runtime
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                sampling
+                --exe $<TARGET_FILE:test_cuda_event_recycling>
+                --peak $<TARGET_FILE:peak>)
+    if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
+        add_test(NAME test_cuda_stream_capture_runtime
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                    capture
+                    --exe $<TARGET_FILE:test_cuda_stream_capture>
+                    --peak $<TARGET_FILE:peak>)
+        add_test(NAME test_cuda_multi_context_runtime
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                    context
+                    --exe $<TARGET_FILE:test_cuda_multi_context>
+                    --peak $<TARGET_FILE:peak>)
+    endif()
+    add_test(NAME test_cuda_finalization_deadline_runtime
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                finalization
+                --exe $<TARGET_FILE:test_cuda_finalization_deadline>
+                --peak $<TARGET_FILE:peak>)
+    if (TARGET benchmark_cuda_launch_overhead)
+        add_test(NAME test_cuda_launch_overhead_runtime
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                    benchmark
+                    --exe $<TARGET_FILE:benchmark_cuda_launch_overhead>
+                    --peak $<TARGET_FILE:peak>)
+    endif()
+
+    set(_peak_cuda_runtime_tests
+        test_cuda_event_recycling_runtime
+        test_cuda_finalization_deadline_runtime)
+    if (TARGET benchmark_cuda_launch_overhead)
+        list(APPEND _peak_cuda_runtime_tests
+            test_cuda_launch_overhead_runtime)
+    endif()
+    if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
+        list(APPEND _peak_cuda_runtime_tests
+            test_cuda_stream_capture_runtime
+            test_cuda_multi_context_runtime)
+    endif()
+    set_tests_properties(${_peak_cuda_runtime_tests}
+        PROPERTIES
+            LABELS "cuda;gpu"
+            RUN_SERIAL TRUE
+            SKIP_RETURN_CODE 77)
+    set(_peak_cuda_correctness_tests
+        test_cuda_event_recycling_runtime
+        test_cuda_finalization_deadline_runtime)
+    if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
+        list(APPEND _peak_cuda_correctness_tests
+            test_cuda_stream_capture_runtime
+            test_cuda_multi_context_runtime)
+    endif()
+    set_tests_properties(${_peak_cuda_correctness_tests}
+        PROPERTIES TIMEOUT 45)
+    if (TARGET benchmark_cuda_launch_overhead)
+        set_tests_properties(test_cuda_launch_overhead_runtime
+            PROPERTIES TIMEOUT 180)
+    endif()
 endif()

--- a/test/cuda/benchmark_launch_overhead.cu
+++ b/test/cuda/benchmark_launch_overhead.cu
@@ -1,0 +1,526 @@
+#include "cuda_test_common.cuh"
+
+#include <cuda.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <thread>
+#include <vector>
+
+#if defined(__linux__)
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+extern "C" __global__ void
+peak_cuda_benchmark_target_kernel(unsigned int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1U);
+    }
+}
+
+extern "C" __global__ void
+peak_cuda_benchmark_non_target_kernel(unsigned int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1U);
+    }
+}
+
+namespace {
+using PeakCudaHarvesterReadyFn = int (*)(void);
+
+struct WorkerResult {
+    unsigned long long submission_ns = 0;
+    int error = 0;
+};
+
+class SpinBarrier {
+public:
+    explicit SpinBarrier(int participants)
+        : participants_(participants), arrived_(0), generation_(0)
+    {
+    }
+
+    void wait()
+    {
+        int generation = generation_.load(std::memory_order_acquire);
+        if (arrived_.fetch_add(1, std::memory_order_acq_rel) ==
+            participants_ - 1) {
+            arrived_.store(0, std::memory_order_relaxed);
+            generation_.fetch_add(1, std::memory_order_release);
+            return;
+        }
+        while (generation_.load(std::memory_order_acquire) == generation) {
+            std::this_thread::yield();
+        }
+    }
+
+private:
+    int participants_;
+    std::atomic<int> arrived_;
+    std::atomic<int> generation_;
+};
+
+bool
+parse_positive(const char* text, int* result)
+{
+    char* end = nullptr;
+    long value = std::strtol(text, &end, 10);
+    if (end == text || *end != '\0' || value <= 0 || value > 1000000) {
+        return false;
+    }
+    *result = static_cast<int>(value);
+    return true;
+}
+
+bool
+allowed_cpus(std::vector<int>* cpus)
+{
+#if defined(__linux__)
+    cpu_set_t allowed;
+    CPU_ZERO(&allowed);
+    if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) {
+        return false;
+    }
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &allowed)) {
+            cpus->push_back(cpu);
+        }
+    }
+    return !cpus->empty();
+#else
+    (void)cpus;
+    return false;
+#endif
+}
+
+bool
+pin_current_worker(int cpu)
+{
+#if defined(__linux__)
+    cpu_set_t requested;
+    CPU_ZERO(&requested);
+    CPU_SET(cpu, &requested);
+    if (pthread_setaffinity_np(pthread_self(), sizeof(requested),
+                               &requested) != 0) {
+        return false;
+    }
+    cpu_set_t actual;
+    CPU_ZERO(&actual);
+    return pthread_getaffinity_np(pthread_self(), sizeof(actual), &actual) ==
+               0 &&
+           CPU_COUNT(&actual) == 1 && CPU_ISSET(cpu, &actual);
+#else
+    (void)cpu;
+    return false;
+#endif
+}
+}
+
+int
+main(int argc, char** argv)
+{
+    const char* mode = "target";
+    const char* api = "runtime";
+    int thread_count = 1;
+    int iterations = 64;
+    int batch_size = 4;
+    bool native_events = false;
+    for (int index = 1; index < argc; ++index) {
+        if (std::strcmp(argv[index], "--mode") == 0 && index + 1 < argc) {
+            mode = argv[++index];
+        } else if (std::strcmp(argv[index], "--api") == 0 &&
+                   index + 1 < argc) {
+            api = argv[++index];
+        } else if (std::strcmp(argv[index], "--threads") == 0 &&
+                   index + 1 < argc) {
+            if (!parse_positive(argv[++index], &thread_count)) {
+                return 2;
+            }
+        } else if (std::strcmp(argv[index], "--iterations") == 0 &&
+                   index + 1 < argc) {
+            if (!parse_positive(argv[++index], &iterations)) {
+                return 2;
+            }
+        } else if (std::strcmp(argv[index], "--batch") == 0 &&
+                   index + 1 < argc) {
+            if (!parse_positive(argv[++index], &batch_size)) {
+                return 2;
+            }
+        } else if (std::strcmp(argv[index], "--native-events") == 0) {
+            native_events = true;
+        } else {
+            return 2;
+        }
+    }
+    if (std::strcmp(mode, "target") != 0 &&
+        std::strcmp(mode, "non-target") != 0) {
+        return 2;
+    }
+    if (std::strcmp(api, "runtime") != 0 &&
+        std::strcmp(api, "driver") != 0) {
+        return 2;
+    }
+
+    std::vector<int> worker_cpus;
+    if (!allowed_cpus(&worker_cpus)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: unable to read Linux CPU affinity\n");
+        return 1;
+    }
+    if (worker_cpus.size() < static_cast<size_t>(thread_count)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: benchmark needs %d distinct CPUs, "
+                     "affinity allows %zu\n",
+                     thread_count, worker_cpus.size());
+        return 1;
+    }
+
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+    if (!peak_cuda_test_check(cudaSetDevice(0), "cudaSetDevice")) {
+        return 1;
+    }
+    cudaFunction_t runtime_function = nullptr;
+    const void* kernel_symbol = std::strcmp(mode, "target") == 0
+        ? reinterpret_cast<const void*>(peak_cuda_benchmark_target_kernel)
+        : reinterpret_cast<const void*>(
+              peak_cuda_benchmark_non_target_kernel);
+    if (std::strcmp(api, "driver") == 0 &&
+        !peak_cuda_test_check(
+            cudaGetFuncBySymbol(&runtime_function, kernel_symbol),
+            "benchmark cudaGetFuncBySymbol")) {
+        return 1;
+    }
+    CUfunction driver_function =
+        reinterpret_cast<CUfunction>(runtime_function);
+    PeakCudaHarvesterReadyFn harvester_ready =
+        reinterpret_cast<PeakCudaHarvesterReadyFn>(
+            dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_ready"));
+    int harvester_ready_before_measurement = -1;
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> start_warmup{false};
+    std::atomic<int> warmup_done{0};
+    std::atomic<bool> start_measurement{false};
+    std::atomic<bool> abort{false};
+    std::atomic<int> pinned_workers{0};
+    std::atomic<bool> overlap_failure{false};
+    SpinBarrier submission_barrier(thread_count);
+    std::vector<unsigned long long> batch_start_ns(
+        static_cast<size_t>(thread_count));
+    std::vector<unsigned long long> batch_end_ns(
+        static_cast<size_t>(thread_count));
+    unsigned long long aggregate_submission_ns = 0;
+    int overlapping_batches = 0;
+    const int measured_batches =
+        (iterations + batch_size - 1) / batch_size;
+    std::vector<WorkerResult> results(static_cast<size_t>(thread_count));
+    std::vector<std::thread> workers;
+    workers.reserve(static_cast<size_t>(thread_count));
+
+    for (int worker = 0; worker < thread_count; ++worker) {
+        workers.emplace_back([&, worker]() {
+            if (!pin_current_worker(
+                    worker_cpus[static_cast<size_t>(worker)])) {
+                results[static_cast<size_t>(worker)].error = 1;
+                abort.store(true, std::memory_order_release);
+                ready.fetch_add(1, std::memory_order_release);
+                return;
+            }
+            pinned_workers.fetch_add(1, std::memory_order_release);
+            cudaStream_t stream = nullptr;
+            cudaEvent_t start_event = nullptr;
+            cudaEvent_t end_event = nullptr;
+            unsigned int* device_value = nullptr;
+            if (cudaSetDevice(0) != cudaSuccess ||
+                cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking) !=
+                    cudaSuccess ||
+                cudaMalloc(&device_value, sizeof(*device_value)) != cudaSuccess ||
+                cudaMemsetAsync(device_value, 0, sizeof(*device_value), stream) !=
+                    cudaSuccess) {
+                results[static_cast<size_t>(worker)].error = 1;
+                abort.store(true, std::memory_order_release);
+                ready.fetch_add(1, std::memory_order_release);
+                return;
+            }
+            if (native_events &&
+                (cudaEventCreate(&start_event) != cudaSuccess ||
+                 cudaEventCreate(&end_event) != cudaSuccess)) {
+                results[static_cast<size_t>(worker)].error = 1;
+                abort.store(true, std::memory_order_release);
+                ready.fetch_add(1, std::memory_order_release);
+                return;
+            }
+
+            CUdeviceptr driver_value =
+                reinterpret_cast<CUdeviceptr>(device_value);
+            auto launch_kernel = [&]() {
+                if (native_events &&
+                    cuEventRecord(reinterpret_cast<CUevent>(start_event),
+                                  reinterpret_cast<CUstream>(stream)) !=
+                        CUDA_SUCCESS) {
+                    return false;
+                }
+                bool launched = true;
+                if (std::strcmp(api, "driver") == 0) {
+                    void* arguments[] = {&driver_value};
+                    launched = cuLaunchKernel(
+                               driver_function, 1, 1, 1, 1, 1, 1, 0,
+                               reinterpret_cast<CUstream>(stream), arguments,
+                               nullptr) == CUDA_SUCCESS;
+                } else if (std::strcmp(mode, "target") == 0) {
+                    peak_cuda_benchmark_target_kernel<<<1, 1, 0, stream>>>(
+                        device_value);
+                } else {
+                    peak_cuda_benchmark_non_target_kernel<<<1, 1, 0, stream>>>(
+                        device_value);
+                }
+                return launched &&
+                    (!native_events ||
+                     cuEventRecord(reinterpret_cast<CUevent>(end_event),
+                                   reinterpret_cast<CUstream>(stream)) ==
+                         CUDA_SUCCESS);
+            };
+
+            if (!launch_kernel() || cudaPeekAtLastError() != cudaSuccess ||
+                cudaStreamSynchronize(stream) != cudaSuccess) {
+                results[static_cast<size_t>(worker)].error = 1;
+                ready.fetch_add(1, std::memory_order_release);
+                return;
+            }
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start_warmup.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            if (abort.load(std::memory_order_acquire)) {
+                cudaFree(device_value);
+                cudaStreamDestroy(stream);
+                return;
+            }
+
+            for (int launch = 0; launch < batch_size; ++launch) {
+                if (!launch_kernel()) {
+                    results[static_cast<size_t>(worker)].error = 1;
+                    abort.store(true, std::memory_order_release);
+                    break;
+                }
+            }
+            if (cudaPeekAtLastError() != cudaSuccess ||
+                cudaStreamSynchronize(stream) != cudaSuccess) {
+                results[static_cast<size_t>(worker)].error = 1;
+                abort.store(true, std::memory_order_release);
+            }
+            warmup_done.fetch_add(1, std::memory_order_release);
+            while (!start_measurement.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            if (abort.load(std::memory_order_acquire)) {
+                cudaFree(device_value);
+                cudaStreamDestroy(stream);
+                return;
+            }
+
+            for (int begin = 0; begin < iterations; begin += batch_size) {
+                int count = std::min(batch_size, iterations - begin);
+                submission_barrier.wait();
+                auto batch_start = std::chrono::steady_clock::now();
+                for (int launch = 0; launch < count; ++launch) {
+                    if (!launch_kernel()) {
+                        results[static_cast<size_t>(worker)].error = 1;
+                        abort.store(true, std::memory_order_release);
+                        break;
+                    }
+                }
+                auto batch_end = std::chrono::steady_clock::now();
+                batch_start_ns[static_cast<size_t>(worker)] =
+                    static_cast<unsigned long long>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            batch_start.time_since_epoch())
+                            .count());
+                batch_end_ns[static_cast<size_t>(worker)] =
+                    static_cast<unsigned long long>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            batch_end.time_since_epoch())
+                            .count());
+                results[static_cast<size_t>(worker)].submission_ns +=
+                    static_cast<unsigned long long>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            batch_end - batch_start)
+                            .count());
+                submission_barrier.wait();
+                if (worker == 0) {
+                    auto first = std::min_element(batch_start_ns.begin(),
+                                                  batch_start_ns.end());
+                    auto last = std::max_element(batch_end_ns.begin(),
+                                                 batch_end_ns.end());
+                    aggregate_submission_ns += *last - *first;
+                    auto latest_start = std::max_element(
+                        batch_start_ns.begin(), batch_start_ns.end());
+                    auto earliest_end = std::min_element(
+                        batch_end_ns.begin(), batch_end_ns.end());
+                    if (*latest_start < *earliest_end) {
+                        ++overlapping_batches;
+                    } else {
+                        overlap_failure.store(true,
+                                              std::memory_order_release);
+                        abort.store(true, std::memory_order_release);
+                    }
+                }
+                submission_barrier.wait();
+                if (cudaPeekAtLastError() != cudaSuccess ||
+                    cudaStreamSynchronize(stream) != cudaSuccess) {
+                    results[static_cast<size_t>(worker)].error = 1;
+                    abort.store(true, std::memory_order_release);
+                }
+                submission_barrier.wait();
+                if (abort.load(std::memory_order_acquire)) {
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+            cudaFree(device_value);
+            if (start_event != nullptr) {
+                cudaEventDestroy(start_event);
+            }
+            if (end_event != nullptr) {
+                cudaEventDestroy(end_event);
+            }
+            cudaStreamDestroy(stream);
+        });
+    }
+
+    auto wait_deadline = std::chrono::steady_clock::now() +
+                         std::chrono::seconds(10);
+    while (ready.load(std::memory_order_acquire) != thread_count &&
+           std::chrono::steady_clock::now() < wait_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (ready.load(std::memory_order_acquire) != thread_count) {
+        std::fprintf(stderr, "cuda_test_error: benchmark worker setup timed out\n");
+        start_warmup.store(true, std::memory_order_release);
+        start_measurement.store(true, std::memory_order_release);
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+        return 1;
+    }
+    if (abort.load(std::memory_order_acquire)) {
+        start_warmup.store(true, std::memory_order_release);
+        start_measurement.store(true, std::memory_order_release);
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+        std::fprintf(stderr, "cuda_test_error: benchmark worker setup failed\n");
+        return 1;
+    }
+    if (pinned_workers.load(std::memory_order_acquire) != thread_count) {
+        start_warmup.store(true, std::memory_order_release);
+        start_measurement.store(true, std::memory_order_release);
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+        std::fprintf(stderr,
+                     "cuda_test_error: not every benchmark worker was pinned\n");
+        return 1;
+    }
+    start_warmup.store(true, std::memory_order_release);
+    auto warmup_deadline = std::chrono::steady_clock::now() +
+                           std::chrono::seconds(10);
+    while (warmup_done.load(std::memory_order_acquire) != thread_count &&
+           std::chrono::steady_clock::now() < warmup_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (warmup_done.load(std::memory_order_acquire) != thread_count) {
+        std::fprintf(stderr, "cuda_test_error: benchmark warmup timed out\n");
+        start_measurement.store(true, std::memory_order_release);
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+        return 1;
+    }
+    if (abort.load(std::memory_order_acquire)) {
+        start_measurement.store(true, std::memory_order_release);
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+        std::fprintf(stderr, "cuda_test_error: benchmark warmup failed\n");
+        return 1;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    if (harvester_ready != nullptr) {
+        harvester_ready_before_measurement = harvester_ready();
+        if (std::strcmp(mode, "target") == 0 &&
+            harvester_ready_before_measurement == 0) {
+            abort.store(true, std::memory_order_release);
+            start_measurement.store(true, std::memory_order_release);
+            for (std::thread& worker : workers) {
+                worker.join();
+            }
+            std::fprintf(
+                stderr,
+                "cuda_test_error: CUDA harvester was not ready before "
+                "the measured target phase\n");
+            return 1;
+        }
+    }
+    start_measurement.store(true, std::memory_order_release);
+    for (std::thread& worker : workers) {
+        worker.join();
+    }
+
+    unsigned long long total_submission_ns = 0;
+    for (const WorkerResult& result : results) {
+        if (result.error != 0) {
+            std::fprintf(stderr, "cuda_test_error: benchmark worker failed\n");
+            return 1;
+        }
+        total_submission_ns += result.submission_ns;
+    }
+    if (overlap_failure.load(std::memory_order_acquire) ||
+        overlapping_batches != measured_batches) {
+        std::fprintf(stderr,
+                     "cuda_test_error: only %d/%d measured batches had "
+                     "overlapping worker submissions\n",
+                     overlapping_batches, measured_batches);
+        return 1;
+    }
+    const unsigned long long calls =
+        static_cast<unsigned long long>(thread_count) *
+        static_cast<unsigned long long>(iterations);
+    const double host_ns_per_launch =
+        static_cast<double>(total_submission_ns) / static_cast<double>(calls);
+    if (aggregate_submission_ns == 0) {
+        std::fprintf(stderr,
+                     "cuda_test_error: benchmark aggregate duration is zero\n");
+        return 1;
+    }
+    const double aggregate_launches_per_second =
+        static_cast<double>(calls) * 1000000000.0 /
+        static_cast<double>(aggregate_submission_ns);
+    std::printf("cuda_launch_benchmark_ok api=%s mode=%s threads=%d calls=%llu "
+                "warmup_calls=%llu host_ns_per_launch=%.3f "
+                "aggregate_launches_per_second=%.3f "
+                "per_launch_synchronizations=0 available_cpus=%zu "
+                "pinned_workers=%d overlap_batches=%d/%d "
+                "harvester_ready_before_measurement=%d native_events=%d\n",
+                api, mode, thread_count, calls,
+                static_cast<unsigned long long>(thread_count) *
+                    static_cast<unsigned long long>(batch_size),
+                host_ns_per_launch, aggregate_launches_per_second,
+                worker_cpus.size(),
+                pinned_workers.load(std::memory_order_acquire),
+                overlapping_batches, measured_batches,
+                harvester_ready_before_measurement,
+                native_events ? 1 : 0);
+    return 0;
+}

--- a/test/cuda/cuda_test_common.cuh
+++ b/test/cuda/cuda_test_common.cuh
@@ -1,0 +1,43 @@
+#ifndef PEAK_CUDA_TEST_COMMON_CUH
+#define PEAK_CUDA_TEST_COMMON_CUH
+
+#include <cuda_runtime_api.h>
+
+#include <cstdio>
+
+constexpr int PEAK_CUDA_TEST_SKIP = 77;
+
+inline int
+peak_cuda_test_require_devices(int required, int* available)
+{
+    int count = 0;
+    cudaError_t result = cudaGetDeviceCount(&count);
+
+    if (result != cudaSuccess) {
+        std::printf("cuda_test_skip: cudaGetDeviceCount failed: %s\n",
+                    cudaGetErrorString(result));
+        return PEAK_CUDA_TEST_SKIP;
+    }
+    if (available != nullptr) {
+        *available = count;
+    }
+    if (count < required) {
+        std::printf("cuda_test_skip: requires %d CUDA device(s), found %d\n",
+                    required, count);
+        return PEAK_CUDA_TEST_SKIP;
+    }
+    return 0;
+}
+
+inline bool
+peak_cuda_test_check(cudaError_t result, const char* operation)
+{
+    if (result == cudaSuccess) {
+        return true;
+    }
+    std::fprintf(stderr, "cuda_test_error: %s failed: %s\n",
+                 operation, cudaGetErrorString(result));
+    return false;
+}
+
+#endif /* PEAK_CUDA_TEST_COMMON_CUH */

--- a/test/cuda/run_cuda_regressions.py
+++ b/test/cuda/run_cuda_regressions.py
@@ -1,0 +1,1044 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SKIP = 77
+
+
+@dataclass
+class RunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def output(self) -> str:
+        return self.stdout + "\n" + self.stderr
+
+
+def clean_environment() -> dict[str, str]:
+    env = {key: value for key, value in os.environ.items()
+           if not key.startswith("PEAK_")}
+    env.pop("LD_PRELOAD", None)
+    env.pop("DYLD_INSERT_LIBRARIES", None)
+    return env
+
+
+def profiled_environment(peak: Path, **overrides: str) -> dict[str, str]:
+    env = clean_environment()
+    env.update({
+        "LD_PRELOAD": str(peak),
+        "PEAK_HEARTBEAT_INTERVAL": "0",
+        "PEAK_OUTPUT_AGGREGATION": "local",
+        "PEAK_VERBOSITY": "warn",
+    })
+    env.update(overrides)
+    return env
+
+
+def run_process(command: list[str], env: dict[str, str], timeout: float,
+                cwd: Path) -> RunResult:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = process.communicate()
+        raise RuntimeError(
+            f"command timed out after {timeout:.1f}s: {' '.join(command)}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}")
+    return RunResult(process.returncode, stdout, stderr)
+
+
+def print_result(label: str, result: RunResult) -> None:
+    print(f"[{label}] stdout:")
+    print(result.stdout.rstrip())
+    if result.stderr:
+        print(f"[{label}] stderr:")
+        print(result.stderr.rstrip())
+
+
+def require_success(label: str, result: RunResult,
+                    allow_skip: bool = True) -> None:
+    if result.returncode == SKIP:
+        print_result(label, result)
+        if allow_skip:
+            raise SystemExit(SKIP)
+        raise RuntimeError(
+            f"{label} reported an unavailable GPU after its baseline passed")
+    if result.returncode != 0:
+        print_result(label, result)
+        raise RuntimeError(f"{label} exited with status {result.returncode}")
+
+
+def diagnostic(output: str, name: str, required: bool = True,
+               allow_negative: bool = False) -> int:
+    value_pattern = r"-?[0-9]+" if allow_negative else r"[0-9]+"
+    values = [int(value) for value in
+              re.findall(rf"(?<![A-Za-z0-9_]){re.escape(name)}=({value_pattern})",
+                         output)]
+    if not values:
+        if required:
+            raise RuntimeError(f"missing CUDA diagnostic: {name}=")
+        return 0
+    return max(values)
+
+
+def require_contains(output: str, token: str, label: str) -> None:
+    if token not in output:
+        raise RuntimeError(f"{label} is missing required token: {token}")
+
+
+def run_sampling(args: argparse.Namespace, directory: Path) -> None:
+    baseline = run_process([str(args.exe)], clean_environment(), 15, directory)
+    require_success("sampling-baseline", baseline)
+    profile = run_process(
+        [str(args.exe)],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="TRUE",
+            PEAK_CUDA_EVENT_POOL_CAPACITY="4",
+        ),
+        20,
+        directory,
+    )
+    require_success("sampling-profile", profile, allow_skip=False)
+    print_result("sampling-profile", profile)
+    require_contains(profile.output, "cuda_event_recycling_ok",
+                     "sampling application output")
+    require_contains(profile.output, "peak_cuda_recycling_late_marker_kernel",
+                     "sampling CUDA report")
+    observed = diagnostic(profile.output, "observed")
+    accepted = diagnostic(profile.output, "accepted")
+    completed = diagnostic(profile.output, "completed")
+    high_water = diagnostic(profile.output, "pool_high_water")
+    if observed < 49:
+        raise RuntimeError(f"observed={observed}, expected at least 49")
+    if accepted <= 4 or completed <= 4:
+        raise RuntimeError(
+            "event slots were not demonstrably recycled: "
+            f"accepted={accepted} completed={completed}")
+    if not completed <= accepted <= observed:
+        raise RuntimeError(
+            "CUDA sampling counters are inconsistent: "
+            f"completed={completed} accepted={accepted} observed={observed}")
+    if high_water > 4:
+        raise RuntimeError(
+            f"pool_high_water={high_water}, fixed capacity is 4")
+    print("cuda_sampling_regression_ok "
+          f"observed={observed} accepted={accepted} completed={completed} "
+          f"pool_high_water={high_water}")
+
+    disabled = run_process(
+        [str(args.exe)],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="TRUE",
+            PEAK_CUDA_EVENT_POOL_CAPACITY="4",
+            PEAK_TEST_FAIL_CUDA_HARVESTER_CAPTURE_MODE="1",
+        ),
+        20,
+        directory,
+    )
+    require_success("sampling-capture-mode-fail-open", disabled,
+                    allow_skip=False)
+    print_result("sampling-capture-mode-fail-open", disabled)
+    require_contains(disabled.output, "cuda_event_recycling_ok",
+                     "capture-mode initialization fail-open output")
+    require_contains(
+        disabled.output,
+        "could not enter relaxed stream-capture mode",
+        "capture-mode initialization fail-open warning",
+    )
+    disabled_observed = diagnostic(disabled.output, "observed")
+    disabled_accepted = diagnostic(disabled.output, "accepted")
+    disabled_completed = diagnostic(disabled.output, "completed")
+    disabled_high_water = diagnostic(disabled.output, "pool_high_water")
+    disabled_unavailable = diagnostic(
+        disabled.output, "harvester_unavailable")
+    if disabled_observed != 49 or disabled_accepted != 0 or \
+            disabled_completed != 0 or disabled_high_water != 0 or \
+            disabled_unavailable != 49:
+        raise RuntimeError(
+            "failed harvester initialization did not disable CUDA timing "
+            "without changing the application: "
+            f"observed={disabled_observed} accepted={disabled_accepted} "
+            f"completed={disabled_completed} "
+            f"pool_high_water={disabled_high_water} "
+            f"harvester_unavailable={disabled_unavailable}")
+    for counter in (
+            "pool_full", "identity_full", "event_create_failed",
+            "timing_error", "stream_capture_skipped",
+            "capture_query_failed", "capture_query_unsupported",
+            "unsupported_multi_device", "event_query_failed",
+            "elapsed_failed", "context_query_failed",
+            "context_switch_failed", "context_restore_failed",
+            "finalization_timeout", "finalization_incomplete",
+            "dimension_overflow"):
+        value = diagnostic(disabled.output, counter)
+        if value != 0:
+            raise RuntimeError(
+                "failed harvester initialization reported an unexpected "
+                f"CUDA profiler failure: {counter}={value}")
+
+
+def run_capture(args: argparse.Namespace, directory: Path) -> None:
+    baseline = run_process([str(args.exe)], clean_environment(), 15, directory)
+    require_success("capture-baseline", baseline)
+    profile = run_process(
+        [str(args.exe)],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="TRUE",
+            PEAK_CUDA_EVENT_POOL_CAPACITY="8",
+        ),
+        20,
+        directory,
+    )
+    require_success("capture-profile", profile, allow_skip=False)
+    print_result("capture-profile", profile)
+    require_contains(profile.output, "cuda_stream_capture_ok",
+                     "capture application output")
+    require_contains(profile.output, "runtime_helper_quiesced=1",
+                     "Runtime capture quiescence evidence")
+    require_contains(profile.output, "runtime_helper_recycled=1",
+                     "Runtime post-capture recycling evidence")
+    require_contains(profile.output, "driver_helper_quiesced=1",
+                     "Driver capture quiescence evidence")
+    require_contains(profile.output, "driver_helper_recycled=1",
+                     "Driver post-capture recycling evidence")
+    skipped = diagnostic(profile.output, "stream_capture_skipped")
+    observed = diagnostic(profile.output, "observed")
+    accepted = diagnostic(profile.output, "accepted")
+    completed = diagnostic(profile.output, "completed")
+    high_water = diagnostic(profile.output, "pool_high_water")
+    pool_full = diagnostic(profile.output, "pool_full")
+    unavailable = diagnostic(profile.output, "harvester_unavailable")
+    identity_full = diagnostic(profile.output, "identity_full")
+    warmup_match = re.search(r"initialization_warmups=([0-9]+)",
+                             profile.output)
+    if warmup_match is None:
+        raise RuntimeError("capture fixture did not report initialization "
+                           "warmup attempts")
+    warmups = int(warmup_match.group(1))
+    if skipped < 80 or skipped % 40 != 0:
+        raise RuntimeError(
+            "captured target launches were not consistently classified as "
+            f"pass-through: stream_capture_skipped={skipped}")
+    minimum_sampled_or_full = 83
+    if warmups < 1 or unavailable < 1 or unavailable > 2 * warmups or \
+            observed != accepted + pool_full + unavailable + skipped or \
+            accepted + pool_full < minimum_sampled_or_full or \
+            completed != accepted:
+        raise RuntimeError(
+            "capture accounting did not include every captured launch, "
+            "graph launch, helper marker, and initialization pass-through: "
+            f"observed={observed} accepted={accepted} "
+            f"completed={completed} pool_full={pool_full} "
+            f"harvester_unavailable={unavailable} "
+            f"initialization_warmups={warmups} "
+            f"minimum_sampled_or_full={minimum_sampled_or_full}")
+    if high_water == 0 or high_water > 8:
+        raise RuntimeError(
+            f"pool_high_water={high_water}, expected in [1, 8]")
+    if identity_full < 1:
+        raise RuntimeError(
+            "graph-identity churn did not exercise the fixed aggregate "
+            f"bound: identity_full={identity_full}")
+    for counter in (
+            "event_create_failed", "timing_error",
+            "capture_query_failed", "capture_query_unsupported",
+            "unsupported_multi_device", "event_query_failed",
+            "elapsed_failed", "context_query_failed",
+            "context_switch_failed", "context_restore_failed",
+            "finalization_timeout", "finalization_incomplete",
+            "dimension_overflow"):
+        value = diagnostic(profile.output, counter)
+        if value != 0:
+            raise RuntimeError(f"{counter}={value}, expected 0")
+    print("cuda_capture_regression_ok "
+          f"stream_capture_skipped={skipped} observed={observed} "
+          f"accepted={accepted} completed={completed} "
+          f"harvester_unavailable={unavailable} "
+          f"pool_full={pool_full} pool_high_water={high_water} "
+          f"identity_full={identity_full}")
+
+    races = run_process(
+        [str(args.exe), "--capture-races"],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="TRUE",
+            PEAK_CUDA_EVENT_POOL_CAPACITY="16",
+        ),
+        30,
+        directory,
+    )
+    require_success("capture-races", races, allow_skip=False)
+    print_result("capture-races", races)
+    require_contains(races.output, "cuda_capture_races_ok",
+                     "capture race application output")
+    require_contains(races.output, "begin_first_nodes=1",
+                     "begin-first graph topology")
+    require_contains(races.output, "begin_first_results=1/1",
+                     "begin-first application results")
+    require_contains(races.output, "reader_first_nodes=1",
+                     "reader-first graph topology")
+    require_contains(races.output, "reader_first_results=1/1",
+                     "reader-first application results")
+    require_contains(races.output, "reader_pending_quiesced=1",
+                     "reader-first harvester quiescence")
+    require_contains(races.output, "reader_pending_recycled=1",
+                     "reader-first post-capture recycling")
+    require_contains(races.output, "global_cycles=32",
+                     "global cross-stream capture cycles")
+    require_contains(races.output, "global_nodes_per_cycle=1",
+                     "global cross-stream graph topology")
+    require_contains(races.output, "global_results=32/32",
+                     "global cross-stream application results")
+
+    race_warmup_match = re.search(r"initialization_warmups=([0-9]+)",
+                                  races.output)
+    if race_warmup_match is None:
+        raise RuntimeError("capture race fixture did not report harvester "
+                           "warmup attempts")
+    race_warmups = int(race_warmup_match.group(1))
+    race_observed = diagnostic(races.output, "observed")
+    race_accepted = diagnostic(races.output, "accepted")
+    race_completed = diagnostic(races.output, "completed")
+    race_unavailable = diagnostic(races.output, "harvester_unavailable")
+    race_skipped = diagnostic(races.output, "stream_capture_skipped")
+    race_high_water = diagnostic(races.output, "pool_high_water")
+    race_pool_full = diagnostic(races.output, "pool_full")
+    minimum_race_sampled_or_full = 36
+    if race_warmups < 1 or race_unavailable < 1 or \
+            race_unavailable > 2 * race_warmups or \
+            race_skipped < 67 or \
+            race_observed != race_accepted + race_pool_full + \
+            race_unavailable + race_skipped or \
+            race_accepted + race_pool_full < \
+            minimum_race_sampled_or_full or \
+            race_completed != race_accepted or race_high_water == 0 or \
+            race_high_water > 16:
+        raise RuntimeError(
+            "capture race accounting did not preserve the admitted-reader "
+            "launch and every post-capture graph launch: "
+            f"observed={race_observed} accepted={race_accepted} "
+            f"completed={race_completed} skipped={race_skipped} "
+            f"harvester_unavailable={race_unavailable} "
+            f"initialization_warmups={race_warmups} "
+            f"pool_full={race_pool_full} "
+            f"minimum_sampled_or_full={minimum_race_sampled_or_full} "
+            f"pool_high_water={race_high_water}")
+    for counter in (
+            "identity_full", "event_create_failed",
+            "timing_error", "capture_query_failed",
+            "capture_query_unsupported", "unsupported_multi_device",
+            "event_query_failed", "elapsed_failed",
+            "context_query_failed", "context_switch_failed",
+            "context_restore_failed", "finalization_timeout",
+            "finalization_incomplete", "dimension_overflow"):
+        value = diagnostic(races.output, counter)
+        if value != 0:
+            raise RuntimeError(
+                f"capture race reported {counter}={value}, expected 0")
+    print("cuda_capture_race_regression_ok "
+          f"observed={race_observed} accepted={race_accepted} "
+          f"completed={race_completed} "
+          f"stream_capture_skipped={race_skipped} "
+          f"pool_full={race_pool_full}")
+
+    lifecycle_environment = profiled_environment(
+        args.peak,
+        PEAK_GPU_MONITOR_ALL="TRUE",
+        PEAK_CUDA_EVENT_POOL_CAPACITY="8",
+        PEAK_CUDA_FINALIZATION_TIMEOUT_MS="500",
+    )
+    lifecycle_cases = (
+        (
+            "reader-wins",
+            "--lifecycle-reader-wins",
+            "cuda_lifecycle_reader_wins_ok",
+            (
+                "admitted_before_close=1",
+                "closer_waited=1",
+                "capture_waited_for_reader=1",
+                "fail_closed_transition=1",
+                "nodes=1",
+                "result=2",
+            ),
+        ),
+        (
+            "closer-wins",
+            "--lifecycle-closer-wins",
+            "cuda_lifecycle_closer_wins_ok",
+            (
+                "close_before_increment=1",
+                "finalize_before_release=1",
+                "listener_rejected=1",
+                "fail_closed_transition=1",
+                "nodes=1",
+                "result=2",
+            ),
+        ),
+    )
+    for label, option, marker, evidence in lifecycle_cases:
+        lifecycle = run_process(
+            [str(args.exe), option], lifecycle_environment, 15, directory)
+        require_success(f"capture-lifecycle-{label}", lifecycle,
+                        allow_skip=False)
+        print_result(f"capture-lifecycle-{label}", lifecycle)
+        require_contains(lifecycle.output, marker,
+                         f"CUDA lifecycle {label} marker")
+        for token in evidence:
+            require_contains(lifecycle.output, token,
+                             f"CUDA lifecycle {label} evidence")
+        for counter in (
+                "pool_full", "identity_full", "event_create_failed",
+                "timing_error", "stream_capture_skipped",
+                "capture_query_failed", "capture_query_unsupported",
+                "unsupported_multi_device", "event_query_failed",
+                "elapsed_failed", "context_query_failed",
+                "context_switch_failed", "context_restore_failed",
+                "finalization_timeout", "finalization_incomplete",
+                "dimension_overflow"):
+            value = diagnostic(lifecycle.output, counter)
+            if value != 0:
+                raise RuntimeError(
+                    f"CUDA lifecycle {label} reported {counter}={value}, "
+                    "expected 0")
+    print("cuda_lifecycle_gate_regression_ok orderings=2 "
+          "listener_rejection=1")
+
+
+def run_context(args: argparse.Namespace, directory: Path) -> None:
+    baseline = run_process([str(args.exe)], clean_environment(), 25, directory)
+    require_success("context-baseline", baseline)
+    profile = run_process(
+        [str(args.exe)],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="TRUE",
+            PEAK_CUDA_EVENT_POOL_CAPACITY="2",
+        ),
+        30,
+        directory,
+    )
+    require_success("context-profile", profile, allow_skip=False)
+    print_result("context-profile", profile)
+    require_contains(profile.output, "cuda_multi_context_ok",
+                     "multi-context application output")
+    require_contains(profile.output, "context_restore_checks=24",
+                     "Driver multi-context application output")
+    require_contains(profile.output, "results=12/12",
+                     "Driver multi-context application output")
+    require_contains(profile.output, "query_error_injected=1",
+                     "Driver harvest-error application output")
+    names_match = re.search(r"driver_names_available=([01])", profile.output)
+    if names_match is None:
+        raise RuntimeError("multi-context fixture did not report Driver name "
+                           "capability")
+    if int(names_match.group(1)) != 0:
+        require_contains(profile.output, "peak_cuda_context_driver_zero",
+                         "multi-context CUDA report")
+        require_contains(profile.output, "peak_cuda_context_driver_one",
+                         "multi-context CUDA report")
+
+    for counter in ("elapsed_failed", "context_query_failed",
+                    "context_switch_failed",
+                    "context_restore_failed"):
+        value = diagnostic(profile.output, counter)
+        if value != 0:
+            raise RuntimeError(f"{counter}={value}, expected 0")
+    event_query_failed = diagnostic(profile.output, "event_query_failed")
+    if event_query_failed != 1:
+        raise RuntimeError(
+            f"event_query_failed={event_query_failed}, expected exactly 1")
+    timing_error = diagnostic(profile.output, "timing_error")
+    if timing_error != event_query_failed:
+        raise RuntimeError(
+            "the injected event-query failure was not reflected exactly in "
+            f"the aggregate timing counter: timing_error={timing_error} "
+            f"event_query_failed={event_query_failed}")
+
+    called_match = re.search(r"multi_device_called=([01])", baseline.output)
+    if called_match is None:
+        raise RuntimeError("baseline did not report multi_device_called")
+    multi_device_called = int(called_match.group(1))
+    unsupported = diagnostic(profile.output, "unsupported_multi_device")
+    if multi_device_called and unsupported < 1:
+        raise RuntimeError(
+            "the cooperative multi-device call was not explicitly skipped")
+
+    accepted = diagnostic(profile.output, "accepted")
+    completed = diagnostic(profile.output, "completed")
+    observed = diagnostic(profile.output, "observed")
+    unavailable = diagnostic(profile.output, "harvester_unavailable")
+    high_water = diagnostic(profile.output, "pool_high_water")
+    pool_full = diagnostic(profile.output, "pool_full")
+    warmup_match = re.search(r"initialization_warmups=([0-9]+)",
+                             profile.output)
+    if warmup_match is None:
+        raise RuntimeError("multi-context fixture did not report harvester "
+                           "warmup attempts")
+    warmups = int(warmup_match.group(1))
+    expected_observed = warmups + 25 + unsupported
+    expected_accepted = expected_observed - unavailable - unsupported
+    if warmups < 1 or unavailable < 1 or unavailable > warmups or \
+            observed != expected_observed or \
+            accepted != expected_accepted or \
+            completed != accepted - 1 or pool_full != 0 or \
+            high_water == 0 or high_water > 2:
+        raise RuntimeError(
+            "context-owned slots were not recycled after the injected "
+            "harvest failure: "
+            f"observed={observed} accepted={accepted} "
+            f"completed={completed} pool_full={pool_full} "
+            f"pool_high_water={high_water} "
+            f"harvester_unavailable={unavailable} "
+            f"initialization_warmups={warmups} "
+            f"unsupported_multi_device={unsupported}")
+    for counter in (
+            "identity_full", "event_create_failed",
+            "stream_capture_skipped", "capture_query_failed",
+            "capture_query_unsupported", "elapsed_failed",
+            "finalization_timeout", "finalization_incomplete",
+            "dimension_overflow"):
+        value = diagnostic(profile.output, counter)
+        if value != 0:
+            raise RuntimeError(f"{counter}={value}, expected 0")
+    print("cuda_context_regression_ok "
+          f"observed={observed} accepted={accepted} completed={completed} "
+          f"pool_full={pool_full} "
+          f"multi_device_called={multi_device_called} "
+          f"unsupported_multi_device={unsupported}")
+
+
+def run_finalization(args: argparse.Namespace, directory: Path) -> None:
+    baseline = run_process([str(args.exe)], clean_environment(), 15, directory)
+    require_success("finalization-baseline", baseline)
+    environment = profiled_environment(
+        args.peak,
+        PEAK_GPU_MONITOR_ALL="TRUE",
+        PEAK_CUDA_EVENT_POOL_CAPACITY="4",
+        PEAK_CUDA_FINALIZATION_TIMEOUT_MS="100",
+    )
+    profile = run_process(
+        [str(args.exe)],
+        environment,
+        15,
+        directory,
+    )
+    require_success("finalization-profile", profile, allow_skip=False)
+    print_result("finalization-profile", profile)
+    require_contains(profile.output, "cuda_finalization_deadline_ok",
+                     "finalization application output")
+    require_contains(profile.output, "peak_cuda_ready_finalization_kernel",
+                     "ready CUDA record before finalization timeout")
+    require_contains(profile.output, "CUDA incomplete event context=",
+                     "bounded finalization diagnostic")
+    require_contains(profile.output, "device=",
+                     "bounded finalization diagnostic")
+    timed_out = diagnostic(profile.output, "finalization_timeout")
+    incomplete = diagnostic(profile.output, "finalization_incomplete")
+    observed = diagnostic(profile.output, "observed")
+    accepted = diagnostic(profile.output, "accepted")
+    completed = diagnostic(profile.output, "completed")
+    unavailable = diagnostic(profile.output, "harvester_unavailable")
+    warmup_match = re.search(r"initialization_warmups=([0-9]+)",
+                             profile.output)
+    if warmup_match is None:
+        raise RuntimeError("finalization fixture did not report harvester "
+                           "warmup attempts")
+    warmups = int(warmup_match.group(1))
+    if timed_out != 1 or incomplete != 1 or warmups < 1 or \
+            unavailable < 1 or unavailable > warmups or \
+            observed != warmups + 2 or \
+            accepted != observed - unavailable or \
+            completed != accepted - 1:
+        raise RuntimeError(
+            "ready and incomplete GPU work were not accounted exactly at "
+            "the deadline: "
+            f"finalization_timeout={timed_out} "
+            f"finalization_incomplete={incomplete} observed={observed} "
+            f"accepted={accepted} completed={completed} "
+            f"harvester_unavailable={unavailable} "
+            f"initialization_warmups={warmups}")
+    for counter in (
+            "pool_full", "identity_full", "event_create_failed",
+            "timing_error", "stream_capture_skipped",
+            "capture_query_failed", "capture_query_unsupported",
+            "unsupported_multi_device", "event_query_failed",
+            "elapsed_failed", "context_query_failed",
+            "context_switch_failed", "context_restore_failed",
+            "dimension_overflow"):
+        value = diagnostic(profile.output, counter)
+        if value != 0:
+            raise RuntimeError(
+                f"finalization profile reported {counter}={value}, "
+                "expected 0")
+    print("cuda_finalization_regression_ok "
+          f"finalization_timeout={timed_out} "
+          f"finalization_incomplete={incomplete}")
+
+    forced = run_process(
+        [str(args.exe), "--forced-incomplete"],
+        environment,
+        15,
+        directory,
+    )
+    require_success("finalization-forced-incomplete", forced,
+                    allow_skip=False)
+    print_result("finalization-forced-incomplete", forced)
+    require_contains(forced.output,
+                     "cuda_forced_incomplete_finalization_ok",
+                     "forced-incomplete application output")
+    require_contains(forced.output, "CUDA incomplete event context=",
+                     "forced-incomplete context diagnostic")
+    require_contains(forced.output, "device=",
+                     "forced-incomplete device diagnostic")
+    forced_timed_out = diagnostic(forced.output, "finalization_timeout")
+    forced_incomplete = diagnostic(forced.output, "finalization_incomplete")
+    forced_observed = diagnostic(forced.output, "observed")
+    forced_accepted = diagnostic(forced.output, "accepted")
+    forced_completed = diagnostic(forced.output, "completed")
+    forced_unavailable = diagnostic(forced.output, "harvester_unavailable")
+    forced_warmup_match = re.search(
+        r"initialization_warmups=([0-9]+)", forced.output)
+    if forced_warmup_match is None:
+        raise RuntimeError("forced finalization fixture did not report "
+                           "harvester warmup attempts")
+    forced_warmups = int(forced_warmup_match.group(1))
+    if forced_timed_out != 1 or forced_incomplete != 1 or \
+            forced_warmups < 1 or forced_unavailable < 1 or \
+            forced_unavailable > forced_warmups or \
+            forced_observed != forced_warmups + 2 or \
+            forced_accepted != forced_observed - forced_unavailable or \
+            forced_completed != forced_accepted - 1:
+        raise RuntimeError(
+            "forced-incomplete event state was not retained at the deadline: "
+            f"finalization_timeout={forced_timed_out} "
+            f"finalization_incomplete={forced_incomplete} "
+            f"observed={forced_observed} accepted={forced_accepted} "
+            f"completed={forced_completed} "
+            f"harvester_unavailable={forced_unavailable} "
+            f"initialization_warmups={forced_warmups}")
+    for counter in (
+            "pool_full", "identity_full", "event_create_failed",
+            "timing_error", "stream_capture_skipped",
+            "capture_query_failed", "capture_query_unsupported",
+            "unsupported_multi_device", "event_query_failed",
+            "elapsed_failed", "context_query_failed",
+            "context_switch_failed", "context_restore_failed",
+            "dimension_overflow"):
+        value = diagnostic(forced.output, counter)
+        if value != 0:
+            raise RuntimeError(
+                f"forced finalization profile reported {counter}={value}, "
+                "expected 0")
+    print("cuda_forced_incomplete_regression_ok "
+          f"finalization_timeout={forced_timed_out} "
+          f"finalization_incomplete={forced_incomplete}")
+
+
+def benchmark_metric(result: RunResult) -> float:
+    match = re.search(r"host_ns_per_launch=([0-9]+(?:\.[0-9]+)?)",
+                      result.output)
+    if match is None:
+        raise RuntimeError("benchmark output is missing host_ns_per_launch")
+    value = float(match.group(1))
+    if value <= 0:
+        raise RuntimeError(f"invalid host_ns_per_launch={value}")
+    return value
+
+
+def benchmark_throughput(result: RunResult) -> float:
+    match = re.search(
+        r"aggregate_launches_per_second=([0-9]+(?:\.[0-9]+)?)",
+        result.output)
+    if match is None:
+        raise RuntimeError(
+            "benchmark output is missing aggregate_launches_per_second")
+    value = float(match.group(1))
+    if value <= 0:
+        raise RuntimeError(f"invalid aggregate_launches_per_second={value}")
+    return value
+
+
+def benchmark_samples(args: argparse.Namespace, directory: Path, api: str,
+                      mode: str, threads: int,
+                      profiled: bool,
+                      native_events: bool = False) -> tuple[float, float]:
+    latencies = []
+    throughputs = []
+    variant = "profile" if profiled else (
+        "event-floor" if native_events else "base")
+    for sample in range(args.samples):
+        command = [
+            str(args.exe),
+            "--api", api,
+            "--mode", mode,
+            "--threads", str(threads),
+            "--iterations", str(args.iterations),
+            "--batch", str(args.batch),
+        ]
+        if native_events:
+            command.append("--native-events")
+        if profiled:
+            pool_capacity = max(64, threads * args.batch * 2)
+            profiler_options = {
+                "PEAK_CUDA_EVENT_POOL_CAPACITY": str(pool_capacity),
+            }
+            if api == "driver" and mode == "target":
+                # Driver function-handle names are toolkit-specific. Monitor
+                # all launches to exercise the same accepted timing path
+                # without making this performance gate depend on that name.
+                profiler_options["PEAK_GPU_MONITOR_ALL"] = "TRUE"
+            else:
+                profiler_options["PEAK_GPU_TARGET"] = (
+                    "peak_cuda_benchmark_target_kernel")
+            env = profiled_environment(args.peak, **profiler_options)
+        else:
+            env = clean_environment()
+        result = run_process(command, env, 20, directory)
+        require_success(
+            f"benchmark-{api}-{mode}-{threads}-{variant}-{sample}",
+            result, allow_skip=not profiled)
+        print_result(
+            f"benchmark-{api}-{mode}-{threads}-{variant}-{sample}", result)
+        require_contains(result.output, f"api={api}",
+                         f"benchmark {api} API evidence")
+        require_contains(
+            result.output,
+            f"native_events={1 if native_events else 0}",
+            f"benchmark {api} native-event evidence",
+        )
+        available_cpus = diagnostic(result.output, "available_cpus")
+        pinned_workers = diagnostic(result.output, "pinned_workers")
+        if available_cpus < threads or pinned_workers != threads:
+            raise RuntimeError(
+                "benchmark workers did not use distinct allowed CPUs: "
+                f"sample={sample} api={api} threads={threads} "
+                f"available_cpus={available_cpus} "
+                f"pinned_workers={pinned_workers}")
+        overlap = re.search(r"overlap_batches=([0-9]+)/([0-9]+)",
+                            result.output)
+        expected_batches = (args.iterations + args.batch - 1) // args.batch
+        if overlap is None or int(overlap.group(1)) != expected_batches or \
+                int(overlap.group(2)) != expected_batches:
+            observed_overlap = overlap.group(0) if overlap is not None \
+                else "missing"
+            raise RuntimeError(
+                "benchmark submission intervals did not overlap in every "
+                f"batch: sample={sample} api={api} threads={threads} "
+                f"overlap={observed_overlap} expected={expected_batches}")
+        if profiled:
+            expected_ready = 1 if mode == "target" else 0
+            # Production builds intentionally omit the test-only readiness
+            # symbol. Exact accounting below still proves that every measured
+            # target launch was admitted (unavailable cannot exceed warmup).
+            ready = diagnostic(
+                result.output, "harvester_ready_before_measurement",
+                allow_negative=True)
+            if ready not in (expected_ready, -1):
+                raise RuntimeError(
+                    f"benchmark {api} {mode} measured-phase admission "
+                    f"reported harvester_ready_before_measurement={ready}, "
+                    f"expected {expected_ready} or unavailable (-1)")
+            observed = diagnostic(result.output, "observed")
+            accepted = diagnostic(result.output, "accepted")
+            completed = diagnostic(result.output, "completed")
+            high_water = diagnostic(result.output, "pool_high_water")
+            unavailable = diagnostic(result.output,
+                                     "harvester_unavailable")
+            if mode == "target":
+                application_launches = (
+                    threads * (1 + args.batch + args.iterations))
+                pre_measurement = threads * (1 + args.batch)
+                if observed != application_launches or unavailable < 1 or \
+                        unavailable > pre_measurement or \
+                        accepted + unavailable != observed or \
+                        completed != accepted or high_water == 0:
+                    raise RuntimeError(
+                        "target benchmark did not keep the measured workload "
+                        "on the sampled path: "
+                        f"sample={sample} api={api} threads={threads} "
+                        f"observed={observed} accepted={accepted} "
+                        f"completed={completed} high_water={high_water} "
+                        f"harvester_unavailable={unavailable} "
+                        f"application_launches={application_launches} "
+                        f"pre_measurement={pre_measurement}")
+            elif observed != 0 or accepted != 0 or completed != 0 or \
+                    high_water != 0 or unavailable != 0:
+                raise RuntimeError(
+                    "non-target benchmark entered CUDA timing accounting: "
+                    f"sample={sample} api={api} threads={threads} "
+                    f"observed={observed} accepted={accepted} "
+                    f"completed={completed} high_water={high_water} "
+                    f"harvester_unavailable={unavailable}")
+            failure_counters = (
+                "pool_full", "identity_full", "event_create_failed",
+                "timing_error", "stream_capture_skipped",
+                "capture_query_failed", "capture_query_unsupported",
+                "unsupported_multi_device", "event_query_failed",
+                "elapsed_failed", "context_query_failed",
+                "context_switch_failed", "context_restore_failed",
+                "finalization_timeout", "finalization_incomplete",
+                "dimension_overflow",
+            )
+            for counter in failure_counters:
+                value = diagnostic(result.output, counter)
+                if value != 0:
+                    raise RuntimeError(
+                        "benchmark reported a CUDA profiler failure: "
+                        f"sample={sample} api={api} threads={threads} "
+                        f"{counter}={value}")
+        latencies.append(benchmark_metric(result))
+        throughputs.append(benchmark_throughput(result))
+    return (statistics.median(latencies),
+            statistics.median(throughputs))
+
+
+def run_benchmark(args: argparse.Namespace, directory: Path) -> None:
+    thread_counts = [1]
+    for threads in (8, 32, args.concurrent_threads):
+        if threads <= args.concurrent_threads and threads not in thread_counts:
+            thread_counts.append(threads)
+    thread_counts.sort()
+    measurements: dict[tuple[str, str, int, bool], float] = {}
+    throughputs: dict[tuple[str, str, int, bool], float] = {}
+    target_event_floors: dict[tuple[str, int], float] = {}
+    target_event_floor_throughputs: dict[tuple[str, int], float] = {}
+    for api in ("runtime", "driver"):
+        for mode in ("non-target", "target"):
+            for threads in thread_counts:
+                baseline, baseline_throughput = benchmark_samples(
+                    args, directory, api, mode, threads, False)
+                if mode == "target":
+                    event_floor, event_floor_throughput = benchmark_samples(
+                        args, directory, api, mode, threads, False,
+                        native_events=True)
+                    target_event_floors[(api, threads)] = event_floor
+                    target_event_floor_throughputs[(api, threads)] = \
+                        event_floor_throughput
+                profile, profile_throughput = benchmark_samples(
+                    args, directory, api, mode, threads, True)
+                measurements[(api, mode, threads, False)] = baseline
+                measurements[(api, mode, threads, True)] = profile
+                throughputs[(api, mode, threads, False)] = baseline_throughput
+                throughputs[(api, mode, threads, True)] = profile_throughput
+
+    for api in ("runtime", "driver"):
+        for threads in thread_counts:
+            baseline = measurements[(api, "non-target", threads, False)]
+            profile = measurements[(api, "non-target", threads, True)]
+            limit = baseline * args.max_non_target_relative + \
+                args.max_non_target_additive_ns
+            if profile > limit:
+                raise RuntimeError(
+                    f"{api}/non-target/{threads} overhead is too high: "
+                    f"baseline={baseline:.3f}ns profile={profile:.3f}ns "
+                    f"limit={limit:.3f}ns")
+
+            target_baseline = measurements[(api, "target", threads, False)]
+            target_profile = measurements[(api, "target", threads, True)]
+            target_event_floor = target_event_floors[(api, threads)]
+            target_increment = target_profile - target_event_floor
+            target_ratio = target_profile / target_event_floor
+            if target_ratio > args.max_target_relative:
+                raise RuntimeError(
+                    f"{api}/target/{threads} relative overhead is too high: "
+                    f"event_floor={target_event_floor:.3f}ns "
+                    f"profile={target_profile:.3f}ns "
+                    f"ratio={target_ratio:.3f}x "
+                    f"limit={args.max_target_relative:.3f}x")
+            if target_increment > args.max_target_additive_ns:
+                raise RuntimeError(
+                    f"{api}/target/{threads} incremental overhead is too "
+                    "high: "
+                    f"baseline={target_baseline:.3f}ns "
+                    f"event_floor={target_event_floor:.3f}ns "
+                    f"profile={target_profile:.3f}ns "
+                    f"increment={target_increment:.3f}ns")
+
+    for api in ("runtime", "driver"):
+        for mode in ("non-target", "target"):
+            def scaled_throughput(threads: int) -> float:
+                profile = throughputs[(api, mode, threads, True)]
+                if mode == "target":
+                    return profile / target_event_floor_throughputs[
+                        (api, threads)]
+                # CUDA launch throughput itself can saturate as concurrency
+                # rises. Normalize the no-record path by its matching
+                # unprofiled sample so this unchanged scaling gate measures
+                # PEAK retention instead of the driver's native curve.
+                return profile / throughputs[
+                    (api, mode, threads, False)]
+
+            one_thread = scaled_throughput(1)
+            previous = one_thread
+            for threads in thread_counts[1:]:
+                current = scaled_throughput(threads)
+                reference = max(one_thread, previous)
+                floor = reference * args.min_profile_throughput_scaling
+                if current < floor:
+                    raise RuntimeError(
+                        f"{api}/{mode}/{threads} profiled throughput "
+                        "declined with concurrency: "
+                        f"one_thread={one_thread:.3f} "
+                        f"previous={previous:.3f} current={current:.3f} "
+                        f"floor={floor:.3f}")
+                previous = current
+
+    for api in ("runtime", "driver"):
+        for mode in ("non-target", "target"):
+            def comparison_latency(threads: int) -> float:
+                if mode == "target":
+                    return target_event_floors[(api, threads)]
+                return measurements[(api, mode, threads, False)]
+
+            def comparison_throughput(threads: int) -> float:
+                if mode == "target":
+                    return target_event_floor_throughputs[(api, threads)]
+                return throughputs[(api, mode, threads, False)]
+
+            one_factor = (measurements[(api, mode, 1, True)] /
+                          comparison_latency(1))
+            one_retention = (throughputs[(api, mode, 1, True)] /
+                             comparison_throughput(1))
+            for threads in thread_counts[1:]:
+                concurrent_factor = (
+                    measurements[(api, mode, threads, True)] /
+                    comparison_latency(threads))
+                retention = (throughputs[(api, mode, threads, True)] /
+                             comparison_throughput(threads))
+                if concurrent_factor > one_factor * \
+                        args.max_concurrency_regression or \
+                        retention * args.max_concurrency_regression < \
+                        one_retention:
+                    raise RuntimeError(
+                        f"{api}/{mode}/{threads} profiler scaling regressed: "
+                        f"one_thread_slowdown={one_factor:.3f}x "
+                        f"concurrent_slowdown={concurrent_factor:.3f}x "
+                        f"one_thread_retention={one_retention:.3f} "
+                        f"concurrent_retention={retention:.3f}")
+
+    for api in ("runtime", "driver"):
+        for mode in ("non-target", "target"):
+            for threads in thread_counts:
+                baseline = measurements[(api, mode, threads, False)]
+                profile = measurements[(api, mode, threads, True)]
+                baseline_throughput = throughputs[
+                    (api, mode, threads, False)]
+                profile_throughput = throughputs[
+                    (api, mode, threads, True)]
+                print("cuda_launch_benchmark_result "
+                      f"api={api} mode={mode} threads={threads} "
+                      f"baseline_ns={baseline:.3f} "
+                      f"profile_ns={profile:.3f} "
+                      f"ratio={profile / baseline:.6f} "
+                      f"baseline_launches_per_second="
+                      f"{baseline_throughput:.3f} "
+                      f"profile_launches_per_second="
+                      f"{profile_throughput:.3f} throughput_retention="
+                      f"{profile_throughput / baseline_throughput:.6f}" +
+                      (f" native_event_floor_ns="
+                       f"{target_event_floors[(api, threads)]:.3f} "
+                       f"software_increment_ns="
+                       f"{profile - target_event_floors[(api, threads)]:.3f} "
+                       f"event_floor_ratio="
+                       f"{profile / target_event_floors[(api, threads)]:.6f} "
+                       f"native_event_floor_launches_per_second="
+                       f"{target_event_floor_throughputs[(api, threads)]:.3f} "
+                       f"event_floor_throughput_retention="
+                       f"{profile_throughput / target_event_floor_throughputs[(api, threads)]:.6f}"
+                       if mode == "target" else ""))
+    print("cuda_launch_benchmark_validation_ok")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("case", choices=(
+        "sampling", "capture", "context", "finalization", "benchmark"))
+    parser.add_argument("--exe", type=Path, required=True)
+    parser.add_argument("--peak", type=Path, required=True)
+    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=64)
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--concurrent-threads", type=int, default=8)
+    parser.add_argument("--max-non-target-relative", type=float, default=1.25)
+    parser.add_argument("--max-non-target-additive-ns", type=float, default=500.0)
+    parser.add_argument("--max-target-relative", type=float, default=2.00)
+    parser.add_argument("--max-target-additive-ns", type=float, default=10000.0)
+    parser.add_argument("--max-concurrency-regression", type=float, default=1.10)
+    parser.add_argument("--min-profile-throughput-scaling", type=float,
+                        default=0.90)
+    args = parser.parse_args()
+    if args.samples <= 0 or args.iterations <= 0 or args.batch <= 0 or \
+            args.concurrent_threads <= 0:
+        parser.error("benchmark counts must be positive")
+    if args.max_non_target_relative < 1.0 or \
+            args.max_target_relative < 1.0 or \
+            args.max_concurrency_regression < 1.0:
+        parser.error("relative overhead limits must be at least 1.0")
+    if args.max_non_target_additive_ns < 0 or \
+            args.max_target_additive_ns < 0:
+        parser.error("additive overhead limits must be non-negative")
+    if not 0.0 < args.min_profile_throughput_scaling <= 1.0:
+        parser.error("profile throughput scaling must be in (0, 1]")
+    return args
+
+
+def main() -> int:
+    args = parse_arguments()
+    if sys.platform != "linux":
+        print("cuda_test_skip: CUDA preload regressions require Linux")
+        return SKIP
+    if not args.exe.is_file() or not args.peak.is_file():
+        raise RuntimeError("CUDA fixture executable or PEAK library is missing")
+    args.exe = args.exe.resolve()
+    args.peak = args.peak.resolve()
+
+    with tempfile.TemporaryDirectory(prefix=f"peak-cuda-{args.case}-") as temp:
+        directory = Path(temp)
+        if args.case == "sampling":
+            run_sampling(args, directory)
+        elif args.case == "capture":
+            run_capture(args, directory)
+        elif args.case == "context":
+            run_context(args, directory)
+        elif args.case == "finalization":
+            run_finalization(args, directory)
+        else:
+            run_benchmark(args, directory)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as error:
+        print(f"cuda_regression_error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/test/cuda/test_event_recycling.cu
+++ b/test/cuda/test_event_recycling.cu
@@ -1,0 +1,85 @@
+#include "cuda_test_common.cuh"
+
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+namespace {
+constexpr int kPoolCapacity = 4;
+constexpr int kSustainedLaunches = kPoolCapacity * 12;
+
+__global__ void
+peak_cuda_recycling_sustained_kernel(unsigned int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1U);
+    }
+}
+
+__global__ void
+peak_cuda_recycling_late_marker_kernel(unsigned int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1000U);
+    }
+}
+}
+
+int
+main()
+{
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+
+    cudaStream_t stream = nullptr;
+    unsigned int* device_value = nullptr;
+    unsigned int value = 0;
+    if (!peak_cuda_test_check(cudaSetDevice(0), "cudaSetDevice") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &stream, cudaStreamNonBlocking),
+                              "cudaStreamCreateWithFlags") ||
+        !peak_cuda_test_check(cudaMalloc(&device_value, sizeof(*device_value)),
+                              "cudaMalloc") ||
+        !peak_cuda_test_check(cudaMemsetAsync(device_value, 0,
+                                              sizeof(*device_value), stream),
+                              "cudaMemsetAsync")) {
+        return 1;
+    }
+
+    for (int launch = 0; launch < kSustainedLaunches; ++launch) {
+        peak_cuda_recycling_sustained_kernel<<<1, 1, 0, stream>>>(device_value);
+        if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                                  "sustained kernel launch")) {
+            return 1;
+        }
+        if ((launch + 1) % 2 == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        }
+    }
+
+    peak_cuda_recycling_late_marker_kernel<<<1, 1, 0, stream>>>(device_value);
+    if (!peak_cuda_test_check(cudaPeekAtLastError(), "late marker launch") ||
+        !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                              "final cudaStreamSynchronize") ||
+        !peak_cuda_test_check(cudaMemcpy(&value, device_value, sizeof(value),
+                                         cudaMemcpyDeviceToHost),
+                              "cudaMemcpy")) {
+        return 1;
+    }
+
+    cudaFree(device_value);
+    cudaStreamDestroy(stream);
+    if (value != static_cast<unsigned int>(kSustainedLaunches + 1000)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: unexpected recycling result: %u\n",
+                     value);
+        return 1;
+    }
+
+    std::printf("cuda_event_recycling_ok capacity=%d launches=%d "
+                "late_marker=1 per_launch_synchronizations=0 result=%u\n",
+                kPoolCapacity, kSustainedLaunches + 1, value);
+    return 0;
+}

--- a/test/cuda/test_finalization_deadline.cu
+++ b/test/cuda/test_finalization_deadline.cu
@@ -1,0 +1,285 @@
+#include "cuda_test_common.cuh"
+
+#include <dlfcn.h>
+
+#include <chrono>
+#include <cstring>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+namespace {
+constexpr unsigned int kKernelDurationMs = 2500;
+constexpr long long kMaximumReportDurationMs = 1000;
+
+__global__ void
+peak_cuda_ready_finalization_kernel()
+{
+}
+
+__global__ void
+peak_cuda_warmup_finalization_kernel()
+{
+}
+
+__global__ void
+peak_cuda_long_finalization_kernel(unsigned long long ticks,
+                                   unsigned int* completed)
+{
+    unsigned long long start = clock64();
+    while (clock64() - start < ticks) {
+    }
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        *completed = 1;
+    }
+}
+
+using FinalizeFunction = void (*)(void);
+using ForceIncompleteFunction = void (*)(int);
+using HarvesterQueryCountFunction = unsigned long long (*)(void);
+using HarvesterReadyFunction = int (*)(void);
+using ActiveSlotCountFunction = unsigned long long (*)(void);
+
+struct FinalizationSeams {
+    FinalizeFunction finalize = nullptr;
+    ForceIncompleteFunction force_incomplete = nullptr;
+    HarvesterQueryCountFunction query_count = nullptr;
+    HarvesterReadyFunction ready = nullptr;
+    ActiveSlotCountFunction active_slots = nullptr;
+};
+
+FinalizationSeams
+load_test_seams()
+{
+    FinalizationSeams seams;
+    seams.finalize = reinterpret_cast<FinalizeFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_finalize"));
+    seams.force_incomplete = reinterpret_cast<ForceIncompleteFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_force_incomplete_events"));
+    seams.query_count = reinterpret_cast<HarvesterQueryCountFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_query_count"));
+    seams.ready = reinterpret_cast<HarvesterReadyFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_ready"));
+    seams.active_slots = reinterpret_cast<ActiveSlotCountFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_active_slot_count"));
+    return seams;
+}
+
+bool
+wait_for_query_after(const FinalizationSeams& seams,
+                     unsigned long long previous)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.query_count() > previous) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+wait_for_no_active_slots(const FinalizationSeams& seams)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.active_slots() == 0) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+initialize_harvester(const FinalizationSeams& seams,
+                     cudaStream_t stream,
+                     int* warmup_attempts)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (seams.ready() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        peak_cuda_warmup_finalization_kernel<<<1, 1, 0, stream>>>();
+        if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                                  "harvester warmup launch") ||
+            !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "harvester warmup synchronize")) {
+            return false;
+        }
+        ++*warmup_attempts;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (seams.ready() == 0) {
+        return false;
+    }
+
+    unsigned long long previous = seams.query_count();
+    peak_cuda_ready_finalization_kernel<<<1, 1, 0, stream>>>();
+    return peak_cuda_test_check(cudaPeekAtLastError(),
+                                "ready marker launch") &&
+           peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                "ready marker synchronize") &&
+           wait_for_query_after(seams, previous) &&
+           wait_for_no_active_slots(seams);
+}
+}
+
+int
+main(int argc, char** argv)
+{
+    bool forced_incomplete = argc == 2 &&
+        std::strcmp(argv[1], "--forced-incomplete") == 0;
+    if (argc > 2 || (argc == 2 && !forced_incomplete)) {
+        return 2;
+    }
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+
+    int clock_rate_khz = 0;
+    cudaStream_t stream = nullptr;
+    unsigned int* device_completed = nullptr;
+    unsigned int completed = 0;
+    if (!peak_cuda_test_check(cudaSetDevice(0), "cudaSetDevice") ||
+        !peak_cuda_test_check(cudaDeviceGetAttribute(
+                                  &clock_rate_khz, cudaDevAttrClockRate, 0),
+                              "cudaDeviceGetAttribute(clock rate)") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &stream, cudaStreamNonBlocking),
+                              "cudaStreamCreateWithFlags") ||
+        !peak_cuda_test_check(cudaMalloc(&device_completed,
+                                         sizeof(*device_completed)),
+                              "cudaMalloc") ||
+        !peak_cuda_test_check(cudaMemsetAsync(device_completed, 0,
+                                              sizeof(*device_completed), stream),
+                              "cudaMemsetAsync")) {
+        return 1;
+    }
+    if (clock_rate_khz <= 0) {
+        std::fprintf(stderr,
+                     "cuda_test_error: device clock rate is not positive\n");
+        return 1;
+    }
+
+    FinalizationSeams seams = load_test_seams();
+    int seam_count = (seams.finalize != nullptr ? 1 : 0) +
+                     (seams.force_incomplete != nullptr ? 1 : 0) +
+                     (seams.query_count != nullptr ? 1 : 0) +
+                     (seams.ready != nullptr ? 1 : 0) +
+                     (seams.active_slots != nullptr ? 1 : 0);
+    const bool seams_available = seam_count == 5;
+    if ((forced_incomplete && !seams_available) ||
+        (seam_count != 0 && !seams_available)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: incomplete PEAK CUDA finalization "
+                     "seam set\n");
+        return 1;
+    }
+
+    int initialization_warmups = 0;
+    if (seams_available &&
+        !initialize_harvester(seams, stream, &initialization_warmups)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: CUDA harvester did not become ready\n");
+        return 1;
+    }
+
+    if (forced_incomplete) {
+        seams.force_incomplete(1);
+        peak_cuda_ready_finalization_kernel<<<1, 1, 0, stream>>>();
+        if (!peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "forced-incomplete cudaStreamSynchronize")) {
+            return 1;
+        }
+        auto report_start = std::chrono::steady_clock::now();
+        seams.finalize();
+        auto report_end = std::chrono::steady_clock::now();
+        long long report_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                report_end - report_start)
+                .count();
+        if (report_ms > kMaximumReportDurationMs) {
+            std::fprintf(stderr,
+                         "cuda_test_error: forced-incomplete report took "
+                         "%lld ms, limit is %lld ms\n",
+                         report_ms, kMaximumReportDurationMs);
+            return 1;
+        }
+        cudaFree(device_completed);
+        cudaStreamDestroy(stream);
+        std::printf("cuda_forced_incomplete_finalization_ok "
+                    "configured_ms=100 report_ms=%lld "
+                    "initialization_warmups=%d\n",
+                    report_ms, initialization_warmups);
+        return 0;
+    }
+
+    const unsigned long long ticks =
+        static_cast<unsigned long long>(clock_rate_khz) *
+        static_cast<unsigned long long>(kKernelDurationMs);
+    if (!seams_available) {
+        peak_cuda_ready_finalization_kernel<<<1, 1, 0, stream>>>();
+        if (!peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "ready kernel cudaStreamSynchronize")) {
+            return 1;
+        }
+    }
+    peak_cuda_long_finalization_kernel<<<1, 1, 0, stream>>>(ticks,
+                                                            device_completed);
+    if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                              "ready and long kernel launches")) {
+        return 1;
+    }
+
+    long long report_ms = -1;
+    if (seams_available) {
+        auto report_start = std::chrono::steady_clock::now();
+        seams.finalize();
+        auto report_end = std::chrono::steady_clock::now();
+        report_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        report_end - report_start)
+                        .count();
+        if (report_ms > kMaximumReportDurationMs) {
+            std::fprintf(
+                stderr,
+                "cuda_test_error: CUDA report took %lld ms, limit is %lld ms\n",
+                report_ms, kMaximumReportDurationMs);
+            return 1;
+        }
+    }
+
+    if (!peak_cuda_test_check(cudaStreamSynchronize(stream),
+                              "application cudaStreamSynchronize") ||
+        !peak_cuda_test_check(cudaMemcpy(&completed, device_completed,
+                                         sizeof(completed),
+                                         cudaMemcpyDeviceToHost),
+                              "cudaMemcpy")) {
+        return 1;
+    }
+    cudaFree(device_completed);
+    cudaStreamDestroy(stream);
+    if (completed != 1) {
+        std::fprintf(stderr,
+                     "cuda_test_error: long kernel did not complete after "
+                     "application synchronization\n");
+        return 1;
+    }
+
+    if (seams_available) {
+        std::printf("cuda_finalization_deadline_ok configured_ms=100 "
+                    "report_ms=%lld kernel_ms=%u completed=%u "
+                    "initialization_warmups=%d\n",
+                    report_ms, kKernelDurationMs, completed,
+                    initialization_warmups);
+    } else {
+        std::printf("cuda_finalization_baseline_ok kernel_ms=%u "
+                    "completed=%u\n",
+                    kKernelDurationMs, completed);
+    }
+    return 0;
+}

--- a/test/cuda/test_multi_context.cu
+++ b/test/cuda/test_multi_context.cu
@@ -1,0 +1,544 @@
+#include "cuda_test_common.cuh"
+
+#include <cuda.h>
+#include <dlfcn.h>
+
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+namespace {
+constexpr int kDriverCycles = 12;
+
+constexpr char kContextPtx[] = R"ptx(
+.version 6.4
+.target sm_52
+.address_size 64
+
+.visible .entry peak_cuda_context_driver_zero(
+    .param .u64 peak_cuda_context_driver_zero_param_0)
+{
+    .reg .b32 %r<3>;
+    .reg .b64 %rd<2>;
+
+    ld.param.u64 %rd1, [peak_cuda_context_driver_zero_param_0];
+    ld.global.u32 %r1, [%rd1];
+    add.u32 %r2, %r1, 1;
+    st.global.u32 [%rd1], %r2;
+    ret;
+}
+
+.visible .entry peak_cuda_context_driver_one(
+    .param .u64 peak_cuda_context_driver_one_param_0)
+{
+    .reg .b32 %r<3>;
+    .reg .b64 %rd<2>;
+
+    ld.param.u64 %rd1, [peak_cuda_context_driver_one_param_0];
+    ld.global.u32 %r1, [%rd1];
+    add.u32 %r2, %r1, 1;
+    st.global.u32 [%rd1], %r2;
+    ret;
+}
+
+.visible .entry peak_cuda_context_harvester_marker()
+{
+    ret;
+}
+)ptx";
+
+struct ExplicitContextFixture {
+    CUcontext context = nullptr;
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+    CUfunction marker = nullptr;
+    CUstream stream = nullptr;
+    CUdeviceptr value = 0;
+};
+
+bool
+check_driver(CUresult result, const char* operation)
+{
+    if (result == CUDA_SUCCESS) {
+        return true;
+    }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    std::fprintf(stderr, "cuda_test_error: %s failed: %s\n", operation,
+                 name != nullptr ? name : "unknown CUDA Driver error");
+    return false;
+}
+
+CUresult
+create_context(CUcontext* context, CUdevice device)
+{
+#if CUDA_VERSION >= 13000
+    CUctxCreateParams params = {};
+    return cuCtxCreate(context, &params, CU_CTX_SCHED_AUTO, device);
+#else
+    return cuCtxCreate(context, CU_CTX_SCHED_AUTO, device);
+#endif
+}
+
+bool
+check_current_context(CUcontext expected, const char* operation)
+{
+    CUcontext current = nullptr;
+    if (!check_driver(cuCtxGetCurrent(&current), operation)) {
+        return false;
+    }
+    if (current != expected) {
+        std::fprintf(stderr,
+                     "cuda_test_error: %s changed the current context\n",
+                     operation);
+        return false;
+    }
+    return true;
+}
+
+void
+destroy_unlaunched_fixture(ExplicitContextFixture* fixture)
+{
+    if (fixture->context == nullptr) {
+        return;
+    }
+    CUcontext current = nullptr;
+    if (cuCtxGetCurrent(&current) == CUDA_SUCCESS &&
+        current == fixture->context) {
+        CUcontext popped = nullptr;
+        (void)cuCtxPopCurrent(&popped);
+    }
+    (void)cuCtxDestroy(fixture->context);
+    *fixture = {};
+}
+
+bool
+initialize_fixture(ExplicitContextFixture* fixture, CUdevice device,
+                   const char* function_name, CUcontext initial_context)
+{
+    if (!check_driver(create_context(&fixture->context, device),
+                      "cuCtxCreate")) {
+        return false;
+    }
+
+    bool initialized =
+        check_driver(cuModuleLoadData(&fixture->module, kContextPtx),
+                     "cuModuleLoadData") &&
+        check_driver(cuModuleGetFunction(&fixture->function, fixture->module,
+                                        function_name),
+                     "cuModuleGetFunction") &&
+        check_driver(cuModuleGetFunction(
+                         &fixture->marker, fixture->module,
+                         "peak_cuda_context_harvester_marker"),
+                     "marker cuModuleGetFunction") &&
+        check_driver(cuStreamCreate(&fixture->stream, CU_STREAM_NON_BLOCKING),
+                     "cuStreamCreate") &&
+        check_driver(cuMemAlloc(&fixture->value, sizeof(unsigned int)),
+                     "cuMemAlloc") &&
+        check_driver(cuMemsetD32Async(fixture->value, 0, 1,
+                                     fixture->stream),
+                     "cuMemsetD32Async") &&
+        check_driver(cuStreamSynchronize(fixture->stream),
+                     "initial cuStreamSynchronize");
+
+    CUcontext popped = nullptr;
+    if (!check_driver(cuCtxPopCurrent(&popped), "setup cuCtxPopCurrent") ||
+        popped != fixture->context) {
+        std::fprintf(stderr,
+                     "cuda_test_error: setup popped the wrong context\n");
+        initialized = false;
+    }
+    if (!check_current_context(initial_context,
+                               "setup context restoration")) {
+        initialized = false;
+    }
+    if (!initialized) {
+        destroy_unlaunched_fixture(fixture);
+    }
+    return initialized;
+}
+
+using ForceQueryErrorFunction = void (*)(int);
+using HarvesterQueryCountFunction = unsigned long long (*)(void);
+using HarvesterReadyFunction = int (*)(void);
+using ActiveSlotCountFunction = unsigned long long (*)(void);
+
+struct HarvesterSeams {
+    ForceQueryErrorFunction force_query_error = nullptr;
+    HarvesterQueryCountFunction query_count = nullptr;
+    HarvesterReadyFunction ready = nullptr;
+    ActiveSlotCountFunction active_slots = nullptr;
+};
+
+HarvesterSeams
+load_harvester_seams()
+{
+    HarvesterSeams seams;
+    seams.force_query_error = reinterpret_cast<ForceQueryErrorFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_force_query_error_once"));
+    seams.query_count = reinterpret_cast<HarvesterQueryCountFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_query_count"));
+    seams.ready = reinterpret_cast<HarvesterReadyFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_ready"));
+    seams.active_slots = reinterpret_cast<ActiveSlotCountFunction>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_active_slot_count"));
+    return seams;
+}
+
+bool
+wait_for_query_after(const HarvesterSeams& seams,
+                     unsigned long long previous)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.query_count() > previous) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+wait_for_no_active_slots(const HarvesterSeams& seams)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.active_slots() == 0) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+launch_marker(ExplicitContextFixture* fixture, CUcontext initial_context)
+{
+    if (!check_driver(cuCtxPushCurrent(fixture->context),
+                      "marker cuCtxPushCurrent") ||
+        !check_current_context(fixture->context,
+                               "marker context before cuLaunchKernel")) {
+        return false;
+    }
+    bool valid = check_driver(
+                     cuLaunchKernel(fixture->marker, 1, 1, 1, 1, 1, 1, 0,
+                                    fixture->stream, nullptr, nullptr),
+                     "marker cuLaunchKernel") &&
+                 check_current_context(
+                     fixture->context,
+                     "marker context after cuLaunchKernel") &&
+                 check_driver(cuStreamSynchronize(fixture->stream),
+                              "marker cuStreamSynchronize");
+    CUcontext popped = nullptr;
+    if (!check_driver(cuCtxPopCurrent(&popped), "marker cuCtxPopCurrent") ||
+        popped != fixture->context ||
+        !check_current_context(initial_context,
+                               "marker context restoration")) {
+        valid = false;
+    }
+    return valid;
+}
+
+bool
+initialize_harvester(ExplicitContextFixture* fixture,
+                     CUcontext initial_context,
+                     const HarvesterSeams& seams,
+                     int* warmup_attempts)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (seams.ready() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        if (!launch_marker(fixture, initial_context)) {
+            return false;
+        }
+        ++*warmup_attempts;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (seams.ready() == 0) {
+        return false;
+    }
+    unsigned long long previous = seams.query_count();
+    return launch_marker(fixture, initial_context) &&
+           wait_for_query_after(seams, previous) &&
+           wait_for_no_active_slots(seams);
+}
+
+bool
+launch_once(ExplicitContextFixture* fixture, CUcontext initial_context)
+{
+    if (!check_driver(cuCtxPushCurrent(fixture->context),
+                      "launch cuCtxPushCurrent") ||
+        !check_current_context(fixture->context,
+                               "context before cuLaunchKernel")) {
+        return false;
+    }
+
+    CUdeviceptr value = fixture->value;
+    void* arguments[] = {&value};
+    bool launched = check_driver(
+        cuLaunchKernel(fixture->function, 1, 1, 1, 1, 1, 1, 0,
+                       fixture->stream, arguments, nullptr),
+        "cuLaunchKernel");
+    if (!check_current_context(fixture->context,
+                               "context after cuLaunchKernel")) {
+        launched = false;
+    }
+
+    CUcontext popped = nullptr;
+    if (!check_driver(cuCtxPopCurrent(&popped), "launch cuCtxPopCurrent") ||
+        popped != fixture->context) {
+        std::fprintf(stderr,
+                     "cuda_test_error: launch popped the wrong context\n");
+        launched = false;
+    }
+    if (!check_current_context(initial_context,
+                               "launch context restoration")) {
+        launched = false;
+    }
+    return launched;
+}
+
+bool
+read_result(ExplicitContextFixture* fixture, CUcontext initial_context,
+            unsigned int* result)
+{
+    if (!check_driver(cuCtxPushCurrent(fixture->context),
+                      "result cuCtxPushCurrent")) {
+        return false;
+    }
+    bool valid =
+        check_driver(cuStreamSynchronize(fixture->stream),
+                     "result cuStreamSynchronize") &&
+        check_driver(cuMemcpyDtoH(result, fixture->value, sizeof(*result)),
+                     "cuMemcpyDtoH");
+
+    CUcontext popped = nullptr;
+    if (!check_driver(cuCtxPopCurrent(&popped), "result cuCtxPopCurrent") ||
+        popped != fixture->context) {
+        std::fprintf(stderr,
+                     "cuda_test_error: result read popped the wrong context\n");
+        valid = false;
+    }
+    if (!check_current_context(initial_context,
+                               "result context restoration")) {
+        valid = false;
+    }
+    return valid;
+}
+
+#if CUDART_VERSION < 13000
+__global__ void
+peak_cuda_multi_device_kernel(int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1);
+    }
+}
+
+bool
+run_optional_multi_device_check(int device_count, bool* called)
+{
+    *called = false;
+    if (device_count < 2) {
+        return true;
+    }
+
+    cudaDeviceProp properties[2] = {};
+    for (int device = 0; device < 2; ++device) {
+        if (!peak_cuda_test_check(cudaGetDeviceProperties(&properties[device],
+                                                          device),
+                                  "cudaGetDeviceProperties")) {
+            return false;
+        }
+        if (!properties[device].cooperativeMultiDeviceLaunch) {
+            return true;
+        }
+    }
+
+    cudaStream_t streams[2] = {};
+    int* values[2] = {};
+    cudaLaunchParams launches[2] = {};
+    bool ready = true;
+    for (int device = 0; device < 2 && ready; ++device) {
+        ready = peak_cuda_test_check(cudaSetDevice(device), "cudaSetDevice") &&
+                peak_cuda_test_check(
+                    cudaStreamCreateWithFlags(&streams[device],
+                                              cudaStreamNonBlocking),
+                    "cudaStreamCreateWithFlags") &&
+                peak_cuda_test_check(cudaMalloc(&values[device], sizeof(int)),
+                                     "cudaMalloc") &&
+                peak_cuda_test_check(cudaMemset(values[device], 0, sizeof(int)),
+                                     "cudaMemset");
+        if (ready) {
+            launches[device].func =
+                reinterpret_cast<void*>(peak_cuda_multi_device_kernel);
+            launches[device].gridDim = dim3(1, 1, 1);
+            launches[device].blockDim = dim3(1, 1, 1);
+            launches[device].args = nullptr;
+            launches[device].sharedMem = 0;
+            launches[device].stream = streams[device];
+        }
+    }
+
+    void* arguments[2][1] = {{&values[0]}, {&values[1]}};
+    if (ready) {
+        launches[0].args = arguments[0];
+        launches[1].args = arguments[1];
+        *called = true;
+        ready = peak_cuda_test_check(
+            cudaLaunchCooperativeKernelMultiDevice(launches, 2, 0),
+            "cudaLaunchCooperativeKernelMultiDevice");
+    }
+
+    int host_values[2] = {};
+    for (int device = 0; device < 2 && ready; ++device) {
+        if (streams[device] == nullptr) {
+            continue;
+        }
+        ready =
+            peak_cuda_test_check(cudaSetDevice(device), "cudaSetDevice") &&
+            peak_cuda_test_check(cudaStreamSynchronize(streams[device]),
+                                 "cudaStreamSynchronize") &&
+            peak_cuda_test_check(cudaMemcpy(&host_values[device],
+                                            values[device], sizeof(int),
+                                            cudaMemcpyDeviceToHost),
+                                 "cudaMemcpy");
+    }
+    if (ready && (host_values[0] != 1 || host_values[1] != 1)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: cooperative multi-device results are "
+                     "%d/%d, expected 1/1\n",
+                     host_values[0], host_values[1]);
+        ready = false;
+    }
+
+    for (int device = 0; device < 2; ++device) {
+        if (streams[device] == nullptr) {
+            continue;
+        }
+        (void)cudaSetDevice(device);
+        if (values[device] != nullptr) {
+            (void)cudaFree(values[device]);
+        }
+        (void)cudaStreamDestroy(streams[device]);
+    }
+    return ready;
+}
+#endif
+}
+
+int
+main()
+{
+    int device_count = 0;
+    int requirement = peak_cuda_test_require_devices(1, &device_count);
+    if (requirement != 0) {
+        return requirement;
+    }
+    if (!check_driver(cuInit(0), "cuInit")) {
+        return 1;
+    }
+
+    CUdevice physical_device = 0;
+    CUcontext initial_context = nullptr;
+    if (!check_driver(cuDeviceGet(&physical_device, 0), "cuDeviceGet") ||
+        !check_driver(cuCtxGetCurrent(&initial_context),
+                      "initial cuCtxGetCurrent")) {
+        return 1;
+    }
+
+    ExplicitContextFixture fixtures[2];
+    if (!initialize_fixture(&fixtures[0], physical_device,
+                            "peak_cuda_context_driver_zero",
+                            initial_context) ||
+        !initialize_fixture(&fixtures[1], physical_device,
+                            "peak_cuda_context_driver_one",
+                            initial_context)) {
+        destroy_unlaunched_fixture(&fixtures[0]);
+        destroy_unlaunched_fixture(&fixtures[1]);
+        return 1;
+    }
+
+    HarvesterSeams seams = load_harvester_seams();
+    int seam_count = (seams.force_query_error != nullptr ? 1 : 0) +
+                     (seams.query_count != nullptr ? 1 : 0) +
+                     (seams.ready != nullptr ? 1 : 0) +
+                     (seams.active_slots != nullptr ? 1 : 0);
+    if (seam_count != 0 && seam_count != 4) {
+        std::fprintf(stderr,
+                     "cuda_test_error: incomplete PEAK CUDA harvester seam "
+                     "set\n");
+        return 1;
+    }
+    const bool query_error_injected = seam_count == 4;
+    int initialization_warmups = 0;
+    if (query_error_injected) {
+        if (!initialize_harvester(&fixtures[0], initial_context, seams,
+                                  &initialization_warmups)) {
+            std::fprintf(stderr,
+                         "cuda_test_error: CUDA harvester did not become "
+                         "ready\n");
+            return 1;
+        }
+        seams.force_query_error(1);
+    }
+
+    int context_restore_checks = 0;
+    for (int cycle = 0; cycle < kDriverCycles; ++cycle) {
+        for (ExplicitContextFixture& fixture : fixtures) {
+            if (!launch_once(&fixture, initial_context)) {
+                return 1;
+            }
+            ++context_restore_checks;
+            std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        }
+    }
+
+    unsigned int results[2] = {};
+    if (!read_result(&fixtures[0], initial_context, &results[0]) ||
+        !read_result(&fixtures[1], initial_context, &results[1])) {
+        return 1;
+    }
+    if (results[0] != kDriverCycles || results[1] != kDriverCycles) {
+        std::fprintf(stderr,
+                     "cuda_test_error: Driver context results are %u/%u, "
+                     "expected %d/%d\n",
+                     results[0], results[1], kDriverCycles, kDriverCycles);
+        return 1;
+    }
+
+    bool multi_device_called = false;
+#if CUDART_VERSION < 13000
+    if (!run_optional_multi_device_check(device_count,
+                                         &multi_device_called)) {
+        return 1;
+    }
+#endif
+    const bool driver_names_available =
+        dlsym(RTLD_DEFAULT, "cuFuncGetName") != nullptr;
+
+    /*
+     * PEAK's reusable timing events remain owned by these explicit contexts
+     * until process-exit detach destroys the event pool. Destroying the
+     * contexts here would invalidate those events first, so process teardown
+     * intentionally reclaims this fixture's contexts and their resources.
+     */
+    std::printf("cuda_multi_context_ok physical_devices=%d "
+                "explicit_contexts=2 driver_cycles=%d "
+                "context_restore_checks=%d results=%u/%u "
+                "function_handles_equal=%d multi_device_called=%d "
+                "driver_names_available=%d query_error_injected=%d "
+                "initialization_warmups=%d\n",
+                device_count, kDriverCycles, context_restore_checks,
+                results[0], results[1],
+                fixtures[0].function == fixtures[1].function ? 1 : 0,
+                multi_device_called ? 1 : 0,
+                driver_names_available ? 1 : 0,
+                query_error_injected ? 1 : 0,
+                initialization_warmups);
+    return 0;
+}

--- a/test/cuda/test_stream_capture.cu
+++ b/test/cuda/test_stream_capture.cu
@@ -1,0 +1,1343 @@
+#include "cuda_test_common.cuh"
+
+#include <cuda.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <cstdio>
+#include <dlfcn.h>
+#include <thread>
+#include <vector>
+
+namespace {
+constexpr int kCaptureCycles = 40;
+
+using PeakCudaForceIncompleteFn = void (*)(int);
+using PeakCudaHarvesterQueryCountFn = unsigned long long (*)(void);
+using PeakCudaHarvesterReadyFn = int (*)(void);
+using PeakCudaActiveSlotCountFn = unsigned long long (*)(void);
+using PeakCudaPauseFn = void (*)(int);
+using PeakCudaBoolFn = int (*)(void);
+using PeakCudaWaitingCountFn = unsigned int (*)(void);
+using PeakCudaFinalizeFn = void (*)(void);
+
+struct PeakCudaCaptureTestSeams {
+    PeakCudaForceIncompleteFn force_incomplete;
+    PeakCudaHarvesterQueryCountFn harvester_query_count;
+    PeakCudaHarvesterReadyFn harvester_ready;
+    PeakCudaActiveSlotCountFn active_slot_count;
+    PeakCudaPauseFn pause_capture_begin;
+    PeakCudaBoolFn capture_begin_waiting;
+    PeakCudaPauseFn pause_cuda_section;
+    PeakCudaWaitingCountFn cuda_sections_waiting;
+    PeakCudaBoolFn capture_blocked;
+    PeakCudaFinalizeFn finalize;
+    PeakCudaPauseFn pause_lifecycle_before_increment;
+    PeakCudaWaitingCountFn lifecycle_before_increment_waiting;
+    PeakCudaPauseFn pause_lifecycle_after_admission;
+    PeakCudaWaitingCountFn lifecycle_after_admission_waiting;
+    PeakCudaBoolFn lifecycle_closing;
+};
+
+__global__ void
+peak_cuda_capture_topology_kernel(int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1);
+    }
+}
+
+__global__ void
+peak_cuda_driver_capture_kernel(int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1);
+    }
+}
+
+__global__ void
+peak_cuda_runtime_pending_capture_marker()
+{
+}
+
+__global__ void
+peak_cuda_capture_race_target(int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1);
+    }
+}
+
+__global__ void
+peak_cuda_capture_race_control(int* value)
+{
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        atomicAdd(value, 1);
+    }
+}
+
+PeakCudaCaptureTestSeams
+load_test_seams()
+{
+    PeakCudaCaptureTestSeams seams = {};
+    seams.force_incomplete = reinterpret_cast<PeakCudaForceIncompleteFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_force_incomplete_events"));
+    seams.harvester_query_count =
+        reinterpret_cast<PeakCudaHarvesterQueryCountFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_harvester_query_count"));
+    seams.harvester_ready = reinterpret_cast<PeakCudaHarvesterReadyFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_harvester_ready"));
+    seams.active_slot_count = reinterpret_cast<PeakCudaActiveSlotCountFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_active_slot_count"));
+    seams.pause_capture_begin = reinterpret_cast<PeakCudaPauseFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_pause_capture_begin"));
+    seams.capture_begin_waiting = reinterpret_cast<PeakCudaBoolFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_capture_begin_waiting"));
+    seams.pause_cuda_section = reinterpret_cast<PeakCudaPauseFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_pause_cuda_section"));
+    seams.cuda_sections_waiting =
+        reinterpret_cast<PeakCudaWaitingCountFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_cuda_sections_waiting"));
+    seams.capture_blocked = reinterpret_cast<PeakCudaBoolFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_capture_blocked"));
+    seams.finalize = reinterpret_cast<PeakCudaFinalizeFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_finalize"));
+    seams.pause_lifecycle_before_increment =
+        reinterpret_cast<PeakCudaPauseFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_pause_lifecycle_before_increment"));
+    seams.lifecycle_before_increment_waiting =
+        reinterpret_cast<PeakCudaWaitingCountFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_lifecycle_before_increment_waiting"));
+    seams.pause_lifecycle_after_admission =
+        reinterpret_cast<PeakCudaPauseFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_pause_lifecycle_after_admission"));
+    seams.lifecycle_after_admission_waiting =
+        reinterpret_cast<PeakCudaWaitingCountFn>(
+            dlsym(RTLD_DEFAULT,
+                  "peak_cuda_test_lifecycle_after_admission_waiting"));
+    seams.lifecycle_closing = reinterpret_cast<PeakCudaBoolFn>(
+        dlsym(RTLD_DEFAULT, "peak_cuda_test_lifecycle_closing"));
+    return seams;
+}
+
+bool
+wait_for_harvester_quiescence(const PeakCudaCaptureTestSeams& seams,
+                              unsigned long long* query_count)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    unsigned long long previous = seams.harvester_query_count();
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        unsigned long long current = seams.harvester_query_count();
+        if (current == previous) {
+            *query_count = current;
+            return true;
+        }
+        previous = current;
+    }
+    return false;
+}
+
+bool
+wait_for_harvester_query(const PeakCudaCaptureTestSeams& seams,
+                         unsigned long long previous)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.harvester_query_count() > previous) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+wait_for_harvester_idle(const PeakCudaCaptureTestSeams& seams)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.active_slot_count() == 0) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+wait_for_active_slots(const PeakCudaCaptureTestSeams& seams,
+                      unsigned long long minimum)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.active_slot_count() >= minimum) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool
+harvester_queries_stay_at(const PeakCudaCaptureTestSeams& seams,
+                          unsigned long long expected)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(25);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (seams.harvester_query_count() != expected) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return seams.harvester_query_count() == expected;
+}
+
+bool
+initialize_harvester(const PeakCudaCaptureTestSeams& seams,
+                     cudaStream_t stream,
+                     int* warmup_attempts)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(1);
+    while (seams.harvester_ready() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        peak_cuda_runtime_pending_capture_marker<<<1, 1, 0, stream>>>();
+        if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                                  "harvester initialization launch") ||
+            !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "harvester initialization synchronize")) {
+            return false;
+        }
+        ++*warmup_attempts;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (seams.harvester_ready() == 0) {
+        return false;
+    }
+
+    unsigned long long prior_queries = seams.harvester_query_count();
+    peak_cuda_runtime_pending_capture_marker<<<1, 1, 0, stream>>>();
+    return peak_cuda_test_check(cudaPeekAtLastError(),
+                                "ready harvester marker launch") &&
+           peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                "ready harvester marker synchronize") &&
+           wait_for_harvester_query(seams, prior_queries) &&
+           wait_for_harvester_idle(seams);
+}
+
+bool
+check_driver(CUresult result, const char* operation)
+{
+    if (result == CUDA_SUCCESS) {
+        return true;
+    }
+    const char* name = nullptr;
+    (void)cuGetErrorName(result, &name);
+    std::fprintf(stderr, "cuda_test_error: %s failed: %s\n", operation,
+                 name != nullptr ? name : "unknown CUDA Driver error");
+    return false;
+}
+
+template <typename Predicate>
+bool
+wait_for_condition(Predicate predicate, const char* operation)
+{
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    std::fprintf(stderr, "cuda_test_error: timed out waiting for %s\n",
+                 operation);
+    return false;
+}
+
+bool
+execute_single_node_graph(cudaGraph_t graph, cudaStream_t stream,
+                          const char* operation)
+{
+    size_t node_count = 0;
+    cudaGraphExec_t executable = nullptr;
+    if (!peak_cuda_test_check(cudaGraphGetNodes(graph, nullptr, &node_count),
+                              "race cudaGraphGetNodes") ||
+        node_count != 1) {
+        std::fprintf(stderr,
+                     "cuda_test_error: %s graph has %zu nodes, expected 1\n",
+                     operation, node_count);
+        return false;
+    }
+    if (!peak_cuda_test_check(
+            cudaGraphInstantiate(&executable, graph, nullptr, nullptr, 0),
+            "race cudaGraphInstantiate") ||
+        !peak_cuda_test_check(cudaGraphLaunch(executable, stream),
+                              "race cudaGraphLaunch") ||
+        !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                              "race cudaStreamSynchronize")) {
+        if (executable != nullptr) {
+            (void)cudaGraphExecDestroy(executable);
+        }
+        return false;
+    }
+    (void)cudaGraphExecDestroy(executable);
+    return true;
+}
+
+bool
+run_begin_first_race(const PeakCudaCaptureTestSeams& seams,
+                     cudaStream_t stream, int* target_value,
+                     int* control_value)
+{
+    std::atomic<int> begin_result{static_cast<int>(cudaErrorNotReady)};
+    std::atomic<int> launch_result{static_cast<int>(cudaErrorNotReady)};
+    std::atomic<int> end_result{static_cast<int>(cudaErrorNotReady)};
+    cudaGraph_t graph = nullptr;
+
+    seams.pause_capture_begin(1);
+    std::thread capture_thread([&]() {
+        cudaError_t result = cudaSetDevice(0);
+        if (result == cudaSuccess) {
+            result = cudaStreamBeginCapture(stream,
+                                            cudaStreamCaptureModeGlobal);
+        }
+        begin_result.store(static_cast<int>(result),
+                           std::memory_order_release);
+        if (result == cudaSuccess) {
+            peak_cuda_capture_race_control<<<1, 1, 0, stream>>>(
+                control_value);
+            cudaError_t launch = cudaPeekAtLastError();
+            launch_result.store(static_cast<int>(launch),
+                                std::memory_order_release);
+            cudaError_t end = cudaStreamEndCapture(stream, &graph);
+            end_result.store(static_cast<int>(end),
+                             std::memory_order_release);
+        }
+    });
+
+    bool waiting = wait_for_condition(
+        [&]() {
+            return seams.capture_begin_waiting() != 0 &&
+                   seams.capture_blocked() != 0;
+        },
+        "paused capture begin");
+    bool target_ok = false;
+    if (waiting) {
+        peak_cuda_capture_race_target<<<1, 1, 0, stream>>>(target_value);
+        target_ok = peak_cuda_test_check(cudaPeekAtLastError(),
+                                         "begin-first target launch") &&
+                    peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                         "begin-first target synchronize");
+    }
+    seams.pause_capture_begin(0);
+    capture_thread.join();
+
+    bool capture_ok =
+        begin_result.load(std::memory_order_acquire) == cudaSuccess &&
+        launch_result.load(std::memory_order_acquire) == cudaSuccess &&
+        end_result.load(std::memory_order_acquire) == cudaSuccess &&
+        graph != nullptr;
+    bool graph_ok = capture_ok &&
+                    execute_single_node_graph(graph, stream, "begin-first");
+    bool graph_drained = graph_ok && wait_for_harvester_idle(seams);
+    if (graph != nullptr) {
+        (void)cudaGraphDestroy(graph);
+    }
+    return waiting && target_ok && graph_drained;
+}
+
+bool
+run_reader_first_race(const PeakCudaCaptureTestSeams& seams,
+                      cudaStream_t stream, int* target_value,
+                      int* control_value, int* helper_quiesced,
+                      int* helper_recycled)
+{
+    std::atomic<bool> worker_ready{false};
+    std::atomic<bool> begin_ready{false};
+    std::atomic<bool> start_worker{false};
+    std::atomic<bool> start_begin{false};
+    std::atomic<bool> capture_active{false};
+    std::atomic<bool> allow_end{false};
+    std::atomic<int> worker_result{static_cast<int>(cudaErrorNotReady)};
+    std::atomic<int> begin_result{static_cast<int>(cudaErrorNotReady)};
+    std::atomic<int> end_result{static_cast<int>(cudaErrorNotReady)};
+    cudaGraph_t graph = nullptr;
+
+    std::thread worker([&]() {
+        cudaError_t result = cudaSetDevice(0);
+        worker_ready.store(true, std::memory_order_release);
+        while (!start_worker.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        if (result == cudaSuccess) {
+            peak_cuda_capture_race_target<<<1, 1, 0, stream>>>(target_value);
+            result = cudaPeekAtLastError();
+        }
+        worker_result.store(static_cast<int>(result),
+                            std::memory_order_release);
+    });
+    std::thread capture_thread([&]() {
+        cudaError_t result = cudaSetDevice(0);
+        begin_ready.store(true, std::memory_order_release);
+        while (!start_begin.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        if (result == cudaSuccess) {
+            result = cudaStreamBeginCapture(stream,
+                                            cudaStreamCaptureModeGlobal);
+        }
+        begin_result.store(static_cast<int>(result),
+                           std::memory_order_release);
+        if (result == cudaSuccess) {
+            capture_active.store(true, std::memory_order_release);
+            while (!allow_end.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            peak_cuda_capture_race_control<<<1, 1, 0, stream>>>(
+                control_value);
+            cudaError_t launch = cudaPeekAtLastError();
+            cudaError_t end = cudaStreamEndCapture(stream, &graph);
+            end_result.store(static_cast<int>(
+                                 launch == cudaSuccess ? end : launch),
+                             std::memory_order_release);
+        }
+    });
+
+    bool setup_ready = wait_for_condition(
+        [&]() {
+            return worker_ready.load(std::memory_order_acquire) &&
+                   begin_ready.load(std::memory_order_acquire);
+        },
+        "race worker setup");
+    seams.force_incomplete(1);
+    seams.pause_cuda_section(1);
+    seams.pause_capture_begin(1);
+    start_worker.store(true, std::memory_order_release);
+    bool reader_waiting = setup_ready && wait_for_condition(
+        [&]() { return seams.cuda_sections_waiting() > 0; },
+        "paused CUDA timing section");
+    start_begin.store(true, std::memory_order_release);
+    bool writer_waiting = reader_waiting && wait_for_condition(
+        [&]() {
+            return seams.capture_blocked() != 0 &&
+                   seams.capture_begin_waiting() == 0;
+        },
+        "capture begin waiting for CUDA section");
+
+    seams.pause_cuda_section(0);
+    bool writer_drained = writer_waiting && wait_for_condition(
+        [&]() { return seams.capture_begin_waiting() != 0; },
+        "capture begin after CUDA section drain");
+    worker.join();
+    bool pending = writer_drained &&
+                   worker_result.load(std::memory_order_acquire) ==
+                       cudaSuccess &&
+                   wait_for_active_slots(seams, 1);
+    unsigned long long pending_queries = seams.harvester_query_count();
+
+    seams.pause_capture_begin(0);
+    bool began = pending && wait_for_condition(
+        [&]() { return capture_active.load(std::memory_order_acquire); },
+        "reader-first active capture");
+    seams.force_incomplete(0);
+    bool quiesced = began && seams.capture_blocked() != 0 &&
+                    harvester_queries_stay_at(seams, pending_queries) &&
+                    seams.active_slot_count() > 0;
+    if (quiesced) {
+        *helper_quiesced = 1;
+    }
+    allow_end.store(true, std::memory_order_release);
+    capture_thread.join();
+    bool recycled = quiesced &&
+                    wait_for_harvester_query(seams, pending_queries) &&
+                    wait_for_harvester_idle(seams);
+    if (recycled) {
+        *helper_recycled = 1;
+    }
+
+    bool capture_ok =
+        begin_result.load(std::memory_order_acquire) == cudaSuccess &&
+        end_result.load(std::memory_order_acquire) == cudaSuccess &&
+        graph != nullptr;
+    bool graph_ok = capture_ok && execute_single_node_graph(
+                                      graph, stream, "reader-first");
+    if (graph != nullptr) {
+        (void)cudaGraphDestroy(graph);
+    }
+    seams.force_incomplete(0);
+    seams.pause_cuda_section(0);
+    seams.pause_capture_begin(0);
+    return setup_ready && reader_waiting && writer_waiting &&
+           writer_drained && pending && began && recycled && graph_ok;
+}
+
+bool
+run_global_cross_stream_cycles(const PeakCudaCaptureTestSeams& seams,
+                               cudaStream_t capture_stream,
+                               cudaStream_t target_stream,
+                               CUfunction target_function,
+                               int* target_value, int* control_value,
+                               int* node_count_total)
+{
+    constexpr int kRaceCycles = 32;
+    std::atomic<bool> worker_ready{false};
+    std::atomic<bool> stop{false};
+    std::atomic<int> requested{0};
+    std::atomic<int> completed{0};
+    std::atomic<int> worker_result{static_cast<int>(CUDA_SUCCESS)};
+    std::atomic<bool> context_unchanged{false};
+    CUdeviceptr target_pointer = reinterpret_cast<CUdeviceptr>(target_value);
+
+    std::thread worker([&]() {
+        CUcontext before = nullptr;
+        CUcontext after = nullptr;
+        cudaError_t runtime_result = cudaSetDevice(0);
+        CUresult result = runtime_result == cudaSuccess
+                              ? cuCtxGetCurrent(&before)
+                              : CUDA_ERROR_INVALID_CONTEXT;
+        worker_result.store(static_cast<int>(result),
+                            std::memory_order_release);
+        worker_ready.store(true, std::memory_order_release);
+        int handled = 0;
+        while (!stop.load(std::memory_order_acquire)) {
+            int next = requested.load(std::memory_order_acquire);
+            if (next <= handled) {
+                std::this_thread::yield();
+                continue;
+            }
+            void* arguments[] = {&target_pointer};
+            result = cuLaunchKernel(
+                target_function, 1, 1, 1, 1, 1, 1, 0,
+                reinterpret_cast<CUstream>(target_stream), arguments,
+                nullptr);
+            if (result != CUDA_SUCCESS) {
+                worker_result.store(static_cast<int>(result),
+                                    std::memory_order_release);
+            }
+            handled = next;
+            completed.store(handled, std::memory_order_release);
+        }
+        if (cuCtxGetCurrent(&after) == CUDA_SUCCESS && before == after &&
+            before != nullptr) {
+            context_unchanged.store(true, std::memory_order_release);
+        }
+    });
+
+    bool ok = wait_for_condition(
+        [&]() { return worker_ready.load(std::memory_order_acquire); },
+        "cross-stream worker setup");
+    for (int cycle = 0; ok && cycle < kRaceCycles; ++cycle) {
+        cudaGraph_t graph = nullptr;
+        cudaError_t begin_result = cudaStreamBeginCapture(
+            capture_stream, cudaStreamCaptureModeGlobal);
+        cudaError_t control_result = begin_result;
+        if (begin_result == cudaSuccess) {
+            peak_cuda_capture_race_control<<<1, 1, 0, capture_stream>>>(
+                control_value);
+            control_result = cudaPeekAtLastError();
+        }
+        bool gate_active = begin_result == cudaSuccess &&
+                           seams.capture_blocked() != 0;
+        requested.store(cycle + 1, std::memory_order_release);
+        bool launched = wait_for_condition(
+            [&]() {
+                return completed.load(std::memory_order_acquire) >= cycle + 1;
+            },
+            "cross-stream target launch");
+        cudaError_t end_result = begin_result;
+        if (begin_result == cudaSuccess) {
+            end_result = cudaStreamEndCapture(capture_stream, &graph);
+        }
+        ok = gate_active && launched && begin_result == cudaSuccess &&
+             control_result == cudaSuccess && end_result == cudaSuccess &&
+             graph != nullptr &&
+             worker_result.load(std::memory_order_acquire) == CUDA_SUCCESS;
+        if (ok) {
+            size_t nodes = 0;
+            ok = peak_cuda_test_check(
+                     cudaGraphGetNodes(graph, nullptr, &nodes),
+                     "cross-stream cudaGraphGetNodes") &&
+                 nodes == 1;
+            if (ok) {
+                *node_count_total += static_cast<int>(nodes);
+                ok = execute_single_node_graph(
+                    graph, capture_stream, "cross-stream");
+            }
+        }
+        if (graph != nullptr) {
+            (void)cudaGraphDestroy(graph);
+        }
+        if (ok) {
+            ok = peak_cuda_test_check(cudaStreamSynchronize(target_stream),
+                                      "cross-stream target synchronize");
+        }
+        if (ok) {
+            ok = wait_for_harvester_idle(seams);
+        }
+    }
+    stop.store(true, std::memory_order_release);
+    worker.join();
+    return ok && context_unchanged.load(std::memory_order_acquire) &&
+           seams.capture_blocked() == 0;
+}
+
+int
+run_lifecycle_gate_race(bool reader_wins)
+{
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+    PeakCudaCaptureTestSeams seams = load_test_seams();
+    int seam_count =
+        (seams.finalize != nullptr ? 1 : 0) +
+        (seams.pause_lifecycle_before_increment != nullptr ? 1 : 0) +
+        (seams.lifecycle_before_increment_waiting != nullptr ? 1 : 0) +
+        (seams.pause_lifecycle_after_admission != nullptr ? 1 : 0) +
+        (seams.lifecycle_after_admission_waiting != nullptr ? 1 : 0) +
+        (seams.lifecycle_closing != nullptr ? 1 : 0) +
+        (seams.pause_cuda_section != nullptr ? 1 : 0) +
+        (seams.cuda_sections_waiting != nullptr ? 1 : 0) +
+        (seams.capture_blocked != nullptr ? 1 : 0);
+    if (seam_count != 9) {
+        std::fprintf(stderr,
+                     "cuda_test_error: lifecycle race mode requires all "
+                     "PEAK CUDA lifecycle seams\n");
+        return 1;
+    }
+
+    cudaStream_t timing_stream = nullptr;
+    cudaStream_t capture_stream = nullptr;
+    int* device_value = nullptr;
+    if (!peak_cuda_test_check(cudaSetDevice(0),
+                              "lifecycle cudaSetDevice") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &timing_stream, cudaStreamNonBlocking),
+                              "lifecycle timing stream create") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &capture_stream, cudaStreamNonBlocking),
+                              "lifecycle capture stream create") ||
+        !peak_cuda_test_check(cudaMalloc(&device_value, sizeof(int)),
+                              "lifecycle value allocation") ||
+        !peak_cuda_test_check(cudaMemset(device_value, 0, sizeof(int)),
+                              "lifecycle value memset")) {
+        return 1;
+    }
+
+    std::atomic<bool> worker_ready{false};
+    std::atomic<bool> start_worker{false};
+    std::atomic<bool> finalize_done{false};
+    std::atomic<int> worker_result{static_cast<int>(cudaErrorNotReady)};
+    std::thread worker([&]() {
+        cudaError_t result = cudaSetDevice(0);
+        worker_ready.store(true, std::memory_order_release);
+        while (!start_worker.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        if (result == cudaSuccess) {
+            peak_cuda_capture_race_target<<<1, 1, 0, timing_stream>>>(
+                device_value);
+            result = cudaPeekAtLastError();
+        }
+        worker_result.store(static_cast<int>(result),
+                            std::memory_order_release);
+    });
+
+    bool setup_ready = wait_for_condition(
+        [&]() { return worker_ready.load(std::memory_order_acquire); },
+        "lifecycle worker setup");
+    if (reader_wins) {
+        seams.pause_lifecycle_after_admission(1);
+        seams.pause_cuda_section(1);
+    } else {
+        seams.pause_lifecycle_before_increment(1);
+    }
+    start_worker.store(true, std::memory_order_release);
+    bool reader_paused = setup_ready && wait_for_condition(
+        [&]() {
+            return reader_wins
+                       ? seams.lifecycle_after_admission_waiting() != 0
+                       : seams.lifecycle_before_increment_waiting() != 0;
+        },
+        reader_wins ? "admitted lifecycle reader"
+                    : "pre-increment lifecycle reader");
+
+    std::thread finalizer([&]() {
+        seams.finalize();
+        finalize_done.store(true, std::memory_order_release);
+    });
+    bool closing = reader_paused && wait_for_condition(
+        [&]() { return seams.lifecycle_closing() != 0; },
+        "lifecycle closing publication");
+    bool ordering_proved = false;
+    bool timing_reader_paused = !reader_wins;
+    bool capture_waited_for_reader = !reader_wins;
+    std::atomic<bool> capture_begin_done{false};
+    std::atomic<int> capture_begin_result{
+        static_cast<int>(cudaErrorNotReady)};
+    std::thread capture_begin_thread;
+    bool capture_begin_started = false;
+    if (reader_wins) {
+        seams.pause_lifecycle_after_admission(0);
+        timing_reader_paused = closing && wait_for_condition(
+            [&]() { return seams.cuda_sections_waiting() != 0; },
+            "admitted CUDA timing reader");
+        if (timing_reader_paused) {
+            capture_begin_started = true;
+            capture_begin_thread = std::thread([&]() {
+                cudaError_t result = cudaSetDevice(0);
+                if (result == cudaSuccess) {
+                    result = cudaStreamBeginCapture(
+                        capture_stream, cudaStreamCaptureModeRelaxed);
+                }
+                capture_begin_result.store(static_cast<int>(result),
+                                           std::memory_order_release);
+                capture_begin_done.store(true, std::memory_order_release);
+            });
+            bool transition_blocked = wait_for_condition(
+                [&]() { return seams.capture_blocked() != 0; },
+                "closed lifecycle capture transition");
+            std::this_thread::sleep_for(std::chrono::milliseconds(25));
+            capture_waited_for_reader = transition_blocked &&
+                !capture_begin_done.load(std::memory_order_acquire);
+        }
+        ordering_proved = closing && timing_reader_paused &&
+            capture_waited_for_reader &&
+            !finalize_done.load(std::memory_order_acquire);
+        seams.pause_cuda_section(0);
+    } else {
+        ordering_proved = closing && wait_for_condition(
+            [&]() { return finalize_done.load(std::memory_order_acquire); },
+            "closer completion before pre-increment reader");
+        seams.pause_lifecycle_before_increment(0);
+    }
+    seams.pause_cuda_section(0);
+    seams.pause_lifecycle_after_admission(0);
+    seams.pause_lifecycle_before_increment(0);
+    worker.join();
+    if (capture_begin_thread.joinable()) {
+        capture_begin_thread.join();
+    }
+    finalizer.join();
+
+    bool target_ok = worker_result.load(std::memory_order_acquire) ==
+        cudaSuccess;
+    if (!capture_begin_started) {
+        target_ok = target_ok && peak_cuda_test_check(
+            cudaStreamSynchronize(timing_stream),
+            "lifecycle target synchronize");
+    }
+    cudaGraph_t graph = nullptr;
+    int node_count = 0;
+    bool listener_ok = target_ok && seams.lifecycle_closing() != 0;
+    bool fail_closed_transition = false;
+    if (listener_ok) {
+        size_t nodes = 0;
+        if (capture_begin_started) {
+            listener_ok = capture_begin_done.load(std::memory_order_acquire) &&
+                capture_begin_result.load(std::memory_order_acquire) ==
+                    cudaSuccess;
+        } else {
+            listener_ok = seams.capture_blocked() == 0 &&
+                peak_cuda_test_check(
+                cudaStreamBeginCapture(capture_stream,
+                                       cudaStreamCaptureModeGlobal),
+                "closed lifecycle cudaStreamBeginCapture");
+        }
+        if (listener_ok) {
+            peak_cuda_capture_race_control<<<1, 1, 0, capture_stream>>>(
+                device_value);
+            listener_ok = peak_cuda_test_check(
+                cudaPeekAtLastError(), "closed lifecycle captured launch");
+        }
+        if (listener_ok) {
+            listener_ok = peak_cuda_test_check(
+                cudaStreamEndCapture(capture_stream, &graph),
+                "closed lifecycle cudaStreamEndCapture");
+        }
+        if (listener_ok) {
+            listener_ok = peak_cuda_test_check(
+                              cudaGraphGetNodes(graph, nullptr, &nodes),
+                              "closed lifecycle cudaGraphGetNodes") &&
+                          nodes == 1;
+            node_count = static_cast<int>(nodes);
+        }
+        if (listener_ok) {
+            listener_ok = execute_single_node_graph(
+                graph, capture_stream, "closed-lifecycle");
+        }
+        listener_ok = listener_ok && peak_cuda_test_check(
+            cudaStreamSynchronize(timing_stream),
+            "lifecycle timing stream synchronize");
+        fail_closed_transition = seams.capture_blocked() != 0;
+        listener_ok = listener_ok && fail_closed_transition;
+    }
+
+    int host_value = 0;
+    bool result_ok = target_ok && listener_ok &&
+        peak_cuda_test_check(cudaMemcpy(
+            &host_value, device_value, sizeof(host_value),
+            cudaMemcpyDeviceToHost), "lifecycle result copy");
+    if (graph != nullptr) {
+        (void)cudaGraphDestroy(graph);
+    }
+    (void)cudaFree(device_value);
+    (void)cudaStreamDestroy(capture_stream);
+    (void)cudaStreamDestroy(timing_stream);
+
+    int expected_value = 2;
+    if (!reader_paused || !closing || !ordering_proved || !result_ok ||
+        host_value != expected_value || node_count != 1) {
+        std::fprintf(stderr,
+                     "cuda_test_error: lifecycle race failed: mode=%s "
+                     "paused=%d closing=%d ordering=%d listener=%d "
+                     "timing_reader_paused=%d capture_waited=%d "
+                     "fail_closed_transition=%d nodes=%d result=%d "
+                     "expected=%d\n",
+                     reader_wins ? "reader-wins" : "closer-wins",
+                     reader_paused ? 1 : 0, closing ? 1 : 0,
+                     ordering_proved ? 1 : 0, listener_ok ? 1 : 0,
+                     timing_reader_paused ? 1 : 0,
+                     capture_waited_for_reader ? 1 : 0,
+                     fail_closed_transition ? 1 : 0,
+                     node_count, host_value, expected_value);
+        return 1;
+    }
+
+    if (reader_wins) {
+        std::printf("cuda_lifecycle_reader_wins_ok admitted_before_close=1 "
+                    "closer_waited=1 capture_waited_for_reader=1 "
+                    "fail_closed_transition=1 nodes=%d result=%d\n",
+                    node_count, host_value);
+    } else {
+        std::printf("cuda_lifecycle_closer_wins_ok close_before_increment=1 "
+                    "finalize_before_release=1 listener_rejected=1 "
+                    "fail_closed_transition=1 nodes=%d result=%d\n",
+                    node_count, host_value);
+    }
+    return 0;
+}
+
+int
+run_capture_races()
+{
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+    PeakCudaCaptureTestSeams seams = load_test_seams();
+    int seam_count =
+        (seams.force_incomplete != nullptr ? 1 : 0) +
+        (seams.harvester_query_count != nullptr ? 1 : 0) +
+        (seams.harvester_ready != nullptr ? 1 : 0) +
+        (seams.active_slot_count != nullptr ? 1 : 0) +
+        (seams.pause_capture_begin != nullptr ? 1 : 0) +
+        (seams.capture_begin_waiting != nullptr ? 1 : 0) +
+        (seams.pause_cuda_section != nullptr ? 1 : 0) +
+        (seams.cuda_sections_waiting != nullptr ? 1 : 0) +
+        (seams.capture_blocked != nullptr ? 1 : 0);
+    if (seam_count != 9) {
+        std::fprintf(stderr,
+                     "cuda_test_error: capture race mode requires all PEAK "
+                     "CUDA test seams\n");
+        return 1;
+    }
+
+    cudaStream_t stream_a = nullptr;
+    cudaStream_t stream_b = nullptr;
+    int* begin_target = nullptr;
+    int* begin_control = nullptr;
+    int* reader_target = nullptr;
+    int* reader_control = nullptr;
+    int* global_target = nullptr;
+    int* global_control = nullptr;
+    if (!peak_cuda_test_check(cudaSetDevice(0), "race cudaSetDevice") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &stream_a, cudaStreamNonBlocking),
+                              "race stream A create") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &stream_b, cudaStreamNonBlocking),
+                              "race stream B create") ||
+        !peak_cuda_test_check(cudaMalloc(&begin_target, sizeof(int)),
+                              "race begin target allocation") ||
+        !peak_cuda_test_check(cudaMalloc(&begin_control, sizeof(int)),
+                              "race begin control allocation") ||
+        !peak_cuda_test_check(cudaMalloc(&reader_target, sizeof(int)),
+                              "race reader target allocation") ||
+        !peak_cuda_test_check(cudaMalloc(&reader_control, sizeof(int)),
+                              "race reader control allocation") ||
+        !peak_cuda_test_check(cudaMalloc(&global_target, sizeof(int)),
+                              "race global target allocation") ||
+        !peak_cuda_test_check(cudaMalloc(&global_control, sizeof(int)),
+                              "race global control allocation") ||
+        !peak_cuda_test_check(cudaMemset(begin_target, 0, sizeof(int)),
+                              "race begin target memset") ||
+        !peak_cuda_test_check(cudaMemset(begin_control, 0, sizeof(int)),
+                              "race begin control memset") ||
+        !peak_cuda_test_check(cudaMemset(reader_target, 0, sizeof(int)),
+                              "race reader target memset") ||
+        !peak_cuda_test_check(cudaMemset(reader_control, 0, sizeof(int)),
+                              "race reader control memset") ||
+        !peak_cuda_test_check(cudaMemset(global_target, 0, sizeof(int)),
+                              "race global target memset") ||
+        !peak_cuda_test_check(cudaMemset(global_control, 0, sizeof(int)),
+                              "race global control memset")) {
+        return 1;
+    }
+
+    int initialization_warmups = 0;
+    if (!initialize_harvester(seams, stream_a, &initialization_warmups)) {
+        std::fprintf(stderr,
+                     "cuda_test_error: CUDA harvester did not become ready "
+                     "for capture races\n");
+        return 1;
+    }
+    bool begin_ok = run_begin_first_race(
+        seams, stream_a, begin_target, begin_control);
+    int reader_quiesced = 0;
+    int reader_recycled = 0;
+    bool reader_ok = begin_ok && run_reader_first_race(
+        seams, stream_a, reader_target, reader_control,
+        &reader_quiesced, &reader_recycled);
+
+    cudaFunction_t runtime_function = nullptr;
+    bool function_ok = reader_ok && peak_cuda_test_check(
+        cudaGetFuncBySymbol(
+            &runtime_function,
+            reinterpret_cast<const void*>(peak_cuda_capture_race_target)),
+        "race cudaGetFuncBySymbol");
+    int global_nodes = 0;
+    bool global_ok = function_ok && run_global_cross_stream_cycles(
+        seams, stream_a, stream_b,
+        reinterpret_cast<CUfunction>(runtime_function), global_target,
+        global_control, &global_nodes);
+
+    int begin_target_value = 0;
+    int begin_control_value = 0;
+    int reader_target_value = 0;
+    int reader_control_value = 0;
+    int global_target_value = 0;
+    int global_control_value = 0;
+    bool copies_ok = global_ok &&
+        peak_cuda_test_check(cudaMemcpy(
+            &begin_target_value, begin_target, sizeof(int),
+            cudaMemcpyDeviceToHost), "race begin target copy") &&
+        peak_cuda_test_check(cudaMemcpy(
+            &begin_control_value, begin_control, sizeof(int),
+            cudaMemcpyDeviceToHost), "race begin control copy") &&
+        peak_cuda_test_check(cudaMemcpy(
+            &reader_target_value, reader_target, sizeof(int),
+            cudaMemcpyDeviceToHost), "race reader target copy") &&
+        peak_cuda_test_check(cudaMemcpy(
+            &reader_control_value, reader_control, sizeof(int),
+            cudaMemcpyDeviceToHost), "race reader control copy") &&
+        peak_cuda_test_check(cudaMemcpy(
+            &global_target_value, global_target, sizeof(int),
+            cudaMemcpyDeviceToHost), "race global target copy") &&
+        peak_cuda_test_check(cudaMemcpy(
+            &global_control_value, global_control, sizeof(int),
+            cudaMemcpyDeviceToHost), "race global control copy");
+
+    (void)cudaFree(global_control);
+    (void)cudaFree(global_target);
+    (void)cudaFree(reader_control);
+    (void)cudaFree(reader_target);
+    (void)cudaFree(begin_control);
+    (void)cudaFree(begin_target);
+    (void)cudaStreamDestroy(stream_b);
+    (void)cudaStreamDestroy(stream_a);
+
+    if (!copies_ok || begin_target_value != 1 || begin_control_value != 1 ||
+        reader_target_value != 1 || reader_control_value != 1 ||
+        global_target_value != 32 || global_control_value != 32 ||
+        global_nodes != 32 || reader_quiesced != 1 ||
+        reader_recycled != 1) {
+        std::fprintf(stderr,
+                     "cuda_test_error: capture race results are incomplete: "
+                     "begin=%d/%d reader=%d/%d global=%d/%d nodes=%d "
+                     "quiesced=%d recycled=%d\n",
+                     begin_target_value, begin_control_value,
+                     reader_target_value, reader_control_value,
+                     global_target_value, global_control_value, global_nodes,
+                     reader_quiesced, reader_recycled);
+        return 1;
+    }
+
+    std::printf(
+        "cuda_capture_races_ok begin_first_nodes=1 "
+        "begin_first_results=%d/%d reader_first_nodes=1 "
+        "reader_first_results=%d/%d reader_pending_quiesced=%d "
+        "reader_pending_recycled=%d global_cycles=32 "
+        "global_nodes_per_cycle=1 global_results=%d/%d "
+        "initialization_warmups=%d\n",
+        begin_target_value, begin_control_value,
+        reader_target_value, reader_control_value,
+        reader_quiesced, reader_recycled,
+        global_target_value, global_control_value,
+        initialization_warmups);
+    return 0;
+}
+}
+
+int
+main(int argc, char** argv)
+{
+    if (argc == 2 && std::strcmp(argv[1], "--capture-races") == 0) {
+        return run_capture_races();
+    }
+    if (argc == 2 &&
+        std::strcmp(argv[1], "--lifecycle-reader-wins") == 0) {
+        return run_lifecycle_gate_race(true);
+    }
+    if (argc == 2 &&
+        std::strcmp(argv[1], "--lifecycle-closer-wins") == 0) {
+        return run_lifecycle_gate_race(false);
+    }
+    if (argc != 1) {
+        return 2;
+    }
+    int requirement = peak_cuda_test_require_devices(1, nullptr);
+    if (requirement != 0) {
+        return requirement;
+    }
+
+    cudaStream_t stream = nullptr;
+    int* device_value = nullptr;
+    int runtime_value = 0;
+    int driver_value = 0;
+    std::vector<cudaGraph_t> runtime_graphs;
+    std::vector<cudaGraphExec_t> runtime_executables;
+    std::vector<CUgraph> driver_graphs;
+    std::vector<CUgraphExec> driver_executables;
+    PeakCudaCaptureTestSeams seams = load_test_seams();
+    bool have_test_seams = seams.force_incomplete != nullptr &&
+                           seams.harvester_query_count != nullptr &&
+                           seams.harvester_ready != nullptr &&
+                           seams.active_slot_count != nullptr;
+    int runtime_helper_quiesced = 0;
+    int runtime_helper_recycled = 0;
+    int driver_helper_quiesced = 0;
+    int driver_helper_recycled = 0;
+    int initialization_warmups = 0;
+    unsigned long long runtime_pending_queries = 0;
+    unsigned long long driver_pending_queries = 0;
+    int seam_count = (seams.force_incomplete != nullptr ? 1 : 0) +
+                     (seams.harvester_query_count != nullptr ? 1 : 0) +
+                     (seams.harvester_ready != nullptr ? 1 : 0) +
+                     (seams.active_slot_count != nullptr ? 1 : 0);
+    if (seam_count != 0 && seam_count != 4) {
+        std::fprintf(stderr,
+                     "cuda_test_error: incomplete PEAK CUDA test seam set\n");
+        return 1;
+    }
+    int race_seam_count =
+        (seams.pause_capture_begin != nullptr ? 1 : 0) +
+        (seams.capture_begin_waiting != nullptr ? 1 : 0) +
+        (seams.pause_cuda_section != nullptr ? 1 : 0) +
+        (seams.cuda_sections_waiting != nullptr ? 1 : 0) +
+        (seams.capture_blocked != nullptr ? 1 : 0);
+    if (race_seam_count != 0 && race_seam_count != 5) {
+        std::fprintf(stderr,
+                     "cuda_test_error: incomplete PEAK CUDA race seam set\n");
+        return 1;
+    }
+    runtime_graphs.reserve(kCaptureCycles);
+    runtime_executables.reserve(kCaptureCycles);
+    driver_graphs.reserve(kCaptureCycles);
+    driver_executables.reserve(kCaptureCycles);
+    if (!peak_cuda_test_check(cudaSetDevice(0), "cudaSetDevice") ||
+        !peak_cuda_test_check(cudaStreamCreateWithFlags(
+                                  &stream, cudaStreamNonBlocking),
+                              "cudaStreamCreateWithFlags") ||
+        !peak_cuda_test_check(cudaMalloc(&device_value, sizeof(*device_value)),
+                              "cudaMalloc") ||
+        !peak_cuda_test_check(cudaMemsetAsync(device_value, 0,
+                                              sizeof(*device_value), stream),
+                              "cudaMemsetAsync") ||
+        !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                              "initial cudaStreamSynchronize")) {
+        return 1;
+    }
+
+    if (have_test_seams) {
+        if (!initialize_harvester(seams, stream,
+                                  &initialization_warmups)) {
+            std::fprintf(stderr,
+                         "cuda_test_error: CUDA harvester did not become "
+                         "ready\n");
+            return 1;
+        }
+        seams.force_incomplete(1);
+        peak_cuda_runtime_pending_capture_marker<<<1, 1, 0, stream>>>();
+        if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                                  "runtime pending marker launch") ||
+            !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "runtime pending marker synchronize") ||
+            !wait_for_active_slots(seams, 1) ||
+            !wait_for_harvester_quiescence(
+                seams, &runtime_pending_queries) ||
+            !peak_cuda_test_check(
+                cudaStreamBeginCapture(stream,
+                                       cudaStreamCaptureModeGlobal),
+                "runtime concurrent cudaStreamBeginCapture")) {
+            seams.force_incomplete(0);
+            return 1;
+        }
+        seams.force_incomplete(0);
+        if (!harvester_queries_stay_at(seams, runtime_pending_queries) ||
+            seams.active_slot_count() == 0) {
+            cudaGraph_t ignored = nullptr;
+            (void)cudaStreamEndCapture(stream, &ignored);
+            std::fprintf(stderr,
+                         "cuda_test_error: harvester was not quiescent "
+                         "during Runtime capture\n");
+            return 1;
+        }
+        runtime_helper_quiesced = 1;
+    }
+
+    for (int cycle = 0; cycle < kCaptureCycles; ++cycle) {
+        cudaGraph_t graph = nullptr;
+        cudaGraphExec_t executable = nullptr;
+        size_t node_count = 0;
+
+        if ((cycle != 0 || !have_test_seams) &&
+            !peak_cuda_test_check(
+                cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
+                "cudaStreamBeginCapture")) {
+            return 1;
+        }
+        peak_cuda_capture_topology_kernel<<<1, 1, 0, stream>>>(device_value);
+        if (!peak_cuda_test_check(cudaPeekAtLastError(),
+                                  "captured kernel launch") ||
+            !peak_cuda_test_check(cudaStreamEndCapture(stream, &graph),
+                                  "cudaStreamEndCapture") ||
+            !peak_cuda_test_check(cudaGraphGetNodes(graph, nullptr,
+                                                    &node_count),
+                                  "cudaGraphGetNodes")) {
+            return 1;
+        }
+        if (node_count != 1) {
+            std::fprintf(stderr,
+                         "cuda_test_error: capture cycle %d has %zu nodes, "
+                         "expected 1\n",
+                         cycle, node_count);
+            return 1;
+        }
+        if (cycle == 0 && have_test_seams) {
+            if (!wait_for_harvester_query(seams,
+                                          runtime_pending_queries) ||
+                !wait_for_harvester_idle(seams)) {
+                std::fprintf(
+                    stderr,
+                    "cuda_test_error: Runtime pending event did not recycle "
+                    "after capture ended\n");
+                return 1;
+            }
+            runtime_helper_recycled = 1;
+        }
+        if (!peak_cuda_test_check(
+                cudaGraphInstantiate(&executable, graph, nullptr, nullptr, 0),
+                "cudaGraphInstantiate") ||
+            !peak_cuda_test_check(cudaGraphLaunch(executable, stream),
+                                  "cudaGraphLaunch") ||
+            !peak_cuda_test_check(cudaStreamSynchronize(stream),
+                                  "cudaStreamSynchronize")) {
+            return 1;
+        }
+        runtime_executables.push_back(executable);
+        runtime_graphs.push_back(graph);
+    }
+
+    if (!peak_cuda_test_check(cudaMemcpy(&runtime_value, device_value,
+                                         sizeof(runtime_value),
+                                         cudaMemcpyDeviceToHost),
+                              "runtime cudaMemcpy") ||
+        !peak_cuda_test_check(cudaMemset(device_value, 0,
+                                         sizeof(*device_value)),
+                              "driver setup cudaMemset")) {
+        return 1;
+    }
+    if (runtime_value != kCaptureCycles) {
+        std::fprintf(stderr,
+                     "cuda_test_error: runtime captured graph result is %d, "
+                     "expected %d\n",
+                     runtime_value, kCaptureCycles);
+        return 1;
+    }
+
+    cudaFunction_t runtime_function = nullptr;
+    cudaFunction_t runtime_marker_function = nullptr;
+    CUstream driver_stream = nullptr;
+    if (!peak_cuda_test_check(
+            cudaGetFuncBySymbol(
+                &runtime_function,
+                reinterpret_cast<const void*>(peak_cuda_driver_capture_kernel)),
+            "cudaGetFuncBySymbol") ||
+        !peak_cuda_test_check(
+            cudaGetFuncBySymbol(
+                &runtime_marker_function,
+                reinterpret_cast<const void*>(
+                    peak_cuda_runtime_pending_capture_marker)),
+            "marker cudaGetFuncBySymbol") ||
+        !check_driver(cuStreamCreate(&driver_stream, CU_STREAM_NON_BLOCKING),
+                      "cuStreamCreate")) {
+        return 1;
+    }
+    CUfunction driver_function =
+        reinterpret_cast<CUfunction>(runtime_function);
+    CUfunction driver_marker_function =
+        reinterpret_cast<CUfunction>(runtime_marker_function);
+    CUdeviceptr driver_pointer =
+        reinterpret_cast<CUdeviceptr>(device_value);
+    void* driver_arguments[] = {&driver_pointer};
+
+    if (have_test_seams) {
+        seams.force_incomplete(1);
+        if (!check_driver(
+                cuLaunchKernel(driver_marker_function, 1, 1, 1, 1, 1, 1,
+                               0, driver_stream, nullptr, nullptr),
+                "Driver pending marker launch") ||
+            !check_driver(cuStreamSynchronize(driver_stream),
+                          "Driver pending marker synchronize") ||
+            !wait_for_active_slots(seams, 1) ||
+            !wait_for_harvester_quiescence(
+                seams, &driver_pending_queries) ||
+            !check_driver(
+                cuStreamBeginCapture(driver_stream,
+                                     CU_STREAM_CAPTURE_MODE_GLOBAL),
+                "Driver concurrent cuStreamBeginCapture")) {
+            seams.force_incomplete(0);
+            return 1;
+        }
+        seams.force_incomplete(0);
+        if (!harvester_queries_stay_at(seams, driver_pending_queries) ||
+            seams.active_slot_count() == 0) {
+            CUgraph ignored = nullptr;
+            (void)cuStreamEndCapture(driver_stream, &ignored);
+            std::fprintf(stderr,
+                         "cuda_test_error: harvester was not quiescent "
+                         "during Driver capture\n");
+            return 1;
+        }
+        driver_helper_quiesced = 1;
+    }
+
+    for (int cycle = 0; cycle < kCaptureCycles; ++cycle) {
+        CUgraph graph = nullptr;
+        CUgraphExec executable = nullptr;
+        size_t node_count = 0;
+
+        if ((cycle != 0 || !have_test_seams) &&
+            !check_driver(
+                cuStreamBeginCapture(driver_stream,
+                                     CU_STREAM_CAPTURE_MODE_GLOBAL),
+                "cuStreamBeginCapture")) {
+            return 1;
+        }
+        if (!check_driver(cuLaunchKernel(driver_function, 1, 1, 1, 1, 1, 1,
+                                         0, driver_stream, driver_arguments,
+                                         nullptr),
+                          "cuLaunchKernel") ||
+            !check_driver(cuStreamEndCapture(driver_stream, &graph),
+                          "cuStreamEndCapture") ||
+            !check_driver(cuGraphGetNodes(graph, nullptr, &node_count),
+                          "cuGraphGetNodes")) {
+            return 1;
+        }
+        if (node_count != 1) {
+            std::fprintf(stderr,
+                         "cuda_test_error: driver capture cycle %d has %zu "
+                         "nodes, expected 1\n",
+                         cycle, node_count);
+            return 1;
+        }
+        if (cycle == 0 && have_test_seams) {
+            if (!wait_for_harvester_query(seams,
+                                          driver_pending_queries) ||
+                !wait_for_harvester_idle(seams)) {
+                std::fprintf(
+                    stderr,
+                    "cuda_test_error: Driver pending event did not recycle "
+                    "after capture ended\n");
+                return 1;
+            }
+            driver_helper_recycled = 1;
+        }
+#if CUDA_VERSION >= 11040
+        CUresult instantiate =
+            cuGraphInstantiateWithFlags(&executable, graph, 0);
+#else
+        CUresult instantiate = cuGraphInstantiate(
+            &executable, graph, nullptr, nullptr, 0);
+#endif
+        if (!check_driver(instantiate,
+                          "cuGraphInstantiate") ||
+            !check_driver(cuGraphLaunch(executable, driver_stream),
+                          "cuGraphLaunch") ||
+            !check_driver(cuStreamSynchronize(driver_stream),
+                          "cuStreamSynchronize")) {
+            return 1;
+        }
+        driver_executables.push_back(executable);
+        driver_graphs.push_back(graph);
+    }
+
+    if (!check_driver(cuMemcpyDtoH(&driver_value, driver_pointer,
+                                   sizeof(driver_value)),
+                      "cuMemcpyDtoH")) {
+        return 1;
+    }
+    for (CUgraphExec executable : driver_executables) {
+        (void)cuGraphExecDestroy(executable);
+    }
+    for (CUgraph graph : driver_graphs) {
+        (void)cuGraphDestroy(graph);
+    }
+    for (cudaGraphExec_t executable : runtime_executables) {
+        (void)cudaGraphExecDestroy(executable);
+    }
+    for (cudaGraph_t graph : runtime_graphs) {
+        (void)cudaGraphDestroy(graph);
+    }
+    (void)cuStreamDestroy(driver_stream);
+    cudaFree(device_value);
+    cudaStreamDestroy(stream);
+    if (driver_value != kCaptureCycles) {
+        std::fprintf(stderr,
+                     "cuda_test_error: driver captured graph result is %d, "
+                     "expected %d\n",
+                     driver_value, kCaptureCycles);
+        return 1;
+    }
+
+    std::printf("cuda_stream_capture_ok runtime_cycles=%d driver_cycles=%d "
+                "live_graph_identities=%d nodes_per_cycle=1 "
+                "runtime_result=%d driver_result=%d "
+                "runtime_helper_quiesced=%d "
+                "runtime_helper_recycled=%d "
+                "driver_helper_quiesced=%d "
+                "driver_helper_recycled=%d "
+                "initialization_warmups=%d\n",
+                kCaptureCycles, kCaptureCycles, kCaptureCycles * 2,
+                runtime_value, driver_value,
+                runtime_helper_quiesced,
+                runtime_helper_recycled,
+                driver_helper_quiesced,
+                driver_helper_recycled,
+                initialization_warmups);
+    return 0;
+}

--- a/test/cuda_profiler_state_test.cpp
+++ b/test/cuda_profiler_state_test.cpp
@@ -1,7 +1,10 @@
 #include "internal/cuda_profiler_state.h"
 
 #include <atomic>
+#include <cstring>
+#include <cstdlib>
 #include <cstdio>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -20,36 +23,13 @@ test_identity_cache_and_non_target_fast_path()
     PeakCudaKernelIdentity lookup;
 
     if (first.target_match || cached.target_match ||
-        cached.name != "unwanted" || !driver.target_match ||
+        std::strcmp(cached.name.data(), "unwanted") != 0 ||
+        !driver.target_match ||
         !state.cached_identity(0x1000, false, &lookup) ||
-        lookup.name != "unwanted" || state.counters().active_slots != 0) {
+        std::strcmp(lookup.name.data(), "unwanted") != 0) {
         return 1;
     }
     return 0;
-}
-
-static int
-test_bounded_pool_and_drop_accounting()
-{
-    PeakCudaProfilerState state(2);
-
-    if (!state.acquire_slot() || !state.acquire_slot() ||
-        state.acquire_slot()) {
-        return 1;
-    }
-    PeakCudaProfilerCounters counters = state.counters();
-    if (counters.active_slots != 2 || counters.high_water_slots != 2 ||
-        counters.dropped_pool_full != 1) {
-        return 1;
-    }
-    state.release_slot();
-    state.release_slot();
-    state.record_event_create_failure();
-    state.record_timing_error();
-    counters = state.counters();
-    return counters.active_slots != 0 ||
-           counters.dropped_event_create != 1 ||
-           counters.dropped_timing_error != 1;
 }
 
 static int
@@ -63,25 +43,58 @@ test_identity_cache_is_bounded()
     PeakCudaKernelIdentity overflow =
         state.identify(0x2, false, "another", "another", true, targets);
     PeakCudaProfilerCounters counters = state.counters();
-    return overflow.name != "<unknown>" || !overflow.target_match ||
+    return std::strcmp(overflow.name.data(), "<unknown>") != 0 ||
+           !overflow.target_match ||
            counters.cached_identities != 1 ||
            counters.dropped_identity_full != 1;
 }
 
 static int
+test_driver_identity_cache_is_context_aware()
+{
+    PeakCudaProfilerState state(4);
+    const std::vector<std::string> targets = {"wanted"};
+    PeakCudaKernelIdentity first = state.identify(
+        0x1000, true, "context-a", "not-wanted", false, targets, 0xa);
+    PeakCudaKernelIdentity second = state.identify(
+        0x1000, true, "context-b", "wanted", false, targets, 0xb);
+    PeakCudaKernelIdentity cached_first;
+    PeakCudaKernelIdentity cached_second;
+
+    if (first.target_match ||
+        std::strcmp(first.name.data(), "context-a") != 0 ||
+        !second.target_match ||
+        std::strcmp(second.name.data(), "context-b") != 0 ||
+        !state.cached_identity(0x1000, true, &cached_first, 0xa) ||
+        !state.cached_identity(0x1000, true, &cached_second, 0xb) ||
+        std::strcmp(cached_first.name.data(), "context-a") != 0 ||
+        cached_first.target_match ||
+        std::strcmp(cached_second.name.data(), "context-b") != 0 ||
+        !cached_second.target_match ||
+        state.counters().cached_identities != 2) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_concurrent_stress_remains_bounded()
 {
-    PeakCudaProfilerState state(8);
+    PeakCudaSlotAllocator allocator(8);
     std::atomic<bool> start(false);
     std::vector<std::thread> workers;
 
     for (int worker = 0; worker < 8; ++worker) {
-        workers.emplace_back([&state, &start]() {
+        workers.emplace_back([&allocator, &start, worker]() {
             while (!start.load(std::memory_order_acquire)) {
             }
             for (int iteration = 0; iteration < 10000; ++iteration) {
-                if (state.acquire_slot()) {
-                    state.release_slot();
+                PeakCudaSlotLease lease = {};
+                if (allocator.acquire(
+                        1, static_cast<std::size_t>(worker), &lease)) {
+                    if (!allocator.release(lease)) {
+                        std::abort();
+                    }
                 }
             }
         });
@@ -90,50 +103,141 @@ test_concurrent_stress_remains_bounded()
     for (std::thread& worker : workers) {
         worker.join();
     }
-    PeakCudaProfilerCounters counters = state.counters();
+    PeakCudaSlotAllocatorCounters counters = allocator.counters();
     return counters.active_slots != 0 || counters.high_water_slots > 8;
 }
 
 static int
-fake_launch_with_admission(PeakCudaProfilerState* state,
+test_pending_queue_shards_preserve_exact_handoff()
+{
+    constexpr std::size_t kWorkers = 8;
+    constexpr std::size_t kPerWorker = 64;
+    constexpr std::size_t kTotal = kWorkers * kPerWorker;
+    PeakCudaPendingQueue queue(kTotal);
+    std::atomic<bool> start(false);
+    std::vector<std::thread> producers;
+    std::vector<unsigned char> seen(kTotal, 0);
+
+    for (std::size_t worker = 0; worker < kWorkers; ++worker) {
+        producers.emplace_back([&queue, &start, worker]() {
+            while (!start.load(std::memory_order_acquire)) {
+            }
+            for (std::size_t item = 0; item < kPerWorker; ++item) {
+                const std::size_t index = worker * kPerWorker + item;
+                PeakCudaSlotLease lease = {
+                    index, index + 1, 0x1000 + worker, worker,
+                };
+                if (!queue.push(lease)) {
+                    std::abort();
+                }
+            }
+        });
+    }
+    start.store(true, std::memory_order_release);
+
+    std::size_t received = 0;
+    while (received != kTotal) {
+        PeakCudaSlotLease lease = {};
+        if (!queue.pop(&lease)) {
+            std::this_thread::yield();
+            continue;
+        }
+        if (lease.index >= kTotal || seen[lease.index] != 0 ||
+            lease.generation != lease.index + 1 ||
+            lease.shard >= kWorkers) {
+            return 1;
+        }
+        seen[lease.index] = 1;
+        ++received;
+    }
+    for (std::thread& producer : producers) {
+        producer.join();
+    }
+    if (queue.pop(nullptr)) {
+        return 1;
+    }
+    for (unsigned char value : seen) {
+        if (value != 1) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+test_pending_queue_local_retry_preserves_producer_empty_transition()
+{
+    PeakCudaPendingQueue queue(2);
+    const PeakCudaSlotLease first = {0, 1, 0x1000, 0};
+    const PeakCudaSlotLease second = {1, 1, 0x1000, 0};
+    PeakCudaSlotLease received = {};
+    bool shard_was_empty = false;
+
+    if (!queue.push(first, &shard_was_empty) || !shard_was_empty ||
+        !queue.pop(&received) || received.index != first.index ||
+        !queue.requeue_local(received)) {
+        return 1;
+    }
+    shard_was_empty = false;
+    if (!queue.push(second, &shard_was_empty) || !shard_was_empty ||
+        !queue.pop(&received) || received.index != first.index ||
+        !queue.pop(&received) || received.index != second.index ||
+        queue.pop(&received)) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
+fake_launch_with_admission(PeakCudaSlotAllocator* allocator,
+                           PeakCudaProfilerState* state,
                            bool event_create_succeeds,
                            int* original_calls,
                            int* event_records)
 {
-    if (!state->acquire_slot()) {
+    PeakCudaSlotLease lease = {};
+    if (!allocator->acquire(1, &lease)) {
         ++*original_calls;
         return 7;
     }
     if (!event_create_succeeds) {
         state->record_event_create_failure();
-        state->release_slot();
+        if (!allocator->release(lease)) {
+            return 8;
+        }
         ++*original_calls;
         return 7;
     }
     ++*event_records;
     ++*original_calls;
     ++*event_records;
-    state->release_slot();
+    if (!allocator->release(lease)) {
+        return 8;
+    }
     return 7;
 }
 
 static int
 test_admission_failure_executes_original_once_without_events()
 {
+    PeakCudaSlotAllocator allocator(1);
     PeakCudaProfilerState state(1);
+    PeakCudaSlotLease held = {};
     int original_calls = 0;
     int event_records = 0;
 
-    if (!state.acquire_slot() ||
-        fake_launch_with_admission(&state, true, &original_calls,
+    if (!allocator.acquire(1, &held) ||
+        fake_launch_with_admission(&allocator, &state, true, &original_calls,
                                    &event_records) != 7 ||
         original_calls != 1 || event_records != 0) {
         return 1;
     }
-    state.release_slot();
+    if (!allocator.release(held)) {
+        return 1;
+    }
     original_calls = 0;
     event_records = 0;
-    if (fake_launch_with_admission(&state, false, &original_calls,
+    if (fake_launch_with_admission(&allocator, &state, false, &original_calls,
                                    &event_records) != 7 ||
         original_calls != 1 || event_records != 0 ||
         state.counters().dropped_event_create != 1) {
@@ -142,14 +246,263 @@ test_admission_failure_executes_original_once_without_events()
     return 0;
 }
 
+static int
+test_slot_allocator_partitions_contexts_and_reuses_slots()
+{
+    PeakCudaSlotAllocator allocator(3);
+    PeakCudaSlotLease first = {};
+    PeakCudaSlotLease other = {};
+    PeakCudaSlotLease reused = {};
+
+    if (!allocator.acquire(0xa, &first) || !allocator.release(first) ||
+        !allocator.acquire(0xb, &other) ||
+        other.index == first.index ||
+        !allocator.acquire(0xa, &reused) ||
+        reused.index != first.index ||
+        reused.generation == first.generation) {
+        return 1;
+    }
+
+    PeakCudaSlotAllocatorCounters counters = allocator.counters();
+    PeakCudaSlotLease snapshot[1] = {};
+    if (counters.capacity != 3 || counters.assigned_slots != 2 ||
+        counters.context_count != 2 || counters.active_slots != 2 ||
+        counters.high_water_slots != 2 ||
+        allocator.snapshot_active_leases(snapshot, 1) != 2 ||
+        (snapshot[0].context != 0xa && snapshot[0].context != 0xb)) {
+        return 1;
+    }
+    return !allocator.release(other) || !allocator.release(reused);
+}
+
+static int
+test_slot_allocator_bounds_exhaustion_and_reset()
+{
+    PeakCudaSlotAllocator allocator(2);
+    PeakCudaSlotLease first = {};
+    PeakCudaSlotLease second = {};
+    PeakCudaSlotLease third = {};
+
+    if (!allocator.acquire(1, &first) ||
+        !allocator.acquire(2, &second) ||
+        allocator.acquire(3, &third) ||
+        !allocator.release(first) || !allocator.release(second) ||
+        allocator.acquire(3, &third)) {
+        return 1;
+    }
+    PeakCudaSlotAllocatorCounters counters = allocator.counters();
+    if (counters.assigned_slots != 2 || counters.context_count != 2 ||
+        counters.active_slots != 0 || counters.high_water_slots != 2) {
+        return 1;
+    }
+
+    allocator.reset(1);
+    counters = allocator.counters();
+    if (counters.capacity != 1 || counters.assigned_slots != 0 ||
+        counters.context_count != 0 || counters.active_slots != 0 ||
+        counters.high_water_slots != 0 ||
+        !allocator.acquire(3, &third) ||
+        third.generation == first.generation || allocator.release(first)) {
+        return 1;
+    }
+    return !allocator.release(third);
+}
+
+static int
+test_slot_allocator_rejects_stale_and_double_release()
+{
+    PeakCudaSlotAllocator allocator(1);
+    PeakCudaSlotLease first = {};
+    PeakCudaSlotLease second = {};
+
+    if (!allocator.acquire(7, &first) || !allocator.release(first) ||
+        allocator.release(first) || !allocator.acquire(7, &second) ||
+        second.index != first.index || second.generation == first.generation ||
+        allocator.release(first)) {
+        return 1;
+    }
+
+    PeakCudaSlotLease wrong_context = second;
+    wrong_context.context = 8;
+    if (allocator.release(wrong_context) ||
+        allocator.counters().active_slots != 1) {
+        return 1;
+    }
+    return !allocator.release(second) || allocator.release(second);
+}
+
+static int
+test_slot_allocator_admission_close_is_fail_open()
+{
+    PeakCudaSlotAllocator allocator(1);
+    std::atomic_bool accepting(false);
+    PeakCudaSlotLease lease = {};
+    bool admission_closed = false;
+
+    if (allocator.acquire_if_accepting(
+            7, accepting, &lease, &admission_closed) ||
+        !admission_closed ||
+        allocator.counters().active_slots != 0) {
+        return 1;
+    }
+    accepting.store(true, std::memory_order_release);
+    if (!allocator.acquire_if_accepting(
+            7, accepting, &lease, &admission_closed) ||
+        admission_closed) {
+        return 1;
+    }
+    accepting.store(false, std::memory_order_release);
+    if (allocator.acquire_if_accepting(
+            7, accepting, &lease, &admission_closed) ||
+        !admission_closed ||
+        allocator.counters().active_slots != 1) {
+        return 1;
+    }
+    return !allocator.release(lease);
+}
+
+static int
+test_explicit_lifecycle_counters()
+{
+    PeakCudaProfilerState state(1);
+
+    state.record_launch_observed();
+    state.record_launch_observed();
+    state.record_launch_accepted();
+    state.record_launch_completed();
+    state.record_pool_full();
+    state.record_identity_full();
+    state.record_event_create_failure();
+    state.record_timing_error();
+    state.record_harvester_unavailable();
+    state.record_stream_capture_skip();
+    state.record_capture_query_failure();
+    state.record_capture_query_unsupported();
+    state.record_unsupported_multi_device();
+    state.record_event_query_failure();
+    state.record_elapsed_time_failure();
+    state.record_context_query_failure();
+    state.record_context_switch_failure();
+    state.record_context_restore_failure();
+    state.record_finalization_timeout(3);
+    state.record_dimension_overflow();
+
+    PeakCudaProfilerCounters counters = state.counters();
+    if (counters.observed_launches != 2 ||
+        counters.accepted_launches != 1 ||
+        counters.completed_launches != 1 ||
+        counters.dropped_pool_full != 1 ||
+        counters.dropped_identity_full != 1 ||
+        counters.dropped_event_create != 1 ||
+        counters.dropped_timing_error != 3 ||
+        counters.dropped_harvester_unavailable != 1 ||
+        counters.dropped_stream_capture != 1 ||
+        counters.dropped_capture_query != 1 ||
+        counters.dropped_capture_query_unsupported != 1 ||
+        counters.dropped_unsupported_multi_device != 1 ||
+        counters.dropped_event_query != 1 ||
+        counters.dropped_elapsed_time != 1 ||
+        counters.dropped_context_query != 1 ||
+        counters.dropped_context_switch != 1 ||
+        counters.dropped_context_restore != 1 ||
+        counters.finalization_timeouts != 1 ||
+        counters.finalization_incomplete != 3 ||
+        counters.dropped_dimension_overflow != 1) {
+        return 1;
+    }
+
+    state.reset(1);
+    counters = state.counters();
+    return counters.observed_launches != 0 ||
+           counters.accepted_launches != 0 ||
+           counters.completed_launches != 0 ||
+           counters.dropped_pool_full != 0 ||
+           counters.dropped_identity_full != 0 ||
+           counters.dropped_timing_error != 0 ||
+           counters.dropped_harvester_unavailable != 0 ||
+           counters.finalization_timeouts != 0 ||
+           counters.finalization_incomplete != 0 ||
+           counters.dropped_dimension_overflow != 0;
+}
+
+static int
+test_concurrent_counters_are_exact()
+{
+    PeakCudaProfilerState state(1);
+    std::vector<std::thread> workers;
+    constexpr int kWorkers = 8;
+    constexpr int kIterations = 10000;
+
+    for (int worker = 0; worker < kWorkers; ++worker) {
+        workers.emplace_back([&state, worker]() {
+            for (int iteration = 0; iteration < kIterations; ++iteration) {
+                state.record_launch_observed(
+                    static_cast<std::size_t>(worker), true);
+                state.record_launch_accepted(
+                    static_cast<std::size_t>(worker), true);
+                state.record_pool_full();
+            }
+        });
+    }
+    for (std::thread& worker : workers) {
+        worker.join();
+    }
+    PeakCudaProfilerCounters counters = state.counters();
+    return counters.observed_launches != kWorkers * kIterations ||
+           counters.accepted_launches != kWorkers * kIterations ||
+           counters.dropped_pool_full != kWorkers * kIterations;
+}
+
+static int
+test_dimension_arithmetic_is_wide_and_saturating()
+{
+    PeakCudaLaunchDimensions legal = peak_cuda_compute_launch_dimensions(
+        65538U, 65535U, 1U, 1024U, 1U, 1U);
+    const std::uint64_t expected_grid =
+        static_cast<std::uint64_t>(65538U) * 65535U;
+    if (legal.overflow || legal.grid_size != expected_grid ||
+        legal.block_size != 1024U ||
+        legal.total_threads != expected_grid * 1024U ||
+        legal.grid_size <= std::numeric_limits<std::uint32_t>::max()) {
+        return 1;
+    }
+
+    PeakCudaLaunchDimensions overflow = peak_cuda_compute_launch_dimensions(
+        std::numeric_limits<unsigned int>::max(),
+        std::numeric_limits<unsigned int>::max(),
+        std::numeric_limits<unsigned int>::max(),
+        std::numeric_limits<unsigned int>::max(), 2U, 2U);
+    if (!overflow.overflow ||
+        overflow.grid_size != std::numeric_limits<std::uint64_t>::max() ||
+        overflow.total_threads != std::numeric_limits<std::uint64_t>::max()) {
+        return 1;
+    }
+
+    bool add_overflow = false;
+    std::uint64_t sum = peak_cuda_saturating_add_u64(
+        std::numeric_limits<std::uint64_t>::max() - 1, 2, &add_overflow);
+    return !add_overflow ||
+           sum != std::numeric_limits<std::uint64_t>::max();
+}
+
 int
 main()
 {
     if (test_identity_cache_and_non_target_fast_path() != 0 ||
-        test_bounded_pool_and_drop_accounting() != 0 ||
         test_identity_cache_is_bounded() != 0 ||
+        test_driver_identity_cache_is_context_aware() != 0 ||
         test_concurrent_stress_remains_bounded() != 0 ||
-        test_admission_failure_executes_original_once_without_events() != 0) {
+        test_pending_queue_shards_preserve_exact_handoff() != 0 ||
+        test_pending_queue_local_retry_preserves_producer_empty_transition() !=
+            0 ||
+        test_admission_failure_executes_original_once_without_events() != 0 ||
+        test_slot_allocator_partitions_contexts_and_reuses_slots() != 0 ||
+        test_slot_allocator_bounds_exhaustion_and_reset() != 0 ||
+        test_slot_allocator_rejects_stale_and_double_release() != 0 ||
+        test_slot_allocator_admission_close_is_fail_open() != 0 ||
+        test_explicit_lifecycle_counters() != 0 ||
+        test_concurrent_counters_are_exact() != 0 ||
+        test_dimension_arithmetic_is_wide_and_saturating() != 0) {
         return 1;
     }
     std::puts("cuda_profiler_state_test_ok");

--- a/test/detach_runtime/CMakeLists.txt
+++ b/test/detach_runtime/CMakeLists.txt
@@ -152,3 +152,27 @@ target_link_libraries(test_unsafe_gum_prologue_policy
     ${RT_LIBRARY}
     ${M_LIBRARY}
 )
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND
+   CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$" AND
+   PEAK_GUM_PEAK_EXACT_ATTACH_API_AVAILABLE)
+  enable_language(ASM)
+  add_executable(test_gum_exact_attach_aarch64
+    test_gum_exact_attach_aarch64.c
+    gum_exact_attach_aarch64.S)
+  target_include_directories(test_gum_exact_attach_aarch64
+    PRIVATE ${FRIDA_GUM_INCLUDE_DIRS})
+  target_link_libraries(test_gum_exact_attach_aarch64
+    PRIVATE
+      ${FRIDA_GUM_LIBRARIES}
+      Threads::Threads
+      ${DL_LIBRARY}
+      ${RT_LIBRARY}
+      ${M_LIBRARY})
+  add_test(NAME test_gum_exact_attach_aarch64
+    COMMAND $<TARGET_FILE:test_gum_exact_attach_aarch64>)
+  set_tests_properties(test_gum_exact_attach_aarch64
+    PROPERTIES
+      TIMEOUT 15
+      PASS_REGULAR_EXPRESSION "gum_exact_attach_aarch64_ok")
+endif()

--- a/test/detach_runtime/gum_exact_attach_aarch64.S
+++ b/test/detach_runtime/gum_exact_attach_aarch64.S
@@ -1,0 +1,25 @@
+    .text
+    .p2align 4
+
+    .global peak_test_exact_entry_one
+    .type peak_test_exact_entry_one, %function
+peak_test_exact_entry_one:
+    b peak_test_exact_dispatch
+    .size peak_test_exact_entry_one, . - peak_test_exact_entry_one
+
+    .p2align 4
+    .global peak_test_exact_entry_two
+    .type peak_test_exact_entry_two, %function
+peak_test_exact_entry_two:
+    b peak_test_exact_dispatch
+    .size peak_test_exact_entry_two, . - peak_test_exact_entry_two
+
+    .p2align 4
+    .global peak_test_exact_dispatch
+    .type peak_test_exact_dispatch, %function
+peak_test_exact_dispatch:
+    add w0, w0, #11
+    ret
+    .size peak_test_exact_dispatch, . - peak_test_exact_dispatch
+
+    .section .note.GNU-stack,"",%progbits

--- a/test/detach_runtime/test_gum_exact_attach_aarch64.c
+++ b/test/detach_runtime/test_gum_exact_attach_aarch64.c
@@ -1,0 +1,170 @@
+#include "frida-gum.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int peak_test_exact_entry_one(int value);
+extern int peak_test_exact_entry_two(int value);
+extern int peak_test_exact_dispatch(int value);
+
+static void
+count_entry(GumInvocationContext* context, gpointer user_data)
+{
+    guint* count = (guint*)user_data;
+
+    (void)context;
+    (*count)++;
+}
+
+static int
+expect_call(const char* label,
+            int (*function)(int),
+            int value,
+            int expected_result,
+            const guint* entry_one_count,
+            const guint* entry_two_count,
+            guint expected_entry_one_count,
+            guint expected_entry_two_count)
+{
+    int result = function(value);
+
+    if (result != expected_result ||
+        *entry_one_count != expected_entry_one_count ||
+        *entry_two_count != expected_entry_two_count) {
+        fprintf(stderr,
+                "%s: result=%d expected_result=%d entry_one=%u/%u entry_two=%u/%u\n",
+                label,
+                result,
+                expected_result,
+                *entry_one_count,
+                expected_entry_one_count,
+                *entry_two_count,
+                expected_entry_two_count);
+        return 1;
+    }
+
+    return 0;
+}
+
+int
+main(void)
+{
+    GumInterceptor* interceptor;
+    GumInvocationListener* listener_one;
+    GumInvocationListener* listener_two;
+    GumAttachReturn attach_one;
+    GumAttachReturn attach_two;
+    guint entry_one_count = 0;
+    guint entry_two_count = 0;
+    gboolean attached_one = FALSE;
+    gboolean attached_two = FALSE;
+    int failed = 0;
+
+    gum_init_embedded();
+    interceptor = gum_interceptor_obtain();
+    listener_one = gum_make_call_listener(count_entry,
+                                          NULL,
+                                          &entry_one_count,
+                                          NULL);
+    listener_two = gum_make_call_listener(count_entry,
+                                          NULL,
+                                          &entry_two_count,
+                                          NULL);
+    if (listener_one == NULL || listener_two == NULL) {
+        fputs("failed to create exact-attach listeners\n", stderr);
+        failed = 1;
+        goto cleanup;
+    }
+
+    gum_interceptor_begin_transaction(interceptor);
+    attach_one = gum_interceptor_peak_attach_exact(
+        interceptor,
+        (gpointer)peak_test_exact_entry_one,
+        listener_one,
+        NULL);
+    attach_two = gum_interceptor_peak_attach_exact(
+        interceptor,
+        (gpointer)peak_test_exact_entry_two,
+        listener_two,
+        NULL);
+    gum_interceptor_end_transaction(interceptor);
+    attached_one = attach_one == GUM_ATTACH_OK;
+    attached_two = attach_two == GUM_ATTACH_OK;
+    if (attach_one != GUM_ATTACH_OK || attach_two != GUM_ATTACH_OK) {
+        fprintf(stderr,
+                "exact attach failed: entry_one=%d entry_two=%d\n",
+                attach_one,
+                attach_two);
+        failed = 1;
+        goto cleanup;
+    }
+    gum_interceptor_flush(interceptor);
+
+    failed |= expect_call("shared dispatcher",
+                          peak_test_exact_dispatch,
+                          1,
+                          12,
+                          &entry_one_count,
+                          &entry_two_count,
+                          0,
+                          0);
+    failed |= expect_call("entry one",
+                          peak_test_exact_entry_one,
+                          2,
+                          13,
+                          &entry_one_count,
+                          &entry_two_count,
+                          1,
+                          0);
+    failed |= expect_call("entry two",
+                          peak_test_exact_entry_two,
+                          3,
+                          14,
+                          &entry_one_count,
+                          &entry_two_count,
+                          1,
+                          1);
+    if (failed) {
+        goto cleanup;
+    }
+
+    gum_interceptor_detach(interceptor, listener_one);
+    gum_interceptor_flush(interceptor);
+    attached_one = FALSE;
+    failed |= expect_call("detached entry one",
+                          peak_test_exact_entry_one,
+                          4,
+                          15,
+                          &entry_one_count,
+                          &entry_two_count,
+                          1,
+                          1);
+    failed |= expect_call("entry two remains attached",
+                          peak_test_exact_entry_two,
+                          5,
+                          16,
+                          &entry_one_count,
+                          &entry_two_count,
+                          1,
+                          2);
+
+cleanup:
+    if (attached_one) {
+        gum_interceptor_detach(interceptor, listener_one);
+    }
+    if (attached_two) {
+        gum_interceptor_detach(interceptor, listener_two);
+    }
+    gum_interceptor_flush(interceptor);
+    g_clear_object(&listener_one);
+    g_clear_object(&listener_two);
+    g_object_unref(interceptor);
+    gum_deinit_embedded();
+
+    if (failed) {
+        return EXIT_FAILURE;
+    }
+
+    puts("gum_exact_attach_aarch64_ok");
+    return EXIT_SUCCESS;
+}

--- a/test/static_checks/check_arm_detach_support.py
+++ b/test/static_checks/check_arm_detach_support.py
@@ -40,7 +40,14 @@ def main():
     source_cmake = read(root, "src/CMakeLists.txt")
     tests_cmake = read(root, "test/CMakeLists.txt")
     detach_tests_cmake = read(root, "test/detach_controller/CMakeLists.txt")
+    detach_runtime_cmake = read(root, "test/detach_runtime/CMakeLists.txt")
     dlopen_tests_cmake = read(root, "test/dlopen_controller/CMakeLists.txt")
+    exact_attach_test = read(
+        root, "test/detach_runtime/test_gum_exact_attach_aarch64.c"
+    )
+    exact_attach_fixture = read(
+        root, "test/detach_runtime/gum_exact_attach_aarch64.S"
+    )
 
     require("peak_exec_configure_platform_support()" in top_cmake and
             "set(PEAK_DETACH_HELPER_SUPPORTED" not in top_cmake,
@@ -152,6 +159,19 @@ def main():
     require("test_gum_raw_syscall_aarch64" in dlopen_tests_cmake and
             "test_gum_module_sync_idle_quiesce" in dlopen_tests_cmake,
             "Arm64 raw syscall and idle module-sync quiesce regressions must remain enabled")
+    require("test_gum_exact_attach_aarch64" in detach_runtime_cmake and
+            "PEAK_GUM_PEAK_EXACT_ATTACH_API_AVAILABLE" in detach_runtime_cmake,
+            "Linux Arm64 exact attach execution test must remain enabled")
+    require("gum_interceptor_peak_attach_exact" in exact_attach_test and
+            "peak_test_exact_entry_one" in exact_attach_test and
+            "peak_test_exact_entry_two" in exact_attach_test and
+            "peak_test_exact_dispatch" in exact_attach_test and
+            "gum_interceptor_detach" in exact_attach_test,
+            "Arm64 exact attach test must cover distinct entries, the shared "
+            "dispatcher, and detach")
+    require(exact_attach_fixture.count("b peak_test_exact_dispatch") == 2,
+            "Arm64 exact attach fixture must expose two tail-branch entries "
+            "sharing one dispatcher")
 
     for rel in [
         "test/detach_controller/test_detach_controller.c",

--- a/test/static_checks/check_cuda_interceptor_consistency.py
+++ b/test/static_checks/check_cuda_interceptor_consistency.py
@@ -31,6 +31,26 @@ CUDA_WRAPPERS = [
     "peak_cu_graph_launch",
 ]
 
+TIMED_CUDA_WRAPPERS = {
+    "peak_cuda_launch_kernel": "original_cuda_launch_kernel",
+    "peak_cuda_launch_cooperative_kernel":
+        "original_cuda_launch_cooperative_kernel",
+    "peak_cuda_launch_kernel_exc": "original_cuda_launch_kernel_exc",
+    "peak_cu_launch_kernel": "original_cu_launch_kernel",
+    "peak_cu_launch_cooperative_kernel":
+        "original_cu_launch_cooperative_kernel",
+    "peak_cu_launch_kernel_ex": "original_cu_launch_kernel_ex",
+    "peak_cuda_graph_launch": "original_cuda_graph_launch",
+    "peak_cu_graph_launch": "original_cu_graph_launch",
+}
+
+MULTI_DEVICE_CUDA_WRAPPERS = {
+    "peak_cuda_launch_cooperative_kernel_multiple_device":
+        "original_cuda_launch_cooperative_kernel_multiple_device",
+    "peak_cu_launch_cooperative_kernel_multiple_device":
+        "original_cu_launch_cooperative_kernel_multiple_device",
+}
+
 GENERAL_LISTENER_CUDA_TARGETS = [
     "cudaLaunchKernel",
     "cudaLaunchCooperativeKernel",
@@ -63,7 +83,7 @@ GENERAL_LISTENER_CUDA_WRAPPER_LOOKUPS = [
 
 
 def function_body(source, name):
-    match = re.search(rf'\b{name}\s*\([^)]*\)\s*\{{', source)
+    match = re.search(rf'\b{name}\s*\([^)]*\)\s*(?:const\s*)?\{{', source)
     if not match:
         raise AssertionError(f"missing function: {name}")
 
@@ -111,6 +131,23 @@ def main():
         encoding="utf-8")
     general = read_general_listener_source(repo_root)
     cuda_header = (repo_root / "include" / "cuda_interceptor.h").read_text(
+        encoding="utf-8")
+    cuda_state_header = (
+        repo_root / "include" / "internal" /
+        "cuda_profiler_state.h").read_text(encoding="utf-8")
+    unsafe_gum_header = (
+        repo_root / "include" / "internal" /
+        "unsafe_gum_prologue.h").read_text(encoding="utf-8")
+    cuda_benchmark = (
+        repo_root / "test" / "cuda" /
+        "benchmark_launch_overhead.cu").read_text(encoding="utf-8")
+    cuda_regressions = (
+        repo_root / "test" / "cuda" /
+        "run_cuda_regressions.py").read_text(encoding="utf-8")
+    cuda_test_cmake = (
+        repo_root / "test" / "cuda" /
+        "CMakeLists.txt").read_text(encoding="utf-8")
+    cuda_state = (repo_root / "src" / "cuda_profiler_state.cpp").read_text(
         encoding="utf-8")
     c_api_headers = [
         "include/internal/general_listener/report_maxima.h",
@@ -189,6 +226,33 @@ def main():
                 re.search(r'#ifdef __cplusplus\s+}\s+#endif\s*\n\s*#endif',
                           header) is not None,
                 f"{relpath} must preserve C linkage for CUDA C++ callers")
+    require(re.search(r'#ifdef __cplusplus\s+extern "C" \{\s+#endif',
+                      unsafe_gum_header) is not None and
+            re.search(r'#ifdef __cplusplus\s+}\s+#endif\s*\n\s*#endif',
+                      unsafe_gum_header) is not None,
+            "unsafe Gum APIs must preserve C linkage for CUDA C++ callers")
+    require('dlsym(driver_handle, "cuLaunchKernel")' not in cuda_benchmark and
+            "launched = cuLaunchKernel(" in cuda_benchmark and
+            "benchmark_launch_overhead.cu\n"
+            "        ${PEAK_CUDA_DRIVER_TEST_LIBRARY}" in cuda_test_cmake,
+            "the Driver benchmark must measure the linked public API entry")
+    require('"--native-events"' in cuda_benchmark and
+            "cuEventRecord(reinterpret_cast<CUevent>(start_event)" in
+            cuda_benchmark and
+            "cuEventRecord(reinterpret_cast<CUevent>(end_event)" in
+            cuda_benchmark and
+            "target_event_floors" in cuda_regressions and
+            "target_event_floor_throughputs" in cuda_regressions and
+            "target_ratio = target_profile / target_event_floor" in
+            cuda_regressions and
+            "target_increment = target_profile - target_event_floor" in
+            cuda_regressions and
+            "return profile / target_event_floor_throughputs" in
+            cuda_regressions and
+            "return target_event_floors[(api, threads)]" in cuda_regressions,
+            "target performance must isolate PEAK software latency and "
+            "throughput scaling from the mandatory native event-timing floor "
+            "using the replacement's Driver record API")
     cxx_link_test = (repo_root / "test" / "CMakeLists.txt").read_text(
         encoding="utf-8")
     require("test_report_snapshot_cxx_link" in cxx_link_test and
@@ -240,7 +304,9 @@ def main():
             "CUDA transport mode values must match PeakOutputAggregationMode")
 
     for hook in CUDA_HOOKS:
-        require(f'peak_general_listener_find_function("{hook}")' in cuda,
+        require(re.search(
+                    rf'peak_general_listener_find_function\(\s*"{hook}"\s*\)',
+                    cuda) is not None,
                 f"missing Frida-native support CUDA hook lookup: {hook}")
 
     require("PEAK_CUDA_WRAPPER_EXPORT extern \"C\" __attribute__((visibility(\"default\")))" in cuda,
@@ -264,60 +330,648 @@ def main():
                 f"general-listener target {target} must use the helper"
                 f" wrapper lookup for {wrapper}")
 
-    require(cuda.count("PeakCudaInflightGuard in_flight;") == 10,
-            "each known CUDA wrapper must use in-flight accounting")
-    require(cuda.count("peak_cuda_acquire_event_pair(&start, &end)") == 10,
-            "each known CUDA wrapper must admit one bounded event-pool lease")
-    require(cuda.count("if (!peak_cuda_record_event(") == 20,
-            "each wrapper must handle both start and end event-record failures")
-    require("launches.reserve(" not in cuda,
-            "per-key launch vectors must not reserve beyond the shared pool budget")
+    require(cuda.count("PeakCudaInflightGuard in_flight;") == 10 and
+            cuda.count("if (!in_flight.entered())") == 10,
+            "each known CUDA wrapper must reject closed lifecycle admission")
+    require(cuda.count("PeakCudaRuntimeLaunchGuard runtime_launch;") == 5 and
+            cuda.count(
+                "if (peak_cuda_runtime_launch_wrapper_depth != 0)") == 5,
+            "accepted Runtime launches must suppress duplicate Driver timing")
+    require("PeakCudaNestedDriverBypassGuard" not in cuda and
+            "gum_interceptor_ignore_current_thread(cuda_interceptor)" not in
+            cuda and
+            "gum_interceptor_unignore_current_thread(cuda_interceptor)" not in
+            cuda,
+            "Runtime duplicate suppression must remain a TLS fast path")
+    for wrapper in (
+            "peak_cu_launch_kernel",
+            "peak_cu_launch_cooperative_kernel",
+            "peak_cu_launch_cooperative_kernel_multiple_device",
+            "peak_cu_launch_kernel_ex",
+            "peak_cu_graph_launch"):
+        require_order(
+            function_body(cuda, wrapper),
+            "if (peak_cuda_runtime_launch_wrapper_depth != 0)",
+            "return original_",
+            "PeakCudaInflightGuard in_flight;")
+    attach = function_body(cuda, "cuda_interceptor_attach")
+    require_order(
+        attach,
+        "if (driver_typed_replacements_are_isolated)",
+        "hook_cuda_launch != NULL && hook_cu_launch != NULL",
+        "gum_interceptor_revert(cuda_interceptor, hook_cuda_launch)",
+        "hook_cuda_launch = NULL")
+    require("hook_cuda_launch_cooperative != NULL &&" in attach and
+            "hook_cu_launch_cooperative != NULL" in attach and
+            "hook_cuda_launch_cooperative_multiple_device != NULL &&" in
+            attach and
+            "hook_cu_launch_cooperative_multiple_device != NULL" in attach and
+            "hook_cuda_launch_exc != NULL && hook_cu_launch_ex != NULL" in
+            attach and
+            "hook_cuda_graph_launch != NULL &&" in attach and
+            "hook_cu_graph_launch != NULL" in attach,
+            "each available Driver entry must independently replace its "
+            "Runtime timing layer")
+    require(cuda.count("if (!peak_cuda_record_event(") ==
+            2 * len(TIMED_CUDA_WRAPPERS),
+            "each timed wrapper must handle both event-record failures")
+    record_event = function_body(cuda, "peak_cuda_record_event")
+    require("peak_cuda_backend_api.event_record(" in record_event and
+            "cudaEventRecord(event, stream)" in record_event,
+            "Driver timing must avoid re-entering the Runtime API while "
+            "retaining the Runtime fallback")
+    require("peak_cuda_acquire_event_pair" not in cuda and
+            "peak_cuda_release_event_pair" not in cuda and
+            "peak_cuda_drain_kernel_event_map" not in cuda and
+            "peak_cuda_drain_graph_event_map" not in cuda,
+            "CUDA timing must use reusable slots instead of launch maps")
     require(re.search(r'^\s*#\s*define\s+(?:min|max)\s*\(', cuda_header,
                       re.MULTILINE) is None,
             "CUDA public header must not poison C++ standard min/max names")
     require(cuda.find("#include <algorithm>") != -1 and
             cuda.find("#include <algorithm>") <
             cuda.find("#include \"cuda_interceptor.h\"") and
-            cuda.count("std::max(") == 5 and cuda.count("std::min(") == 5,
+            "std::max(" in cuda and "std::min(" in cuda,
             "CUDA launch statistics must use standard min/max without macro pollution")
-    require("cudaEventRecord(*event, stream) != cudaSuccess" in cuda and
+    require("recorded = cudaEventRecord(event, stream) == cudaSuccess" in cuda and
+            "if (!recorded)" in cuda and
+            "cudaEventQuery(slot.end)" in cuda and
             "cudaEventElapsedTime(&ms" in cuda and
             "!= cudaSuccess" in cuda,
-            "CUDA event record/elapsed failures must be checked")
+            "CUDA event record/query/elapsed failures must be checked")
     require("record_timing_error" in cuda and
-            "CUDA profiler drops [timing_error]" in cuda,
+            '"[timing_error]"' in cuda,
             "timing failures must be counted and transported")
+    require("record_harvester_unavailable" in cuda and
+            '"[harvester_unavailable]"' in cuda,
+            "deferred helper initialization skips must be counted and "
+            "transported")
     require("peak_cuda_new_event_slot" not in cuda,
             "per-launch CUDA event allocation must not bypass the bounded pool")
     require("PEAK_CUDA_EVENT_POOL_CAPACITY" in cuda and
             "peak_cuda_event_pool_capacity" in cuda,
             "CUDA event-pool capacity must be configurable and bounded")
-    require("PeakCudaProfilerState" in cuda and
-            "peak_cuda_profiler_state.acquire_slot()" in cuda,
-            "CUDA wrappers must share bounded identity/admission state")
+    require("PeakCudaSlotLease" in cuda_state_header and
+            "std::uint64_t generation;" in cuda_state_header and
+            "std::uintptr_t context;" in cuda_state_header and
+            "std::size_t shard;" in cuda_state_header and
+            "kShardCount = 256" in cuda_state_header and
+            "kCacheLineBytes = 64" in cuda_state_header and
+            "sizeof(FreeHead) == kCacheLineBytes" in cuda_state_header and
+            "sizeof(CounterShard) == kCacheLineBytes" in cuda_state_header and
+            "sizeof(QueueShard) ==" in cuda_state_header and
+            "sizeof(LaunchCounterShard) ==" in cuda_state_header and
+            "struct alignas(64) FreeHead" not in cuda_state_header and
+            "std::unique_ptr<Slot[]> slots_;" in cuda_state_header and
+            "free_heads_" in cuda_state_header,
+            "event slots must use fixed sharded context-owned generation "
+            "leases without imposing an over-aligned containing-object ABI")
+    require(re.search(
+                r"struct PeakCudaRetainedState\s*\{\s*"
+                r"PeakCudaProfilerState profiler_state;\s*"
+                r"PeakCudaSlotAllocator slot_allocator;\s*"
+                r"PeakCudaPendingQueue pending_queue;\s*"
+                r"std::vector<PeakCudaEventSlot> event_pool;\s*"
+                r"std::vector<PeakCudaActiveCapture> active_captures;\s*\};",
+                cuda) is not None and
+            "static PeakCudaRetainedState& peak_cuda_retained_state =\n"
+            "    *new PeakCudaRetainedState;" in cuda,
+            "a timed-out helper must retain every reachable C++ object for "
+            "process lifetime")
+    allocator_acquire = function_body(cuda_state, "acquire")
+    allocator_admit = function_body(cuda_state, "acquire_if_accepting")
+    allocator_release = function_body(cuda_state, "release")
+    allocator_reserve = function_body(cuda_state, "reserve_unassigned")
+    require(cuda_state.count(
+                "accepting.load(std::memory_order_seq_cst)") == 2 and
+            "*admission_closed = true;" in cuda_state and
+            "acquire(context, shard, lease)" in cuda_state and
+            "(void)release(*lease);" in cuda_state,
+            "lock-free slot admission must roll back a lease that crosses close")
+    lifecycle_enter = function_body(cuda, "peak_cuda_lifecycle_try_enter")
+    lifecycle_leave = function_body(cuda, "peak_cuda_lifecycle_leave")
+    lifecycle_count = function_body(cuda, "peak_cuda_active_wrapper_count")
+    lifecycle_close = function_body(cuda, "peak_cuda_lifecycle_close")
+    lifecycle_open = function_body(cuda, "peak_cuda_lifecycle_open")
+    require("kPeakCudaLifecycleShardCount = 256" in cuda and
+            "kPeakCudaLifecycleExclusiveShardCount = 192" in cuda and
+            "struct alignas(64) PeakCudaLifecycleShard" in cuda and
+            "peak_cuda_lifecycle_shards[kPeakCudaLifecycleShardCount]" in
+            cuda and
+            "static thread_local size_t peak_cuda_lifecycle_shard_index" in
+            cuda and
+            "static thread_local unsigned int peak_cuda_lifecycle_depth" in
+            cuda and
+            "static thread_local gboolean "
+            "peak_cuda_lifecycle_shard_exclusive" in cuda and
+            "kPeakCudaLifecycleShardCount;" in cuda and
+            "std::atomic_ullong peak_cuda_lifecycle_epoch{1}" in cuda and
+            "Odd epochs are closed; even epochs are open." in cuda,
+            "wrapper lifetime accounting must use fixed cache-line shards "
+            "and begin in a closed epoch")
+    require_order(
+        lifecycle_enter,
+        "unsigned long long epoch = peak_cuda_lifecycle_epoch.load(",
+        "std::memory_order_seq_cst",
+        "if ((epoch & 1ULL) != 0)",
+        "if (peak_cuda_lifecycle_depth != 0)",
+        "++peak_cuda_lifecycle_depth",
+        "peak_cuda_lifecycle_shard_index == kPeakCudaLifecycleShardCount",
+        "peak_cuda_next_lifecycle_shard.fetch_add(",
+        "std::memory_order_relaxed",
+        "ticket < kPeakCudaLifecycleExclusiveShardCount",
+        "kPeakCudaLifecycleExclusiveShardCount +",
+        "shard->active.store(1, std::memory_order_seq_cst)",
+        "shard->active.fetch_add(1, std::memory_order_seq_cst)",
+        "peak_cuda_lifecycle_epoch.load(std::memory_order_seq_cst) != epoch",
+        "shard->active.store(0, std::memory_order_seq_cst)",
+        "shard->active.fetch_sub(1, std::memory_order_seq_cst)",
+        "return NULL;",
+        "peak_cuda_lifecycle_depth = 1",
+        "return shard;",
+    )
+    require_order(lifecycle_leave,
+                  "--peak_cuda_lifecycle_depth",
+                  "peak_cuda_lifecycle_shard_exclusive",
+                  "shard->active.store(0, std::memory_order_seq_cst)",
+                  "shard->active.fetch_sub(1, std::memory_order_seq_cst)")
+    require("ticket - kPeakCudaLifecycleExclusiveShardCount" in
+            lifecycle_enter and
+            "kPeakCudaLifecycleShardCount -\n"
+            "                      kPeakCudaLifecycleExclusiveShardCount" in
+            lifecycle_enter and
+            "for (PeakCudaLifecycleShard& shard : "
+            "peak_cuda_lifecycle_shards)" in lifecycle_count and
+            "shard.active.load(std::memory_order_seq_cst)" in
+            lifecycle_count and
+            "if (active > UINT_MAX - total)" in lifecycle_count,
+            "exclusive lifecycle slots, disjoint overflow counters, release, "
+            "and close-side scans must remain SC and bounded")
+    require_order(
+        lifecycle_close,
+        "unsigned long long epoch = peak_cuda_lifecycle_epoch.load(",
+        "std::memory_order_seq_cst",
+        "if ((epoch & 1ULL) == 0)",
+        "peak_cuda_lifecycle_epoch.store(epoch + 1",
+        "std::memory_order_seq_cst",
+    )
+    require_order(
+        lifecycle_open,
+        "unsigned long long epoch = peak_cuda_lifecycle_epoch.load(",
+        "std::memory_order_seq_cst",
+        "if ((epoch & 1ULL) != 0)",
+        "peak_cuda_lifecycle_epoch.store(epoch + 1",
+        "std::memory_order_seq_cst",
+    )
+    require(cuda.count("peak_cuda_lifecycle_epoch.store(") == 2 and
+            cuda.count("peak_cuda_lifecycle_open();") == 1 and
+            cuda.count("peak_cuda_lifecycle_close();") == 3,
+            "lifecycle epochs must advance only through serialized "
+            "odd/even close and open transitions")
+    require(cuda.count(
+                "for (PeakCudaLifecycleShard& shard : "
+                "peak_cuda_lifecycle_shards)") == 1 and
+            re.search(
+                r"peak_cuda_lifecycle_shards\s*\[[^\]]+\]\s*"
+                r"\.active\.store\s*\(", cuda) is None,
+            "lifecycle reader shards must never be reset across reattach")
+    require("peak_cuda_in_flight" not in cuda,
+            "the unsafe scalar CUDA in-flight handshake must not return")
+    slot_shard = function_body(cuda, "peak_cuda_current_slot_shard")
+    observed = function_body(cuda_state, "record_launch_observed")
+    accepted = function_body(cuda_state, "record_launch_accepted")
+    require("kPeakCudaSlotExclusiveShardCount = 192" in cuda and
+            "peak_cuda_slot_shard_exclusive" in cuda and
+            "ticket < kPeakCudaSlotExclusiveShardCount" in slot_shard and
+            "ticket - kPeakCudaSlotExclusiveShardCount" in slot_shard and
+            "PeakCudaSlotAllocator::kShardCount -\n"
+            "                    kPeakCudaSlotExclusiveShardCount" in
+            slot_shard and
+            "peak_cuda_current_slot_shard(), "
+            "peak_cuda_slot_shard_exclusive" in cuda and
+            "timing.lease.shard < kPeakCudaSlotExclusiveShardCount" in cuda,
+            "launch accounting must use unique producer shards and disjoint "
+            "overflow counters")
+    require("if (exclusive)" in observed and
+            "observed.store(observed.load(std::memory_order_relaxed) + 1" in
+            observed and
+            "observed.fetch_add(1, std::memory_order_relaxed)" in observed and
+            "if (exclusive)" in accepted and
+            "accepted.store(accepted.load(std::memory_order_relaxed) + 1" in
+            accepted and
+            "accepted.fetch_add(1, std::memory_order_relaxed)" in accepted,
+            "exclusive launch counters must avoid RMWs while overflow "
+            "counters remain multi-producer safe")
+    require("slot.context = context;" in allocator_reserve and
+            "slot.shard = static_cast<std::uint16_t>(shard);" in
+            allocator_reserve and
+            "slot.generation.fetch_add(" in allocator_reserve and
+            "push_back" not in allocator_reserve and
+            "resize" not in allocator_reserve,
+            "slot acquisition must partition the fixed pool by context and shard")
+    require_order(allocator_release,
+                  "slot.generation.load(std::memory_order_acquire)",
+                  "counter_shards_[lease.shard].handoff.fetch_add(",
+                  "slot.state.compare_exchange_strong(",
+                  "counter_shards_[lease.shard].active.fetch_sub(",
+                  "push_free(bucket, lease.shard",
+                  "counter_shards_[lease.shard].handoff.fetch_sub(")
+    require("for (" not in allocator_release and
+            "while (" not in allocator_release,
+            "slot release must remain O(1), without a pool scan")
+    require("slot.context != lease.context" in allocator_release and
+            "slot.shard != lease.shard" in allocator_release and
+            "lease.generation" in allocator_release,
+            "slot release must reject stale and cross-context leases")
+    discard = function_body(cuda, "peak_cuda_discard_lease_current")
+    require("peak_cuda_event_pool[lease.index]" in discard and
+            "peak_cuda_slot_allocator.release(lease)" in discard and
+            "for (" not in discard and "while (" not in discard,
+            "the interceptor must release slots by validated token index")
+    attach = function_body(cuda, "cuda_interceptor_attach")
+    require("peak_cuda_event_pool.assign(peak_cuda_event_pool_capacity, {})"
+            in attach and
+            "peak_cuda_pending_queue.reset(peak_cuda_event_pool_capacity)"
+            in attach,
+            "event slots and pending tokens must have one fixed shared bound")
+    pending_push = function_body(cuda, "peak_cuda_pending_push")
+    queue_push = function_body(cuda_state, "push")
+    queue_requeue = function_body(cuda_state, "requeue_local")
+    require("peak_cuda_pending_queue.push(lease, &shard_was_empty)" in
+            pending_push and
+            "if (shard_was_empty &&" in pending_push and
+            "lease.shard == kPeakCudaWakeShard" in pending_push and
+            "peak_cuda_harvester_waiting.compare_exchange_strong" in
+            pending_push and
+            "pthread_mutex_lock(&peak_cuda_harvester_mutex)" in
+            pending_push and
+            "pthread_cond_signal(&peak_cuda_harvester_cond)" in
+            pending_push and
+            "wake_pending" not in cuda and
+            "shards_[lease.shard].head" in queue_push and
+            "free_head_index(current) == kInvalidSlotIndex" in queue_push and
+            ".count" not in queue_push and
+            "compare_exchange_weak" in queue_push and
+            "push_back" not in queue_push,
+            "pending producers must use a per-shard empty-to-nonempty "
+            "handoff and synchronize only with a sleeping helper")
+    require("local_heads_[lease.shard]" in queue_requeue and
+            "compare_exchange" not in queue_requeue and
+            "shards_[lease.shard].head" not in queue_requeue and
+            "peak_cuda_pending_queue.requeue_local" in
+            function_body(cuda, "peak_cuda_harvest_pass"),
+            "harvester retries must remain consumer-local so they do not "
+            "suppress the next producer empty-to-nonempty notification")
+    publish_timing = function_body(cuda, "peak_cuda_publish_timing")
+    require("peak_cuda_pending_push(timing.lease)" in publish_timing and
+            "slot->lease" not in publish_timing,
+            "publishing must reuse the lease stored at acquisition instead "
+            "of rewriting the large event-slot handoff state")
+    require("kPeakCudaHarvestRecordBudget = 64" in cuda and
+            "kPeakCudaHarvestTimeBudgetNs = 1000000" in cuda and
+            "kPeakCudaHarvestRetryNs = 1000000L" in cuda,
+            "the harvester must retain its 64-record/1-ms pass and bounded "
+            "1-ms retry interval")
+    harvest_pass = function_body(cuda, "peak_cuda_harvest_pass")
+    require_order(harvest_pass,
+                  "checked < kPeakCudaHarvestRecordBudget",
+                  "!peak_cuda_harvester_running.load(",
+                  "peak_cuda_pending_pop(&lease)",
+                  "peak_cuda_activate_context(lease_context, &activation)",
+                  "peak_cuda_harvest_one_current(lease)",
+                  "now_ns - started_ns >= kPeakCudaHarvestTimeBudgetNs",
+                  "peak_cuda_restore_context(&activation)",
+                  "peak_cuda_slot_allocator.release(leases[index])")
+    require("peak_cuda_pending_size" not in cuda,
+            "the harvester must not scan producer-owned queue counts")
+    require("outcomes[index] == PEAK_CUDA_HARVEST_RETRY &&\n"
+            "                       peak_cuda_harvester_running.load(" in
+            harvest_pass,
+            "a stopped harvester must not requeue or continue incomplete "
+            "records")
+    require("peak_cuda_pending_queue.requeue_local(lease)" in harvest_pass and
+            "peak_cuda_pending_queue.requeue_local(leases[index])" in
+            harvest_pass and
+            "peak_cuda_pending_push(lease)" not in harvest_pass,
+            "helper retries must remain consumer-local and leave producer "
+            "wake transitions available")
+    require("lease_context != batch_context" in harvest_pass and
+            "PeakCudaSlotLease leases[kPeakCudaHarvestRecordBudget]" in
+            harvest_pass,
+            "the helper must amortize context activation across one bounded "
+            "same-context batch")
+    harvest_one = function_body(cuda, "peak_cuda_harvest_one_current")
+    require("cudaEventQuery(slot.end)" in harvest_one and
+            "cudaEventElapsedTime(&ms, slot.start, slot.end)" in harvest_one and
+            "pthread_mutex_lock" not in harvest_one and
+            "peak_cuda_activate_context" not in harvest_one and
+            "peak_cuda_restore_context" not in harvest_one,
+            "CUDA completion queries must run outside locks and reuse the "
+            "pass-owned current context")
+    require("peak_cuda_test_force_incomplete.load(" in harvest_one and
+            "return PEAK_CUDA_HARVEST_RETRY;" in harvest_one and
+            "peak_cuda_test_force_incomplete.store(" in
+            function_body(cuda, "peak_cuda_test_force_incomplete_events"),
+            "the permanent-incomplete test seam must stop before CUDA query")
+    require_order(
+        harvest_one,
+        "peak_cuda_test_force_query_error.exchange(",
+        "cudaEventQuery(slot.end)",
+        "peak_cuda_test_harvester_queries.fetch_add(",
+        "!peak_cuda_harvester_running.load(",
+        "record_event_query_failure()",
+        "peak_cuda_destroy_slot_events_current(&slot)",
+        "return PEAK_CUDA_HARVEST_RELEASE;",
+    )
+    harvester = function_body(cuda, "peak_cuda_harvester_main")
+    require("pthread_cond_timedwait" in harvester and
+            "peak_cuda_harvester_waiting.store(true" in harvester and
+            "peak_cuda_harvester_waiting.store(false" in harvester and
+            "kPeakCudaHarvestRetryNs" in harvester and
+            "peak_general_listener_exclude_current_thread()" in harvester,
+            "the bounded harvester must be helper-excluded and condition-driven")
+    require_order(
+        harvester,
+        "peak_general_listener_fast_ignore_current_thread()",
+        "!peak_cuda_harvester_initialization_requested",
+        "cudaThreadExchangeStreamCaptureMode(&runtime_mode)",
+        ".driver_thread_exchange_stream_capture_mode(&driver_mode)",
+        "peak_cuda_harvester_capture_mode_ready = capture_mode_ready",
+        "peak_cuda_harvester_initialization_done = TRUE",
+        "peak_cuda_accepting_events.store(true",
+        "for (;;)",
+    )
+    start_harvester = function_body(cuda, "peak_cuda_start_harvester")
+    require_order(
+        start_harvester,
+        "peak_cuda_harvester_initialization_requested = FALSE",
+        "peak_cuda_harvester_initialization_allowed = TRUE",
+        "peak_cuda_harvester_initialization_done = FALSE",
+        "pthread_create(",
+        "peak_cuda_harvester_started.store(true",
+        "return TRUE;",
+    )
+    require("peak_cuda_accepting_events" not in start_harvester,
+            "helper creation must not publish CUDA timing admission")
+    request_harvester = function_body(
+        cuda, "peak_cuda_request_harvester_initialization")
+    require("peak_cuda_harvester_initialization_terminal.load(" in
+            request_harvester,
+            "terminal helper initialization failure must bypass the mutex on "
+            "later matching launches")
+    require_order(
+        request_harvester,
+        "peak_cuda_harvester_started.load(",
+        "pthread_mutex_trylock(",
+        "peak_cuda_harvester_initialization_allowed",
+        "peak_cuda_harvester_initialization_requested = TRUE",
+        "pthread_cond_broadcast",
+    )
+    require("pthread_cond_wait" not in request_harvester and
+            "cudaThreadExchangeStreamCaptureMode" not in request_harvester,
+            "matching launches must request deferred helper initialization "
+            "without waiting or entering CUDA")
+    require_order(
+        harvester,
+        "peak_cuda_harvester_initialization_inflight.store(\n"
+        "            true",
+        "cudaThreadExchangeStreamCaptureMode(&runtime_mode)",
+        ".driver_thread_exchange_stream_capture_mode(&driver_mode)",
+        "peak_cuda_harvester_initialization_inflight.store(\n"
+        "        false",
+    )
     require("*(char**)((size_t)func" not in cuda and
             "(size_t)func + 8" not in cuda,
             "Driver CUfunction handles must not be read through private layouts")
-    require('peak_general_listener_find_function("cuFuncGetName")' in cuda,
-            "Driver names must use dynamically-resolved cuFuncGetName")
+    driver_name = function_body(cuda, "peak_cuda_driver_kernel_name")
+    require('dlsym(driver, "cuFuncGetName")' in cuda and
+            "dlsym(" not in driver_name and
+            "peak_cuda_func_get_name(&name, function)" in driver_name,
+            "Driver names must use a once-cached cuFuncGetName lookup")
+    identify_kernel = function_body(cuda, "peak_cuda_identify_kernel")
+    require(identify_kernel.count(
+                "demangled_name != NULL ? demangled_name : resolved_name") == 2,
+            "plain Driver symbols must retain their resolved name when "
+            "demangling is not applicable")
     for forbidden_mpi_call in ("MPI_Init(", "MPI_Reduce(", "MPI_Gather(",
                                "MPI_Gatherv("):
         require(forbidden_mpi_call not in cuda,
                 f"CUDA interceptor must not own {forbidden_mpi_call} transport")
 
-    kernel_wrappers = CUDA_WRAPPERS[:8]
+    backend_resolver = function_body(cuda, "peak_cuda_resolve_backend_api")
+    require('dlsym(driver, "cuStreamIsCapturing")' in backend_resolver and
+            'dlsym(driver, "cuThreadExchangeStreamCaptureMode")' in
+            backend_resolver,
+            "Driver capture APIs must be resolved once for lifecycle listeners")
+    acquire_timing = function_body(cuda, "peak_cuda_acquire_timing")
+    require_order(acquire_timing,
+                  "!capture_guard->try_enter()",
+                  "!peak_cuda_accepting_events.load(",
+                  "peak_cuda_request_harvester_initialization()",
+                  "record_harvester_unavailable()",
+                  "return FALSE;",
+                  "peak_cuda_current_context(&context)",
+                  "peak_cuda_slot_allocator.acquire_if_accepting(")
+    require("driver_stream_is_capturing" not in acquire_timing and
+            "if (!admission_closed)" in acquire_timing and
+            "record_pool_full()" in acquire_timing,
+            "the fail-closed capture gate must avoid redundant per-launch "
+            "queries and closed admission must not look like pool exhaustion")
+
+    capture_begin = function_body(cuda, "peak_cuda_capture_begin_transition")
+    capture_end = function_body(cuda,
+                                "peak_cuda_capture_end_transition_locked")
+    capture_enter = function_body(cuda,
+                                  "peak_cuda_capture_listener_on_enter")
+    capture_leave = function_body(cuda,
+                                  "peak_cuda_capture_listener_on_leave")
+    require("kPeakCudaTimingShardCount = 256" in cuda and
+            "kPeakCudaTimingExclusiveShardCount = 192" in cuda and
+            "struct alignas(64) PeakCudaTimingShard" in cuda and
+            "thread_local unsigned int peak_cuda_timing_depth" in cuda and
+            "thread_local gboolean peak_cuda_timing_shard_exclusive" in cuda and
+            "peak_cuda_next_timing_shard.fetch_add(" in cuda and
+            "ticket < kPeakCudaTimingExclusiveShardCount" in cuda and
+            "kPeakCudaTimingExclusiveShardCount +" in cuda and
+            "shard_->active.fetch_add(1, std::memory_order_seq_cst)" in cuda and
+            "shard->active.fetch_sub(" in cuda,
+            "capture coordination must reserve disjoint exclusive and "
+            "overflow cache-line reader shards")
+    timing_enter = function_body(cuda, "try_enter")
+    timing_leave = function_body(cuda, "release_reader")
+    require_order(timing_enter,
+                  "peak_cuda_capture_blocked.load(std::memory_order_acquire)",
+                  "if (peak_cuda_timing_depth != 0)",
+                  "peak_cuda_next_timing_shard.fetch_add(",
+                  "shard_->active.store(1, std::memory_order_seq_cst)",
+                  "peak_cuda_timing_depth = 1",
+                  "peak_cuda_capture_blocked.load(std::memory_order_seq_cst)",
+                  "release_reader()",
+                  "return false;")
+    require_order(timing_leave,
+                  "if (--peak_cuda_timing_depth != 0)",
+                  "shard->active.store(0, std::memory_order_seq_cst)",
+                  "shard->active.fetch_sub(",
+                  "peak_cuda_capture_blocked.load(",
+                  "pthread_cond_broadcast")
+    require_order(capture_begin,
+                  "peak_cuda_capture_blocked.store(true",
+                  "while (peak_cuda_timing_sections_active())",
+                  "pthread_cond_wait")
+    require("peak_cuda_capture_any_active_locked()" in capture_end and
+            "peak_cuda_capture_tracking_terminal.load(" in capture_end and
+            "peak_cuda_capture_blocked.store(false" in capture_end,
+            "capture timing may reopen only after proven quiescence")
+    require_order(capture_enter,
+                  "invocation->lifecycle_shard = "
+                  "peak_cuda_lifecycle_try_enter()",
+                  "if (invocation->lifecycle_shard == NULL)",
+                  "peak_cuda_capture_teardown_mutex.lock()",
+                  "invocation->teardown_lock_held = TRUE",
+                  "peak_cuda_capture_tracking_terminal.store(",
+                  "invocation->fail_closed_transition = TRUE",
+                  "peak_cuda_capture_begin_transition()",
+                  "return;",
+                  "peak_cuda_capture_begin_transition()",
+                  "peak_cuda_capture_status(",
+                  "ctx_get_current")
+    rejected_listener = capture_enter[
+        capture_enter.find("if (invocation->lifecycle_shard == NULL)"):
+        capture_enter.find("return;",
+                           capture_enter.find(
+                               "if (invocation->lifecycle_shard == NULL)"))]
+    require("peak_cuda_capture_status" not in rejected_listener and
+            "peak_cuda_profiler_state" not in rejected_listener and
+            "ctx_get_current" not in rejected_listener,
+            "a lifecycle-rejected capture listener must fail closed without "
+            "calling CUDA or profiler-state APIs")
+    require_order(capture_leave,
+                  "if (invocation->lifecycle_shard == NULL)",
+                  "if (invocation->fail_closed_transition)",
+                  "pthread_mutex_lock(&peak_cuda_capture_mutex)",
+                  "peak_cuda_capture_end_transition_locked()",
+                  "pthread_mutex_unlock(&peak_cuda_capture_mutex)",
+                  "if (invocation->teardown_lock_held)",
+                  "peak_cuda_capture_teardown_mutex.unlock()",
+                  "return;",
+                  "peak_cuda_capture_status(",
+                  "peak_cuda_capture_end_transition_locked()",
+                  "peak_cuda_lifecycle_leave(invocation->lifecycle_shard)")
+    require("peak_cuda_capture_register_locked(" in capture_leave and
+            "peak_cuda_capture_remove_locked(" in capture_leave and
+            "result == 0 && !expected_edge" in capture_leave and
+            "peak_cuda_capture_end_transition_locked()" in capture_leave,
+            "capture listeners must validate and publish each lifecycle edge")
+    require("kPeakCudaCaptureRegistryCapacity = 1024" in cuda and
+            "peak_cuda_active_captures.assign(\n"
+            "        kPeakCudaCaptureRegistryCapacity, {})" in attach and
+            "peak_cuda_active_captures.assign(peak_cuda_event_pool_capacity"
+            not in attach,
+            "capture tracking must be bounded independently of timing slots")
+
+    capture_census = function_body(
+        cuda, "peak_cuda_capture_entry_point_census")
+    require('"cuGetProcAddress_v2"' in capture_census and
+            '"cuGetProcAddress"' in capture_census and
+            "static const unsigned long long flags[] = {0, 1, 2};" in
+            capture_census and
+            "query.introduction_version > driver_version" in capture_census and
+            "peak_cuda_capture_entry_point_is_covered(\n"
+            "                         entry, query.operation)" in capture_census and
+            "peak_cuda_install_direct_capture_hook(\n"
+            "                         entry, query.symbol, query.operation)" in
+            capture_census and
+            "if (!begin_covered || !end_covered)" in capture_census,
+            "capture pointer census must cover ABI versions and stream modes "
+            "without querying future APIs")
+    direct_capture_attach = function_body(
+        cuda, "peak_cuda_install_direct_capture_hook")
+    direct_capture_detach = function_body(cuda, "cuda_interceptor_dettach")
+    require("kPeakCudaDirectCaptureHookCapacity = 42" in cuda and
+            "peak_cuda_direct_capture_hook_count >=\n"
+            "        kPeakCudaDirectCaptureHookCapacity" in
+            direct_capture_attach and
+            "peak_cuda_attach_capture_entry(entry, listener)" in
+            direct_capture_attach and
+            "peak_cuda_direct_capture_hook_count" in direct_capture_detach and
+            "peak_cuda_direct_capture_listeners[index]" in
+            direct_capture_detach,
+            "direct Driver capture entries must use a fixed attach-time "
+            "listener set with symmetric teardown")
+    require("entry_point_listener" not in cuda and
+            "capture_begin_transition_except_current" not in cuda,
+            "capture pointer coverage must remain an attach-time census")
+    driver_isolation = function_body(
+        cuda, "peak_cuda_driver_typed_replacements_are_isolated")
+    require("gum_interceptor_peak_resolve_redirect_chain(" in
+            driver_isolation and
+            "if (canonical != address)" in driver_isolation and
+            "Driver launch timing remains disabled" in driver_isolation,
+            "typed Driver replacements must reject redirecting dispatch stubs")
+    for support_symbol in (
+            "cuCtxGetCurrent", "cuCtxGetDevice", "cuCtxPushCurrent_v2",
+            "cuCtxPopCurrent_v2", "cuStreamIsCapturing",
+            "cuThreadExchangeStreamCaptureMode", "cuFuncGetName",
+            "cuDriverGetVersion", "cuGetProcAddress",
+            "cuGetProcAddress_v2"):
+        require(f'"{support_symbol}"' in driver_isolation,
+                f"Driver isolation census must include {support_symbol}")
+    require("for (const char* symbol : support_symbols)" in driver_isolation and
+            "for (const PeakCudaCaptureHookDescriptor& descriptor :" in
+            driver_isolation and
+            "descriptor.api == PEAK_CUDA_CAPTURE_API_DRIVER" in
+            driver_isolation and
+            "!non_timed_entry_is_isolated(descriptor.symbol)" in
+            driver_isolation and
+            "address == timed[index].canonical ||" in driver_isolation and
+            "canonical == timed[index].canonical" in driver_isolation,
+            "Driver isolation must resolve support/getproc/capture entries and "
+            "reject raw or canonical collisions with timed hooks")
+
+    kernel_wrappers = [
+        "peak_cuda_launch_kernel",
+        "peak_cuda_launch_cooperative_kernel",
+        "peak_cuda_launch_kernel_exc",
+        "peak_cu_launch_kernel",
+        "peak_cu_launch_cooperative_kernel",
+        "peak_cu_launch_kernel_ex",
+    ]
     for wrapper in kernel_wrappers:
         body = function_body(cuda, wrapper)
         require("peak_cuda_identify_kernel" in body and
-                "if (!identity.target_match)" in body,
+                "if (!identity->target_match)" in body,
                 f"{wrapper} must filter a cached kernel identity")
-        require_order(body, "if (!identity.target_match)",
-                      "peak_cuda_acquire_event_pair(&start, &end)")
-    for wrapper in CUDA_WRAPPERS[8:]:
-        require("peak_cuda_acquire_event_pair(&start, &end)" in
-                function_body(cuda, wrapper),
-                f"{wrapper} must use the shared bounded graph-event pool")
-    for wrapper in CUDA_WRAPPERS:
+        require_order(body, "peak_cuda_identify_kernel",
+                      "if (!identity->target_match)",
+                      "PeakCudaCaptureTimingGuard capture_guard",
+                      "peak_cuda_acquire_timing(")
+        if wrapper.startswith("peak_cu_"):
+            require_order(body, "if (!in_flight.entered())",
+                          "peak_cuda_cached_driver_identity(func, &context)",
+                          "if (identity == NULL)",
+                          "peak_cuda_current_context(&context)",
+                          "peak_cuda_identify_kernel")
+            require_order(body, "if (!identity->target_match)",
+                          "PeakCudaCaptureTimingGuard capture_guard",
+                          "if (!capture_guard.try_enter())",
+                          "peak_cuda_acquire_timing(")
+    cached_driver = function_body(
+        cuda, "peak_cuda_cached_driver_identity")
+    require("peak_cuda_identity_epoch.load(" in cached_driver and
+            "peak_cuda_thread_identity.epoch != epoch" in cached_driver and
+            "peak_cuda_thread_identity.driver_function" in cached_driver and
+            "peak_cuda_thread_identity.context" in cached_driver and
+            "&peak_cuda_thread_identity.value" in cached_driver and
+            "peak_cuda_current_context" not in cached_driver,
+            "repeated Driver identities must use the epoch-bounded TLS cache "
+            "without a serialized context query")
+    require("PEAK_CUDA_LAUNCH_BACKEND_RUNTIME" in
+            function_body(cuda, "peak_cuda_launch_kernel") and
+            "PEAK_CUDA_LAUNCH_BACKEND_DRIVER" in
+            function_body(cuda, "peak_cu_launch_kernel"),
+            "both CUDA launch families must pass through capture validation")
+
+    for wrapper, original in TIMED_CUDA_WRAPPERS.items():
         body = function_body(cuda, wrapper)
         first_guard = body.find("if (!peak_cuda_record_event(")
         second_guard = body.find("if (!peak_cuda_record_event(", first_guard + 1)
@@ -325,29 +979,111 @@ def main():
                 f"{wrapper} must check start and end event records")
         start_block = body[first_guard:second_guard]
         end_block = body[second_guard:]
-        require("peak_cuda_release_event_pair(start, end);" in start_block and
-                "return original_" in start_block,
+        start_return = ("return call_original();"
+                        if wrapper.startswith("peak_cuda_")
+                        else f"return {original}(")
+        require("peak_cuda_discard_lease_current(timing.lease)" in start_block and
+                start_return in start_block,
                 f"{wrapper} start-record failure must release and call original once")
-        require("peak_cuda_release_event_pair(start, end);" in end_block and
-                "return result;" in end_block,
+        require("peak_cuda_discard_lease_current(timing.lease)" in end_block and
+                "return result;" in end_block and
+                f"return {original}(" not in end_block,
                 f"{wrapper} end-record failure must release without rerunning original")
 
-    require("std::mutex peak_kernel_event_map_mutex" in cuda,
-            "missing kernel event-map mutex")
-    require("std::mutex peak_graph_event_map_mutex" in cuda,
-            "missing graph event-map mutex")
+    for wrapper, original in MULTI_DEVICE_CUDA_WRAPPERS.items():
+        body = function_body(cuda, wrapper)
+        expected_original_calls = 3 if wrapper.startswith("peak_cu_") else 2
+        require("record_unsupported_multi_device" in body and
+                body.count(original) == expected_original_calls and
+                "peak_cuda_acquire_timing" not in body and
+                "peak_cuda_record_event" not in body,
+                f"{wrapper} must safely skip unsupported multi-device timing")
+
+    for wrapper in CUDA_WRAPPERS:
+        body = function_body(cuda, wrapper)
+        original = TIMED_CUDA_WRAPPERS.get(
+            wrapper, MULTI_DEVICE_CUDA_WRAPPERS.get(wrapper))
+        require(original is not None,
+                f"missing original-function mapping for {wrapper}")
+        rejection = body.find("if (!in_flight.entered())")
+        rejection_end = body.find("}", rejection)
+        require_order(body,
+                      "PeakCudaInflightGuard in_flight;",
+                      "if (!in_flight.entered())",
+                      f"return {original}(")
+        require(rejection != -1 and rejection_end != -1 and
+                f"return {original}(" in body[rejection:rejection_end] and
+                all(token not in body[:rejection_end] for token in (
+                    "peak_cuda_profiler_state",
+                    "peak_cuda_identify_kernel",
+                    "peak_cuda_current_context",
+                    "PeakCudaCaptureTimingGuard",
+                    "peak_cuda_acquire_timing",
+                )),
+                f"{wrapper} must delegate immediately when lifecycle "
+                "admission is closed")
+
     require("std::atomic_bool peak_cuda_accepting_events" in cuda,
             "missing accepting-events gate")
-    require("std::atomic_uint peak_cuda_in_flight" in cuda,
-            "missing in-flight counter")
+    require("std::atomic_bool peak_cuda_harvester_started" in cuda,
+            "helper publication must be race-free with newly active wrappers")
+    pin_harvester = function_body(
+        cuda, "peak_cuda_pin_harvester_to_last_allowed_cpu")
+    require_order(pin_harvester,
+                  "sched_getaffinity(0, sizeof(allowed), &allowed)",
+                  "CPU_ISSET(cpu, &allowed)",
+                  "pthread_setaffinity_np(")
+    require_order(function_body(cuda, "peak_cuda_harvester_main"),
+                  "peak_cuda_pin_harvester_to_last_allowed_cpu()",
+                  "peak_general_listener_exclude_current_thread()")
+    require("std::atomic_ullong peak_cuda_lifecycle_epoch" in cuda and
+            "PeakCudaLifecycleShard" in cuda,
+            "missing epoch-based lifecycle reader gate")
     require("static gboolean peak_cuda_hooks_reverted" in cuda,
             "missing physical-detach state flag")
-    require("g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free)" in cuda,
-            "CUDA graph maps must use pointer equality")
+    require(re.search(
+                r'g_hash_table_new_full\(\s*g_str_hash,\s*str_equal_function,'
+                r'\s*g_free,\s*g_free\)', attach) is not None and
+            re.search(
+                r'g_hash_table_new_full\(\s*peak_cuda_graph_key_hash,'
+                r'\s*peak_cuda_graph_key_equal,\s*g_free,\s*g_free\)',
+                attach) is not None,
+            "CUDA aggregation maps must own and free their heap keys")
     require("g_int_equal" not in cuda,
             "CUDA graph pointer maps must not use g_int_equal")
+    require("std::uintptr_t context;" in cuda and
+            "a->context == b->context && a->graph == b->graph" in cuda,
+            "graph identity must include its owning CUDA context")
+    graph_insert = function_body(cuda, "insert_cuda_graph_record")
+    require("g_hash_table_size(cuda_graph_local_mapping) >=\n"
+            "            peak_cuda_graph_identity_capacity" in graph_insert and
+            "record_identity_full()" in graph_insert and
+            "g_try_new(PeakCudaGraphKey, 1)" in graph_insert and
+            "g_try_new(GraphRecordInfo, 1)" in graph_insert,
+            "graph aggregation must retain a fixed fail-open identity bound")
+    require("peak_cuda_graph_identity_capacity = "
+            "peak_cuda_event_pool_capacity * 4;" in attach,
+            "graph identity capacity must derive from the configured pool")
     require("Graph executable handles are rank-local" in cuda,
             "graph records must document their rank-local policy")
+    require(re.search(
+                r'struct PeakCudaLaunchDimensions\s*\{\s*'
+                r'std::uint64_t total_threads;\s*'
+                r'std::uint64_t grid_size;\s*'
+                r'std::uint64_t block_size;', cuda_state_header) is not None and
+            "std::uint64_t total_gpu_threads;" in cuda and
+            "std::uint64_t total_kernel_call_cnt;" in cuda and
+            "std::uint64_t total_block_size;" in cuda and
+            "std::uint64_t total_grid_size;" in cuda,
+            "CUDA launch dimensions and aggregates must use 64-bit counters")
+    saturating_multiply = function_body(cuda_state, "saturating_multiply")
+    saturating_add = function_body(cuda_state, "peak_cuda_saturating_add_u64")
+    require("std::numeric_limits<std::uint64_t>::max() / left" in
+            saturating_multiply and
+            "std::numeric_limits<std::uint64_t>::max() - left" in
+            saturating_add and
+            "record_dimension_overflow" in cuda,
+            "CUDA dimension arithmetic must saturate and report overflow")
     require("peak_cuda_build_report_snapshot" in cuda and
             "peak_cuda_render_report_snapshot" in cuda,
             "CUDA must own an isolated transport snapshot and renderer")
@@ -357,6 +1093,20 @@ def main():
             "CUDA snapshots must copy the CPU transport-overhead context")
     require("snapshot->rank_count = 1;" in cuda_snapshot,
             "CUDA local snapshots must begin with a single local rank")
+    cuda_counter_names = [
+        "observed", "accepted", "completed", "pool_high_water", "pool_full",
+        "identity_full", "event_create_failed", "timing_error",
+        "harvester_unavailable",
+        "stream_capture_skipped", "capture_query_failed",
+        "capture_query_unsupported", "unsupported_multi_device",
+        "event_query_failed", "elapsed_failed", "context_query_failed",
+        "context_switch_failed", "context_restore_failed",
+        "finalization_timeout", "finalization_incomplete",
+        "dimension_overflow",
+    ]
+    for counter in cuda_counter_names:
+        require(f'"CUDA profiler counter [{counter}]"' in cuda_snapshot,
+                f"CUDA snapshot must transport the {counter} counter")
     require("peak_socket_report_transport_begin_channel" in cuda and
             "PEAK_SOCKET_REPORT_CHANNEL_CUDA" in cuda,
             "CUDA socket output must use its own port channel")
@@ -435,23 +1185,68 @@ def main():
             "attach must track replacement success for each known CUDA hook")
     require_order(
         attach,
+        "std::lock_guard<std::mutex> lifecycle_lock",
+        "if (!peak_cuda_timing_requested())",
+        "return GUM_REPLACE_OK;",
+        "peak_cuda_finalization_timed_out",
+        "refusing to reinitialize active or retained CUDA profiler state",
+        "peak_cuda_lifecycle_close()",
         "peak_cuda_accepting_events.store(false",
-        "gum_interceptor_begin_transaction(cuda_interceptor)",
-        "gum_interceptor_end_transaction(cuda_interceptor)",
-        "peak_cuda_accepting_events.store(true",
+        "if (!peak_cuda_destroy_event_pool())",
+        "g_hash_table_new_full",
     )
+    require_order(
+        attach,
+        "peak_cuda_accepting_events.store(false",
+        "peak_cuda_resolve_backend_api()",
+        "gum_interceptor_begin_transaction(cuda_interceptor)",
+        "peak_cuda_install_capture_hook(",
+        "peak_cuda_capture_entry_point_census(",
+        "peak_cuda_lifecycle_open()",
+        "gum_interceptor_end_transaction(cuda_interceptor)",
+        "if (peak_cuda_has_timed_hook() && peak_cuda_capture_hooks_ready)",
+        "peak_cuda_start_harvester()",
+    )
+    require(attach.count("peak_cuda_resolve_backend_api()") == 1,
+            "CUDA backend entry points must be immutable before hook "
+            "publication")
+    require(attach.count(
+                "peak_cuda_driver_typed_replacements_are_isolated()") == 1 and
+            cuda.count(
+                "peak_cuda_driver_typed_replacements_are_isolated()") == 2,
+            "Driver collision census must run once at attach time only")
+    require_order(
+        attach,
+        "for (size_t hook_index = 0;",
+        "if (!driver_typed_replacements_are_isolated &&",
+        "peak_cuda_capture_descriptors[index].api ==",
+        "PEAK_CUDA_CAPTURE_API_DRIVER)",
+        "continue;",
+        "gboolean installed = peak_cuda_install_capture_hook(",
+    )
+    require("driver_typed_replacements_are_isolated\n"
+            "        ? (gpointer*) peak_general_listener_find_function("
+            in attach,
+            "a failed Driver ABI-isolation census must suppress typed launch "
+            "replacements and generic Driver capture listeners")
+    for wrapper in CUDA_WRAPPERS:
+        require("peak_cuda_resolve_backend_api" not in
+                function_body(cuda, wrapper),
+                f"{wrapper} must not resolve Driver APIs on the launch path")
 
     detach = function_body(cuda, "cuda_interceptor_dettach")
     require_order(
         detach,
-        "peak_cuda_accepting_events.store(false",
+        "peak_cuda_lifecycle_close()",
+        "peak_cuda_disable_harvester_initialization()",
         "gum_interceptor_begin_transaction(cuda_interceptor)",
         "gum_interceptor_end_transaction(cuda_interceptor)",
         "gum_interceptor_flush(cuda_interceptor)",
         "peak_cuda_hooks_reverted = TRUE",
         "peak_cuda_clear_hook_pointers()",
-        "peak_cuda_drain_kernel_event_map(FALSE)",
-        "peak_cuda_drain_graph_event_map(FALSE)",
+        "peak_cuda_finalize_pending()",
+        "if (peak_cuda_finalization_timed_out)",
+        "peak_cuda_destroy_event_pool()",
         "g_hash_table_destroy(cuda_kernel_local_dim_mapping)",
         "g_hash_table_destroy(cuda_graph_local_mapping)",
     )
@@ -460,10 +1255,19 @@ def main():
     require("cuda_interceptor = NULL" not in detach,
             "CUDA physical detach must keep interceptor state referenced")
     active_guard = detach.find("if (active_cuda_wrappers != 0)")
-    drain = detach.find("peak_cuda_drain_kernel_event_map(FALSE)")
-    require(active_guard != -1 and drain != -1 and active_guard < drain and
-            "return;" in detach[active_guard:drain],
+    finalize = detach.find("peak_cuda_finalize_pending()")
+    require(active_guard != -1 and finalize != -1 and
+            active_guard < finalize and
+            "return;" in detach[active_guard:finalize],
             "active CUDA wrappers must retain pool/maps for a safe cleanup retry")
+    timed_out = detach.find("if (peak_cuda_finalization_timed_out)")
+    destroy_pool = detach.find("peak_cuda_destroy_event_pool()", timed_out)
+    require(timed_out != -1 and destroy_pool > timed_out and
+            "return;" in detach[timed_out:destroy_pool],
+            "a bounded finalization timeout must retain incomplete CUDA state")
+    require("peak_cuda_capture_listeners[index] != NULL" in detach and
+            "gum_interceptor_detach(" in detach,
+            "capture lifecycle listeners must detach in the Gum transaction")
 
     clear_hooks = function_body(cuda, "peak_cuda_clear_hook_pointers")
     for hook in [
@@ -480,22 +1284,135 @@ def main():
     ]:
         require(f"{hook} = NULL;" in clear_hooks,
                 f"hook cleanup helper must clear {hook}")
+    require("peak_cuda_capture_hooks[index] = NULL;" in clear_hooks and
+            "g_object_unref(peak_cuda_capture_listeners[index])" in
+            clear_hooks,
+            "capture lifecycle hook storage must be cleared after flush")
 
-    sync = function_body(cuda, "cuda_sync_kernel_event")
+    for forbidden_sync in ("cudaDeviceSynchronize(",
+                           "cudaStreamSynchronize(",
+                           "cuCtxSynchronize("):
+        require(forbidden_sync not in cuda,
+                f"CUDA timing and finalization must not call {forbidden_sync}")
+
+    timeout_parser = function_body(cuda,
+                                   "peak_cuda_parse_finalization_timeout_ms")
+    require("PEAK_CUDA_FINALIZATION_TIMEOUT_MS" in timeout_parser and
+            '"milliseconds", 1000, 1,' in timeout_parser and
+            "60000" in timeout_parser,
+            "CUDA finalization timeout must default to 1000 ms in [1, 60000]")
+    monotonic = function_body(cuda, "peak_cuda_monotonic_ns")
+    require("clock_gettime(CLOCK_MONOTONIC" in monotonic,
+            "CUDA finalization must use a monotonic clock")
+    finalizer = function_body(cuda, "peak_cuda_finalize_pending")
+    require("peak_cuda_disable_harvester_initialization();" in finalizer,
+            "finalization must cancel a deferred helper handshake before "
+            "waiting for CUDA wrapper quiescence")
+    disable_initialization = function_body(
+        cuda, "peak_cuda_disable_harvester_initialization")
     require_order(
-        sync,
-        "cudaDeviceSynchronize()",
-        "peak_cuda_drain_kernel_event_map(TRUE)",
-        "peak_cuda_drain_graph_event_map(TRUE)",
+        disable_initialization,
+        "peak_cuda_harvester_initialization_allowed = FALSE",
+        "peak_cuda_harvester_initialization_terminal.store(",
+        "peak_cuda_accepting_events.store(false",
+        "!peak_cuda_harvester_initialization_done",
+        "peak_cuda_harvester_running.store(false",
     )
-    require("free(launch.start_event)" not in sync,
-            "sync must drain through ownership helpers, not free inline")
+    require_order(
+        finalizer,
+        "peak_cuda_lifecycle_close()",
+        "peak_cuda_monotonic_ns()",
+        "peak_cuda_disable_harvester_initialization()",
+        "deadline_ns",
+        "unsigned int wrappers = peak_cuda_active_wrapper_count()",
+        "size_t active_slots = peak_cuda_slot_allocator.active_count()",
+        "now_ns >= deadline_ns",
+        "peak_cuda_request_harvester_stop_no_wait()",
+        "deadline_wrappers = peak_cuda_active_wrapper_count()",
+        "deadline_incomplete = peak_cuda_slot_allocator.active_count()",
+        "deadline_initialization_inflight =",
+        "if (deadline_incomplete == 0 && deadline_wrappers == 0 &&",
+        "peak_cuda_finalization_complete = TRUE",
+        "if (peak_cuda_finalization_complete)",
+        "record_finalization_timeout(\n            deadline_incomplete)",
+        "retaining incomplete event state",
+        "peak_cuda_log_incomplete_records(deadline_wrappers)",
+    )
+    require("peak_cuda_harvester_initialization_inflight.load(" in
+            finalizer and
+            "helper_initialization_inflight=%d" in finalizer,
+            "a helper blocked while establishing capture mode must consume "
+            "the same bounded finalization deadline")
+    complete_branch = finalizer.find("if (peak_cuda_finalization_complete)")
+    timeout_branch = finalizer.find("} else {", complete_branch)
+    require(complete_branch != -1 and timeout_branch != -1 and
+            "peak_cuda_request_harvester_stop_no_wait()" in
+            finalizer[:complete_branch] and
+            "peak_cuda_stop_harvester()" in
+            finalizer[complete_branch:timeout_branch] and
+            "peak_cuda_stop_harvester()" not in finalizer[timeout_branch:] and
+            "pthread_join" not in finalizer[timeout_branch:],
+            "deadline expiry must stop without a blocking lock or join")
+    incomplete_log = function_body(cuda, "peak_cuda_log_incomplete_records")
+    require("kDiagnosticLimit = 16" in incomplete_log and
+            "try_snapshot_active_leases" in incomplete_log and
+            "diagnostics unavailable because slot ownership is busy" in
+            incomplete_log and
+            "CUDA incomplete event context=%p device=%d" in
+            incomplete_log,
+            "bounded timeout diagnostics must identify affected contexts/devices")
+    harvest_one = function_body(cuda, "peak_cuda_harvest_one_current")
+    require_order(
+        harvest_one,
+        "record_event_query_failure()",
+        "peak_cuda_destroy_slot_events_current(&slot)",
+        "if (destroyed)",
+        "return PEAK_CUDA_HARVEST_RELEASE;",
+    )
+    harvest_pass = function_body(cuda, "peak_cuda_harvest_pass")
+    require_order(
+        harvest_pass,
+        "peak_cuda_restore_context(&activation)",
+        "if (restored)",
+        "outcomes[index] == PEAK_CUDA_HARVEST_RELEASE",
+        "peak_cuda_slot_allocator.release(leases[index])",
+    )
+    destroy_events = function_body(cuda, "peak_cuda_destroy_event_pool")
+    destroy_slot = function_body(cuda,
+                                 "peak_cuda_destroy_slot_events_current")
+    require("slot->start != NULL" in destroy_slot and
+            "slot->end != NULL" in destroy_slot and
+            "if (destroyed)" in destroy_slot and
+            "slot->initialized = FALSE;" in destroy_slot,
+            "partial CUDA event creation must retain and retry each live handle")
+    require("slot.start == NULL && slot.end == NULL" in destroy_events and
+            "peak_cuda_activate_context(slot.owner_context" in destroy_events and
+            "if (!peak_cuda_destroy_slot_events_current(&slot))" in
+            destroy_events and
+            "if (!peak_cuda_restore_context(&activation))" in destroy_events and
+            "retaining CUDA event state" in destroy_events and
+            "return FALSE;" in destroy_events and
+            "return TRUE;" in destroy_events,
+            "event destruction must occur in the owning context or retain state")
+    require("if (capture_unsafe)" in destroy_events and
+            "capture_unsafe && !peak_cuda_event_pool.empty()" not in
+            destroy_events and
+            destroy_events.find("if (capture_unsafe)") <
+            destroy_events.find("for (PeakCudaEventSlot& slot"),
+            "capture-unsafe teardown must retain state even when the event "
+            "pool is empty")
+
+    graph_renderer = function_body(cuda, "cuda_interceptor_print_graph_result")
+    require_order(graph_renderer,
+                  "g_mutex_lock(&cuda_graph_local_mapping_mutex)",
+                  "g_hash_table_iter_init",
+                  "g_mutex_unlock(&cuda_graph_local_mapping_mutex)")
 
     require_order(
         printer,
         "std::lock_guard<std::mutex> lifecycle_lock",
-        "peak_cuda_accepting_events.store(false",
-        "cuda_sync_kernel_event()",
+        "peak_cuda_finalize_pending()",
+        "peak_cuda_build_report_snapshot()",
     )
     require("cuda_interceptor_print_kernel_result" not in printer,
             "kernel output must flow through the shared snapshot transport")

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -833,13 +833,15 @@ def check_x86_patched_gum_requires_exact_attach(repo_root):
     require(match is not None, "missing patched Gum API validation function")
     validate = match.group(0)
     exact_probe = validate.find("PEAK_GUM_HAS_PEAK_EXACT_ATTACH_API")
-    x86_guard = validate.find('MATCHES "^(x86_64|amd64)$"', exact_probe)
-    fatal = validate.find("message(FATAL_ERROR", x86_guard)
-    require(exact_probe != -1 and x86_guard != -1 and fatal != -1 and
-            exact_probe < x86_guard < fatal and
+    linux_guard = validate.find(
+        'MATCHES "^(x86_64|amd64|aarch64|arm64)$"', exact_probe)
+    fatal = validate.find("message(FATAL_ERROR", linux_guard)
+    require(exact_probe != -1 and linux_guard != -1 and fatal != -1 and
+            exact_probe < linux_guard < fatal and
             "NOT PEAK_GUM_HAS_PEAK_EXACT_ATTACH_API" in
-            validate[x86_guard:fatal],
-            "Linux x86 PEAK-patched Gum must fail configuration without exact-entry attach")
+            validate[linux_guard:fatal] and
+            "GUM_PEAK_REDIRECT_RESOLVER_API_VERSION" in validate,
+            "supported Linux PEAK-patched Gum must require exact-entry and redirect-resolution APIs")
 
 
 def check_fast_listener_unwind_abi(repo_root):

--- a/test/static_checks/check_gum_mutation_allowlist.py
+++ b/test/static_checks/check_gum_mutation_allowlist.py
@@ -75,9 +75,11 @@ EXPECTED = {
         "begin_transaction": 1,
         "end_transaction": 1,
         "replace_fast": 10,
+        "revert": 5,
     },
     ("support-shutdown-debt", "src/cuda_interceptor.cpp"): {
         "begin_transaction": 1,
+        "detach": 2,
         "end_transaction": 1,
         "flush": 1,
         "revert": 10,


### PR DESCRIPTION
## Summary

- recycle a fixed, context-owned CUDA event-slot pool through a bounded asynchronous harvester
- keep stream capture fail-open by excluding PEAK timing events while capture coordination is active
- preserve context ownership, skip unsupported multi-device timing, and use checked 64-bit launch dimensions
- replace device-wide finalization synchronization with a finite deadline and explicit incomplete-sample accounting
- retain a lock-free/sharded launch path and select one typed Driver timing layer when safe, with per-entry Runtime fallback

Closes #83.
Closes #84.
Closes #85.
Closes #86.

## Validation

- Local RTX 5090: CUDA build, focused state/static tests, Runtime accounting smoke checks
- Vista GH200 interactive allocation: Slurm job `936099`, stage `/scratch/05450/wangyinz/codex-tests/peak/20260824-120539-session-82a80a1f`
- Vista correctness: event recycling, stream capture, multi-context ownership, and bounded finalization all passed
- Vista Linux/AArch64 exact-attach regression: Slurm job `936735`, stage `/scratch/05450/wangyinz/codex-tests/peak/20260824-153514-session-c34cffa7`; two one-instruction tail-branch entries remained distinct from each other and their shared dispatcher, and detaching one listener left the other attached
- Vista production benchmark: complete Runtime/Driver target and non-target matrix at 1/8/32/64 threads, 160 samples, exact accounting, and zero CUDA failure counters
- 64-thread Runtime target software increment over the mandatory native two-event floor: `6.451 us`
- 64-thread Driver target software increment over the mandatory native two-event floor: `4.790 us`
- 64-thread non-target throughput retention: Runtime `1.021`, Driver `0.986`
- unchanged performance gates passed: `2.00x`, `10000 ns`, `1.10`, and `0.90`

The local full build is additionally limited by the host's missing `/usr/lib64/libubsan.so.1.0.0` for the pre-existing `long_double_64` test target; focused affected targets and static checks pass, and GitHub CI provides the clean general build matrix.
