### PR TITLE
Gate optional backends and report capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,12 @@ the selected output transport. Each row distinguishes `requested`, `compiled`,
 include stable masks for compiled, found, installed, and failed API families.
 MPI and socket aggregation preserve the common installed coverage, OR
 failure/degradation evidence across ranks, and mark rank-varying coverage as
-partial. An unavailable requested optional backend fails open: PEAK emits one
-warning, records the failed capability, and continues the application and any
-independently installed profiler backends.
+partial. Report-transport `active` state records the transport that actually
+published that report; a fallback marks the requested transport partial and
+failed while marking the rank-local or socket fallback active. An unavailable
+requested optional backend fails open: PEAK emits one warning, records the
+failed capability, and continues the application and any independently
+installed profiler backends.
 
 ### MPI Output
 
@@ -355,6 +358,9 @@ full output and teardown behavior.
 | `PEAK_HB_MIN_US`, `PEAK_HB_MAX_US` | Adaptive heartbeat sleep bounds. Defaults: `10000` and `500000` microseconds. |
 | `PEAK_HB_K_ERR`, `PEAK_HB_K_RATE` | Adaptive response coefficients. Defaults: `3.0` and `0.8`. |
 | `PEAK_HB_EMA_A` | Growth-rate EMA alpha in `(0, 1]`. Default: `0.3`. |
+
+PEAK creates the heartbeat helper only when at least one CPU target is
+requested. GPU-only, memory-only, and JIT-only workloads do not start it.
 
 Numeric overhead-control values must consume the complete value and be finite.
 Invalid present values emit one warning and use their documented default.
@@ -527,7 +533,10 @@ run until the configured monotonic deadline. If work remains, PEAK reports the
 incomplete count, logs bounded context/device diagnostics, and retains the
 affected event state instead of destroying an event in the wrong or unfinished
 context. That retained state remains process-owned until operating-system
-reclamation, so a blocked CUDA query cannot race library teardown.
+reclamation, so a blocked CUDA query cannot race library teardown. The
+capability manifest records retention decisions made before its report
+snapshot. A later physical-detach flush failure is reported by its teardown
+warning but cannot retroactively change an already published manifest.
 
 Allocation lifetimes are tracked in a lock-free pointer radix. Memory events
 use sharded ordering metadata, and their process-wide `current` totals and

--- a/README.md
+++ b/README.md
@@ -291,12 +291,14 @@ the selected output transport. Each row distinguishes `requested`, `compiled`,
 include stable masks for compiled, found, installed, and failed API families.
 MPI and socket aggregation preserve the common installed coverage, OR
 failure/degradation evidence across ranks, and mark rank-varying coverage as
-partial. Report-transport `active` state records the transport that actually
-published that report; a fallback marks the requested transport partial and
-failed while marking the rank-local or socket fallback active. An unavailable
-requested optional backend fails open: PEAK emits one warning, records the
-failed capability, and continues the application and any independently
-installed profiler backends.
+partial. Report-transport `active` state records the transport selected for
+the final report after fallback; a fallback marks the requested transport
+partial and failed while marking the rank-local or socket fallback active. An
+unavailable requested optional backend fails open: PEAK emits one warning,
+records the failed capability, and continues the application and any
+independently installed profiler backends. CPU target profiling remains active
+when strict mutation support is not compiled, while `strict-mutation` is
+reported partial and failed.
 
 ### MPI Output
 

--- a/README.md
+++ b/README.md
@@ -283,16 +283,17 @@ in detail.
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
 | `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. |
 
-Every text report includes a capability manifest for CPU targets, strict
-mutation, CUDA, memory tracking, JIT input, dynamic DSO discovery, and the
-selected output transport. Each row distinguishes `requested`, `compiled`,
-`active`, `partial`, `retained`, and `failed` state. CUDA reports also include
-stable hexadecimal masks for compiled, found, installed, and failed API
-families. MPI and socket aggregation preserve the common installed coverage,
-OR failure/degradation evidence across ranks, and mark rank-varying coverage
-as partial. An unavailable requested optional backend fails open: PEAK emits
-one warning, records the failed capability, and continues the application and
-any independently installed profiler backends.
+Every text and stats CSV report includes a capability manifest for CPU targets,
+strict mutation, CUDA, memory tracking, JIT input, dynamic DSO discovery, and
+the selected output transport. Each row distinguishes `requested`, `compiled`,
+`active`, `partial`, `retained`, and `failed` state. CSV rows prefixed with
+`PEAK_CAPABILITY_` provide the same machine-readable fields. CUDA reports also
+include stable masks for compiled, found, installed, and failed API families.
+MPI and socket aggregation preserve the common installed coverage, OR
+failure/degradation evidence across ranks, and mark rank-varying coverage as
+partial. An unavailable requested optional backend fails open: PEAK emits one
+warning, records the failed capability, and continues the application and any
+independently installed profiler backends.
 
 ### MPI Output
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ in detail.
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
 | `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. |
 
+Every text report includes a capability manifest for CPU targets, strict
+mutation, CUDA, memory tracking, JIT input, dynamic DSO discovery, and the
+selected output transport. Each row distinguishes `requested`, `compiled`,
+`active`, `partial`, `retained`, and `failed` state. CUDA reports also include
+stable hexadecimal masks for compiled, found, installed, and failed API
+families. MPI and socket aggregation preserve the common installed coverage,
+OR failure/degradation evidence across ranks, and mark rank-varying coverage
+as partial. An unavailable requested optional backend fails open: PEAK emits
+one warning, records the failed capability, and continues the application and
+any independently installed profiler backends.
+
 ### MPI Output
 
 | Variable | Purpose |

--- a/include/cuda_interceptor.h
+++ b/include/cuda_interceptor.h
@@ -17,6 +17,7 @@
 #include "utils/utils.h"
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <stdint.h>
 #include <pthread.h>
 #include <string.h>
 
@@ -35,6 +36,38 @@ extern "C" {
 
 /** @name Interceptor lifecycle
  * @{ */
+
+typedef enum {
+    PEAK_CUDA_API_RUNTIME_LAUNCH = 1u << 0,
+    PEAK_CUDA_API_RUNTIME_COOPERATIVE = 1u << 1,
+    PEAK_CUDA_API_RUNTIME_MULTI_DEVICE = 1u << 2,
+    PEAK_CUDA_API_RUNTIME_LAUNCH_EX = 1u << 3,
+    PEAK_CUDA_API_RUNTIME_GRAPH = 1u << 4,
+    PEAK_CUDA_API_DRIVER_LAUNCH = 1u << 5,
+    PEAK_CUDA_API_DRIVER_COOPERATIVE = 1u << 6,
+    PEAK_CUDA_API_DRIVER_MULTI_DEVICE = 1u << 7,
+    PEAK_CUDA_API_DRIVER_LAUNCH_EX = 1u << 8,
+    PEAK_CUDA_API_DRIVER_GRAPH = 1u << 9,
+    PEAK_CUDA_API_RUNTIME_CAPTURE = 1u << 10,
+    PEAK_CUDA_API_DRIVER_CAPTURE = 1u << 11,
+    PEAK_CUDA_API_DRIVER_TIMING = 1u << 12,
+} PeakCudaApiCapability;
+
+typedef struct {
+    uint32_t compiled_apis;
+    uint32_t found_apis;
+    uint32_t installed_apis;
+    uint32_t failed_apis;
+    int active;
+    int partial;
+    int retained;
+} PeakCudaCapabilities;
+
+/** Returns the CUDA API families supported by this build. */
+uint32_t cuda_interceptor_compiled_api_mask(void);
+
+/** Returns the immutable result of the most recent attach attempt. */
+PeakCudaCapabilities cuda_interceptor_get_capabilities(void);
 
 /**
  * @brief Installs the available CUDA launch replacements.
@@ -109,6 +142,9 @@ void cuda_interceptor_print_with_mpi_job_policy(int aggregation_mode,
                                                 int active_mpi_job);
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
+/** Returns top-level calls to CUDA attach, including disabled requests. */
+__attribute__((visibility("default")))
+unsigned long long peak_cuda_test_attach_call_count(void);
 /** Forces accepted CUDA events to remain pending in regression tests. */
 void peak_cuda_test_force_incomplete_events(int enabled);
 /** Forces the next harvested CUDA event query down the error path. */

--- a/include/internal/general_listener/report_snapshot.h
+++ b/include/internal/general_listener/report_snapshot.h
@@ -45,6 +45,11 @@ typedef enum {
     PEAK_CAPABILITY_LOCAL_REPORT    = 1u << 8,
 } PeakProfilerCapabilityMask;
 
+#define PEAK_CAPABILITY_REPORT_TRANSPORTS \
+    (PEAK_CAPABILITY_MPI_REPORT | \
+     PEAK_CAPABILITY_SOCKET_REPORT | \
+     PEAK_CAPABILITY_LOCAL_REPORT)
+
 typedef struct {
     uint32_t requested;
     uint32_t compiled;
@@ -70,6 +75,22 @@ void peak_report_capability_note_active(uint32_t mask);
 void peak_report_capability_note_partial(uint32_t mask);
 void peak_report_capability_note_retained(uint32_t mask);
 void peak_report_capability_note_failed(uint32_t mask);
+
+/**
+ * Replaces the report-transport outcome in one captured manifest.
+ *
+ * This is used to project an attempted transport into a snapshot before that
+ * snapshot is handed to the transport. A later fallback may replace the same
+ * bits without retaining a false active transport from the failed attempt.
+ */
+void peak_report_capability_manifest_set_output_outcome(
+    PeakProfilerCapabilityManifest* manifest,
+    uint32_t requested,
+    uint32_t active);
+
+/** Publishes the final report-transport outcome for later report domains. */
+void peak_report_capability_set_output_outcome(uint32_t requested,
+                                               uint32_t active);
 
 /** Stores the immutable CUDA API coverage masks produced by CUDA attach. */
 void peak_report_capability_set_cuda_apis(uint32_t compiled,

--- a/include/internal/general_listener/report_snapshot.h
+++ b/include/internal/general_listener/report_snapshot.h
@@ -28,7 +28,62 @@ typedef enum {
     PEAK_PROFILER_DEGRADED_REPORT           = 1u << 1,
     PEAK_PROFILER_DEGRADED_MEMORY_TRACKING  = 1u << 2,
     PEAK_PROFILER_DEGRADED_EXIT_INTERPOSER  = 1u << 3,
+    PEAK_PROFILER_DEGRADED_CUDA             = 1u << 4,
+    PEAK_PROFILER_DEGRADED_JIT              = 1u << 5,
+    PEAK_PROFILER_DEGRADED_DYNAMIC_DSO      = 1u << 6,
 } PeakProfilerDegradedMask;
+
+typedef enum {
+    PEAK_CAPABILITY_CPU_TARGET      = 1u << 0,
+    PEAK_CAPABILITY_STRICT_MUTATION = 1u << 1,
+    PEAK_CAPABILITY_CUDA            = 1u << 2,
+    PEAK_CAPABILITY_MEMORY          = 1u << 3,
+    PEAK_CAPABILITY_JIT             = 1u << 4,
+    PEAK_CAPABILITY_DYNAMIC_DSO     = 1u << 5,
+    PEAK_CAPABILITY_MPI_REPORT      = 1u << 6,
+    PEAK_CAPABILITY_SOCKET_REPORT   = 1u << 7,
+    PEAK_CAPABILITY_LOCAL_REPORT    = 1u << 8,
+} PeakProfilerCapabilityMask;
+
+typedef struct {
+    uint32_t requested;
+    uint32_t compiled;
+    uint32_t active;
+    uint32_t partial;
+    uint32_t retained;
+    uint32_t failed;
+    uint32_t cuda_compiled_apis;
+    uint32_t cuda_found_apis;
+    uint32_t cuda_installed_apis;
+    uint32_t cuda_failed_apis;
+} PeakProfilerCapabilityManifest;
+
+/** Publishes the immutable startup request and build capability masks. */
+void peak_report_capability_reset(
+    const PeakProfilerCapabilityManifest* manifest);
+
+/** Records a late-frozen request derived during startup symbol resolution. */
+void peak_report_capability_note_requested(uint32_t mask);
+
+/** Records control-path subsystem state transitions. */
+void peak_report_capability_note_active(uint32_t mask);
+void peak_report_capability_note_partial(uint32_t mask);
+void peak_report_capability_note_retained(uint32_t mask);
+void peak_report_capability_note_failed(uint32_t mask);
+
+/** Stores the immutable CUDA API coverage masks produced by CUDA attach. */
+void peak_report_capability_set_cuda_apis(uint32_t compiled,
+                                          uint32_t found,
+                                          uint32_t installed,
+                                          uint32_t failed);
+
+/** Returns one consistent process-local capability snapshot. */
+PeakProfilerCapabilityManifest peak_report_capability_manifest(void);
+
+/** Merges one rank manifest into an already initialized aggregate. */
+void peak_report_capability_manifest_merge(
+    PeakProfilerCapabilityManifest* aggregate,
+    const PeakProfilerCapabilityManifest* incoming);
 
 /** Records one non-critical subsystem that was safely disabled. */
 void peak_report_snapshot_note_degraded(uint32_t mask, const char* reason);
@@ -73,6 +128,7 @@ typedef struct {
     uint64_t dropped_threads;
     /** Non-critical profiler facilities disabled without mutating user code. */
     uint32_t degraded_mask;
+    PeakProfilerCapabilityManifest capabilities;
     double overhead_per_call;
     int rank_count;
     PeakReportOverhead overhead;

--- a/include/internal/jit_provider.h
+++ b/include/internal/jit_provider.h
@@ -44,6 +44,12 @@ extern "C" {
  */
 void peak_jit_provider_enable(void);
 
+/** Returns whether the immutable startup configuration requests JIT input. */
+gboolean peak_jit_provider_requested(void);
+
+/** Returns whether a supported JIT provider is currently active. */
+gboolean peak_jit_provider_is_active(void);
+
 /**
  * @brief Stops ingestion and releases module-owned provider state.
  *

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -184,14 +184,46 @@ struct PeakCudaBackendApi {
 };
 
 static PeakCudaBackendApi peak_cuda_backend_api;
-struct PeakCudaCapabilityReport {
-    gboolean runtime_base_installed;
-    gboolean runtime_ex_installed;
-    gboolean driver_base_installed;
-    gboolean driver_ex_installed;
-    gboolean driver_timing_available;
-};
-static PeakCudaCapabilityReport peak_cuda_capability_report;
+static PeakCudaCapabilities peak_cuda_capabilities;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static std::atomic<std::uint64_t> peak_cuda_test_attach_calls{0};
+
+extern "C" unsigned long long
+peak_cuda_test_attach_call_count(void)
+{
+    return peak_cuda_test_attach_calls.load(std::memory_order_acquire);
+}
+#endif
+
+extern "C" uint32_t
+cuda_interceptor_compiled_api_mask(void)
+{
+    uint32_t mask =
+        PEAK_CUDA_API_RUNTIME_LAUNCH |
+        PEAK_CUDA_API_RUNTIME_COOPERATIVE |
+        PEAK_CUDA_API_RUNTIME_MULTI_DEVICE |
+        PEAK_CUDA_API_RUNTIME_GRAPH |
+        PEAK_CUDA_API_DRIVER_LAUNCH |
+        PEAK_CUDA_API_DRIVER_COOPERATIVE |
+        PEAK_CUDA_API_DRIVER_MULTI_DEVICE |
+        PEAK_CUDA_API_DRIVER_GRAPH |
+        PEAK_CUDA_API_RUNTIME_CAPTURE |
+        PEAK_CUDA_API_DRIVER_CAPTURE |
+        PEAK_CUDA_API_DRIVER_TIMING;
+#if defined(PEAK_CUDA_RUNTIME_LAUNCH_EX)
+    mask |= PEAK_CUDA_API_RUNTIME_LAUNCH_EX;
+#endif
+#if defined(PEAK_CUDA_DRIVER_LAUNCH_EX)
+    mask |= PEAK_CUDA_API_DRIVER_LAUNCH_EX;
+#endif
+    return mask;
+}
+
+extern "C" PeakCudaCapabilities
+cuda_interceptor_get_capabilities(void)
+{
+    return peak_cuda_capabilities;
+}
 
 enum PeakCudaCaptureApi {
     PEAK_CUDA_CAPTURE_API_RUNTIME = 0,
@@ -3261,9 +3293,42 @@ peak_cuda_capture_entry_point_census(gboolean* available_out)
     return TRUE;
 }
 
+static GumReplaceReturn
+peak_cuda_replace_fast(gpointer address,
+                       gpointer replacement,
+                       gpointer* original,
+                       const char* symbol,
+                       uint32_t capability)
+{
+    GumReplaceReturn result;
+
+    peak_cuda_capabilities.found_apis |= capability;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    const char* fail_symbol = getenv("PEAK_TEST_FAIL_CUDA_REPLACEMENT");
+    if (fail_symbol != NULL && strcmp(fail_symbol, symbol) == 0) {
+        result = GUM_REPLACE_WRONG_TYPE;
+    } else
+#else
+    (void)symbol;
+#endif
+    {
+        result = gum_interceptor_replace_fast(
+            cuda_interceptor, address, replacement, original, NULL);
+    }
+    if (result == GUM_REPLACE_OK) {
+        peak_cuda_capabilities.installed_apis |= capability;
+    } else {
+        peak_cuda_capabilities.failed_apis |= capability;
+    }
+    return result;
+}
+
 extern "C" int cuda_interceptor_attach()
 {
     std::lock_guard<std::mutex> lifecycle_lock(peak_cuda_lifecycle_mutex);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_cuda_test_attach_calls.fetch_add(1, std::memory_order_acq_rel);
+#endif
     if (!peak_cuda_timing_requested()) {
         return GUM_REPLACE_OK;
     }
@@ -3290,6 +3355,9 @@ extern "C" int cuda_interceptor_attach()
 
     GumReplaceReturn replace_check = GUM_REPLACE_OK;
     GumReplaceReturn hook_replace_check = GUM_REPLACE_OK;
+    peak_cuda_capabilities = {};
+    peak_cuda_capabilities.compiled_apis =
+        cuda_interceptor_compiled_api_mask();
     gboolean capture_hook_present[PEAK_CUDA_CAPTURE_HOOK_COUNT] = {};
     gboolean runtime_capture_hook_install_failed = FALSE;
     gboolean driver_capture_hook_install_failed = FALSE;
@@ -3369,11 +3437,11 @@ extern "C" int cuda_interceptor_attach()
     hook_cuda_launch =
         (gpointer*) peak_general_listener_find_function("cudaLaunchKernel");
     if (hook_cuda_launch) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cuda_launch,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cuda_launch,
             (gpointer)&peak_cuda_launch_kernel,
             (gpointer*)&original_cuda_launch_kernel,
-            NULL);
+            "cudaLaunchKernel", PEAK_CUDA_API_RUNTIME_LAUNCH);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3385,11 +3453,12 @@ extern "C" int cuda_interceptor_attach()
     hook_cuda_launch_cooperative =
         (gpointer*) peak_general_listener_find_function("cudaLaunchCooperativeKernel");
     if (hook_cuda_launch_cooperative) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cuda_launch_cooperative,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cuda_launch_cooperative,
             (gpointer)&peak_cuda_launch_cooperative_kernel,
             (gpointer*)&original_cuda_launch_cooperative_kernel,
-            NULL);
+            "cudaLaunchCooperativeKernel",
+            PEAK_CUDA_API_RUNTIME_COOPERATIVE);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3401,11 +3470,12 @@ extern "C" int cuda_interceptor_attach()
     hook_cuda_launch_cooperative_multiple_device =
         (gpointer*) peak_general_listener_find_function("cudaLaunchCooperativeKernelMultiDevice");
     if (hook_cuda_launch_cooperative_multiple_device) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cuda_launch_cooperative_multiple_device,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cuda_launch_cooperative_multiple_device,
             (gpointer)&peak_cuda_launch_cooperative_kernel_multiple_device,
             (gpointer*)&original_cuda_launch_cooperative_kernel_multiple_device,
-            NULL);
+            "cudaLaunchCooperativeKernelMultiDevice",
+            PEAK_CUDA_API_RUNTIME_MULTI_DEVICE);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3418,11 +3488,11 @@ extern "C" int cuda_interceptor_attach()
     hook_cuda_launch_exc =
         (gpointer*) peak_general_listener_find_function("cudaLaunchKernelExC");
     if (hook_cuda_launch_exc) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cuda_launch_exc,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cuda_launch_exc,
             (gpointer)&peak_cuda_launch_kernel_exc,
             (gpointer*)&original_cuda_launch_kernel_exc,
-            NULL);
+            "cudaLaunchKernelExC", PEAK_CUDA_API_RUNTIME_LAUNCH_EX);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3436,11 +3506,11 @@ extern "C" int cuda_interceptor_attach()
         ? (gpointer*) peak_general_listener_find_function("cuLaunchKernel")
         : NULL;
     if (hook_cu_launch) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cu_launch,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cu_launch,
             (gpointer)&peak_cu_launch_kernel,
             (gpointer*)&original_cu_launch_kernel,
-            NULL);
+            "cuLaunchKernel", PEAK_CUDA_API_DRIVER_LAUNCH);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3454,11 +3524,12 @@ extern "C" int cuda_interceptor_attach()
             "cuLaunchCooperativeKernel")
         : NULL;
     if (hook_cu_launch_cooperative) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cu_launch_cooperative,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cu_launch_cooperative,
             (gpointer)&peak_cu_launch_cooperative_kernel,
             (gpointer*)&original_cu_launch_cooperative_kernel,
-            NULL);
+            "cuLaunchCooperativeKernel",
+            PEAK_CUDA_API_DRIVER_COOPERATIVE);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3473,11 +3544,12 @@ extern "C" int cuda_interceptor_attach()
                 "cuLaunchCooperativeKernelMultiDevice")
             : NULL;
     if (hook_cu_launch_cooperative_multiple_device) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cu_launch_cooperative_multiple_device,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cu_launch_cooperative_multiple_device,
             (gpointer)&peak_cu_launch_cooperative_kernel_multiple_device,
             (gpointer*)&original_cu_launch_cooperative_kernel_multiple_device,
-            NULL);
+            "cuLaunchCooperativeKernelMultiDevice",
+            PEAK_CUDA_API_DRIVER_MULTI_DEVICE);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3491,11 +3563,11 @@ extern "C" int cuda_interceptor_attach()
         ? (gpointer*) peak_general_listener_find_function("cuLaunchKernelEx")
         : NULL;
     if (hook_cu_launch_ex) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cu_launch_ex,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cu_launch_ex,
             (gpointer)&peak_cu_launch_kernel_ex,
             (gpointer*)&original_cu_launch_kernel_ex,
-            NULL);
+            "cuLaunchKernelEx", PEAK_CUDA_API_DRIVER_LAUNCH_EX);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3508,11 +3580,11 @@ extern "C" int cuda_interceptor_attach()
     hook_cuda_graph_launch =
         (gpointer*) peak_general_listener_find_function("cudaGraphLaunch");
     if (hook_cuda_graph_launch) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cuda_graph_launch,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cuda_graph_launch,
             (gpointer)&peak_cuda_graph_launch,
             (gpointer*)&original_cuda_graph_launch,
-            NULL);
+            "cudaGraphLaunch", PEAK_CUDA_API_RUNTIME_GRAPH);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3525,11 +3597,11 @@ extern "C" int cuda_interceptor_attach()
         ? (gpointer*) peak_general_listener_find_function("cuGraphLaunch")
         : NULL;
     if (hook_cu_graph_launch) {
-        hook_replace_check = gum_interceptor_replace_fast(
-            cuda_interceptor, hook_cu_graph_launch,
+        hook_replace_check = peak_cuda_replace_fast(
+            hook_cu_graph_launch,
             (gpointer)&peak_cu_graph_launch,
             (gpointer*)&original_cu_graph_launch,
-            NULL);
+            "cuGraphLaunch", PEAK_CUDA_API_DRIVER_GRAPH);
         if (hook_replace_check != GUM_REPLACE_OK) {
             if (replace_check == GUM_REPLACE_OK) {
                 replace_check = hook_replace_check;
@@ -3547,12 +3619,16 @@ extern "C" int cuda_interceptor_attach()
         if (hook_cuda_launch != NULL && hook_cu_launch != NULL) {
             gum_interceptor_revert(cuda_interceptor, hook_cuda_launch);
             hook_cuda_launch = NULL;
+            peak_cuda_capabilities.installed_apis &=
+                ~PEAK_CUDA_API_RUNTIME_LAUNCH;
         }
         if (hook_cuda_launch_cooperative != NULL &&
             hook_cu_launch_cooperative != NULL) {
             gum_interceptor_revert(cuda_interceptor,
                                    hook_cuda_launch_cooperative);
             hook_cuda_launch_cooperative = NULL;
+            peak_cuda_capabilities.installed_apis &=
+                ~PEAK_CUDA_API_RUNTIME_COOPERATIVE;
         }
         if (hook_cuda_launch_cooperative_multiple_device != NULL &&
             hook_cu_launch_cooperative_multiple_device != NULL) {
@@ -3560,12 +3636,16 @@ extern "C" int cuda_interceptor_attach()
                 cuda_interceptor,
                 hook_cuda_launch_cooperative_multiple_device);
             hook_cuda_launch_cooperative_multiple_device = NULL;
+            peak_cuda_capabilities.installed_apis &=
+                ~PEAK_CUDA_API_RUNTIME_MULTI_DEVICE;
         }
 #if defined(PEAK_CUDA_RUNTIME_LAUNCH_EX) && \
     defined(PEAK_CUDA_DRIVER_LAUNCH_EX)
         if (hook_cuda_launch_exc != NULL && hook_cu_launch_ex != NULL) {
             gum_interceptor_revert(cuda_interceptor, hook_cuda_launch_exc);
             hook_cuda_launch_exc = NULL;
+            peak_cuda_capabilities.installed_apis &=
+                ~PEAK_CUDA_API_RUNTIME_LAUNCH_EX;
         }
 #endif
         if (hook_cuda_graph_launch != NULL &&
@@ -3573,6 +3653,8 @@ extern "C" int cuda_interceptor_attach()
             gum_interceptor_revert(cuda_interceptor,
                                    hook_cuda_graph_launch);
             hook_cuda_graph_launch = NULL;
+            peak_cuda_capabilities.installed_apis &=
+                ~PEAK_CUDA_API_RUNTIME_GRAPH;
         }
     }
 
@@ -3653,25 +3735,55 @@ extern "C" int cuda_interceptor_attach()
          !runtime_capture_hook_install_failed &&
          !driver_capture_hook_install_failed);
 
-    peak_cuda_capability_report.runtime_base_installed =
-        hook_cuda_launch != NULL ||
-        hook_cuda_launch_cooperative != NULL ||
-        hook_cuda_graph_launch != NULL;
-    peak_cuda_capability_report.runtime_ex_installed =
-        hook_cuda_launch_exc != NULL;
-    peak_cuda_capability_report.driver_base_installed =
-        hook_cu_launch != NULL ||
-        hook_cu_launch_cooperative != NULL ||
-        hook_cu_graph_launch != NULL;
-    peak_cuda_capability_report.driver_ex_installed =
-        hook_cu_launch_ex != NULL;
-    peak_cuda_capability_report.driver_timing_available =
+    gboolean driver_timing_available =
         peak_cuda_driver_timing_available();
+    if (runtime_capture_required_ready ||
+        runtime_capture_hook_install_failed) {
+        peak_cuda_capabilities.found_apis |=
+            PEAK_CUDA_API_RUNTIME_CAPTURE;
+    }
+    if (driver_capture_required_ready ||
+        driver_capture_hook_install_failed ||
+        capture_entry_point_census_available) {
+        peak_cuda_capabilities.found_apis |=
+            PEAK_CUDA_API_DRIVER_CAPTURE;
+    }
+    if (runtime_capture_required_ready &&
+        !runtime_capture_hook_install_failed) {
+        peak_cuda_capabilities.installed_apis |=
+            PEAK_CUDA_API_RUNTIME_CAPTURE;
+    } else if (runtime_timing_hook) {
+        peak_cuda_capabilities.failed_apis |=
+            PEAK_CUDA_API_RUNTIME_CAPTURE;
+    }
+    if (driver_capture_required_ready &&
+        !driver_capture_hook_install_failed &&
+        capture_entry_points_ready) {
+        peak_cuda_capabilities.installed_apis |=
+            PEAK_CUDA_API_DRIVER_CAPTURE;
+    } else if (driver_timing_hook) {
+        peak_cuda_capabilities.failed_apis |=
+            PEAK_CUDA_API_DRIVER_CAPTURE;
+    }
+    if (driver_timing_available) {
+        peak_cuda_capabilities.found_apis |=
+            PEAK_CUDA_API_DRIVER_TIMING;
+        peak_cuda_capabilities.installed_apis |=
+            PEAK_CUDA_API_DRIVER_TIMING;
+    }
+    peak_cuda_capabilities.active =
+        peak_cuda_has_timed_hook() && peak_cuda_capture_hooks_ready;
+    peak_cuda_capabilities.partial =
+        peak_cuda_capabilities.failed_apis != 0 ||
+        (peak_cuda_has_timed_hook() && !peak_cuda_capture_hooks_ready);
 
     peak_cuda_lifecycle_open();
     gum_interceptor_end_transaction(cuda_interceptor);
     if (peak_cuda_has_timed_hook() && peak_cuda_capture_hooks_ready) {
-        (void)peak_cuda_start_harvester();
+        if (!peak_cuda_start_harvester()) {
+            peak_cuda_capabilities.active = FALSE;
+            peak_cuda_capabilities.partial = TRUE;
+        }
     } else if (peak_cuda_has_timed_hook()) {
         peak_cuda_harvester_initialization_terminal.store(
             true, std::memory_order_release);
@@ -4133,11 +4245,20 @@ peak_cuda_render_report_snapshot(const PeakReportSnapshot* snapshot)
         " installed_runtime_base=%d installed_runtime_ex=%d"
         " installed_driver_base=%d installed_driver_ex=%d"
         " driver_timing=%d\n",
-        (int)peak_cuda_capability_report.runtime_base_installed,
-        (int)peak_cuda_capability_report.runtime_ex_installed,
-        (int)peak_cuda_capability_report.driver_base_installed,
-        (int)peak_cuda_capability_report.driver_ex_installed,
-        (int)peak_cuda_capability_report.driver_timing_available);
+        (peak_cuda_capabilities.installed_apis &
+         (PEAK_CUDA_API_RUNTIME_LAUNCH |
+          PEAK_CUDA_API_RUNTIME_COOPERATIVE |
+          PEAK_CUDA_API_RUNTIME_GRAPH)) != 0,
+        (peak_cuda_capabilities.installed_apis &
+         PEAK_CUDA_API_RUNTIME_LAUNCH_EX) != 0,
+        (peak_cuda_capabilities.installed_apis &
+         (PEAK_CUDA_API_DRIVER_LAUNCH |
+          PEAK_CUDA_API_DRIVER_COOPERATIVE |
+          PEAK_CUDA_API_DRIVER_GRAPH)) != 0,
+        (peak_cuda_capabilities.installed_apis &
+         PEAK_CUDA_API_DRIVER_LAUNCH_EX) != 0,
+        (peak_cuda_capabilities.installed_apis &
+         PEAK_CUDA_API_DRIVER_TIMING) != 0);
     peak_log_report(
         "[peak] CUDA profiler drops: pool_full=%" G_GUINT64_FORMAT
         " identity_full=%" G_GUINT64_FORMAT

--- a/src/cuda_interceptor.cpp
+++ b/src/cuda_interceptor.cpp
@@ -44,6 +44,51 @@ enum PeakCudaOutputAggregationMode {
     PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET = 2,
 };
 
+static uint32_t
+peak_cuda_output_capability(int aggregation_mode)
+{
+    if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_MPI) {
+        return PEAK_CAPABILITY_MPI_REPORT;
+    }
+    if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET) {
+        return PEAK_CAPABILITY_SOCKET_REPORT;
+    }
+    return PEAK_CAPABILITY_LOCAL_REPORT;
+}
+
+static uint32_t
+peak_cuda_requested_output_capability(const PeakReportSnapshot* snapshot,
+                                      int attempted_mode)
+{
+    uint32_t requested = snapshot->capabilities.requested &
+        PEAK_CAPABILITY_REPORT_TRANSPORTS;
+
+    return requested != 0
+        ? requested
+        : peak_cuda_output_capability(attempted_mode);
+}
+
+static void
+peak_cuda_project_output_outcome(PeakReportSnapshot* snapshot,
+                                 int attempted_mode,
+                                 int actual_mode)
+{
+    peak_report_capability_manifest_set_output_outcome(
+        &snapshot->capabilities,
+        peak_cuda_requested_output_capability(snapshot, attempted_mode),
+        peak_cuda_output_capability(actual_mode));
+}
+
+static void
+peak_cuda_commit_output_outcome(const PeakReportSnapshot* snapshot,
+                                int attempted_mode,
+                                int actual_mode)
+{
+    peak_report_capability_set_output_outcome(
+        peak_cuda_requested_output_capability(snapshot, attempted_mode),
+        peak_cuda_output_capability(actual_mode));
+}
+
 static GHashTable* cuda_kernel_local_dim_mapping;
 static GHashTable* cuda_graph_local_mapping;
 static GMutex cuda_kernel_local_dim_mapping_mutex;
@@ -185,6 +230,16 @@ struct PeakCudaBackendApi {
 
 static PeakCudaBackendApi peak_cuda_backend_api;
 static PeakCudaCapabilities peak_cuda_capabilities;
+
+static void
+peak_cuda_note_retained_state()
+{
+    peak_cuda_capabilities.retained = TRUE;
+    peak_cuda_capabilities.partial = TRUE;
+    peak_report_capability_note_retained(PEAK_CAPABILITY_CUDA);
+    peak_report_capability_note_partial(PEAK_CAPABILITY_CUDA);
+}
+
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static std::atomic<std::uint64_t> peak_cuda_test_attach_calls{0};
 
@@ -1495,6 +1550,7 @@ peak_cuda_destroy_event_pool()
     std::unique_lock<std::mutex> capture_teardown_lock(
         peak_cuda_capture_teardown_mutex, std::try_to_lock);
     if (!capture_teardown_lock.owns_lock()) {
+        peak_cuda_note_retained_state();
         peak_log_warn(
             "[peak] retaining CUDA event state while a stream-capture call crosses teardown\n");
         return FALSE;
@@ -1506,6 +1562,7 @@ peak_cuda_destroy_event_pool()
             std::memory_order_acquire);
     pthread_mutex_unlock(&peak_cuda_capture_mutex);
     if (capture_unsafe) {
+        peak_cuda_note_retained_state();
         peak_log_warn(
             "[peak] retaining CUDA event state because stream-capture quiescence is not proven\n");
         return FALSE;
@@ -1529,6 +1586,7 @@ peak_cuda_destroy_event_pool()
         }
     }
     if (retained) {
+        peak_cuda_note_retained_state();
         peak_log_warn("[peak] retaining CUDA event state that could not be destroyed in its owning context\n");
         return FALSE;
     }
@@ -2345,6 +2403,7 @@ peak_cuda_finalize_pending()
         peak_cuda_profiler_state.record_finalization_timeout(
             deadline_incomplete);
         peak_cuda_finalization_timed_out = TRUE;
+        peak_cuda_note_retained_state();
         peak_log_warn(
             "[peak] CUDA finalization_timeout=1 finalization_incomplete=%zu helper_initialization_inflight=%d; retaining incomplete event state\n",
             deadline_incomplete,
@@ -3860,6 +3919,7 @@ extern "C" void cuda_interceptor_dettach()
         gum_interceptor_end_transaction(cuda_interceptor);
 
         if (!gum_interceptor_flush(cuda_interceptor)) {
+            peak_cuda_note_retained_state();
             peak_log_warn("[peak] CUDA interceptor teardown did not flush; leaving CUDA interceptor state alive\n");
             return;
         }
@@ -3870,6 +3930,7 @@ extern "C" void cuda_interceptor_dettach()
 
     unsigned int active_cuda_wrappers = peak_cuda_active_wrapper_count();
     if (active_cuda_wrappers != 0) {
+        peak_cuda_note_retained_state();
         peak_log_warn("[peak] CUDA interceptor teardown observed %u active wrapper(s); keeping all CUDA state alive for cleanup retry\n",
                    active_cuda_wrappers);
         /*
@@ -4438,11 +4499,26 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
 #ifdef HAVE_MPI
         if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_MPI) {
             PeakReportSnapshot* aggregate = NULL;
+            peak_cuda_project_output_outcome(
+                local, aggregation_mode, PEAK_CUDA_OUTPUT_AGGREGATION_MPI);
             PeakMpiReportTransportResult result =
                 peak_mpi_report_transport_reduce(local, &aggregate);
             if (result == PEAK_MPI_REPORT_TRANSPORT_ROOT_READY) {
                 (void)peak_cuda_render_report_snapshot(aggregate);
-            } else if (result != PEAK_MPI_REPORT_TRANSPORT_PEER_COMPLETE) {
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_MPI);
+            } else if (result == PEAK_MPI_REPORT_TRANSPORT_PEER_COMPLETE) {
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_MPI);
+            } else {
+                peak_cuda_project_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
                 (void)peak_cuda_render_report_snapshot(local);
             }
             peak_report_snapshot_destroy(aggregate);
@@ -4451,6 +4527,9 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
         if (aggregation_mode == PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET) {
             PeakSocketReportSession* session = NULL;
             PeakReportSnapshot* aggregate = NULL;
+            peak_cuda_project_output_outcome(
+                local, aggregation_mode,
+                PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET);
             PeakSocketReportRankSource socket_rank_source = active_mpi_job
                 ? PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED
                 : PEAK_SOCKET_REPORT_RANK_MPI_OR_ENV;
@@ -4459,19 +4538,47 @@ extern "C" void cuda_interceptor_print_with_mpi_job_policy(
                 PEAK_SOCKET_REPORT_CHANNEL_CUDA, &session, &aggregate);
             if (status == PEAK_SOCKET_REPORT_SINGLE_READY) {
                 (void)peak_cuda_render_report_snapshot(aggregate);
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET);
             } else if (status == PEAK_SOCKET_REPORT_ROOT_PREPARED) {
                 if (peak_cuda_render_report_snapshot(aggregate)) {
                     (void)peak_socket_report_transport_commit(session);
+                    peak_cuda_commit_output_outcome(
+                        local, aggregation_mode,
+                        PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET);
                 } else {
                     peak_socket_report_transport_abort(session);
+                    peak_cuda_project_output_outcome(
+                        local, aggregation_mode,
+                        PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
+                    peak_cuda_commit_output_outcome(
+                        local, aggregation_mode,
+                        PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
                     (void)peak_cuda_render_report_snapshot(local);
                 }
-            } else if (status != PEAK_SOCKET_REPORT_PEER_RELEASED) {
+            } else if (status == PEAK_SOCKET_REPORT_PEER_RELEASED) {
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_SOCKET);
+            } else {
                 peak_socket_report_transport_abort(session);
+                peak_cuda_project_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
+                peak_cuda_commit_output_outcome(
+                    local, aggregation_mode,
+                    PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
                 (void)peak_cuda_render_report_snapshot(local);
             }
             peak_report_snapshot_destroy(aggregate);
         } else {
+            peak_cuda_project_output_outcome(
+                local, aggregation_mode,
+                PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
+            peak_cuda_commit_output_outcome(
+                local, aggregation_mode,
+                PEAK_CUDA_OUTPUT_AGGREGATION_LOCAL);
             (void)peak_cuda_render_report_snapshot(local);
         }
         peak_report_snapshot_destroy(local);

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -8445,6 +8445,60 @@ peak_general_listener_mpi_reducer_failed_closed(void)
 #endif
 }
 
+static uint32_t
+peak_general_listener_output_capability(
+    PeakOutputAggregationMode aggregation_mode)
+{
+    if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI) {
+        return PEAK_CAPABILITY_MPI_REPORT;
+    }
+    if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_SOCKET) {
+        return PEAK_CAPABILITY_SOCKET_REPORT;
+    }
+    return PEAK_CAPABILITY_LOCAL_REPORT;
+}
+
+static uint32_t
+peak_general_listener_requested_output_capability(
+    const PeakReportSnapshot* snapshot,
+    PeakOutputAggregationMode attempted_mode)
+{
+    uint32_t requested = snapshot != NULL
+        ? snapshot->capabilities.requested &
+            PEAK_CAPABILITY_REPORT_TRANSPORTS
+        : peak_report_capability_manifest().requested &
+            PEAK_CAPABILITY_REPORT_TRANSPORTS;
+
+    return requested != 0
+        ? requested
+        : peak_general_listener_output_capability(attempted_mode);
+}
+
+static void
+peak_general_listener_project_output_outcome(
+    PeakReportSnapshot* snapshot,
+    PeakOutputAggregationMode attempted_mode,
+    PeakOutputAggregationMode actual_mode)
+{
+    peak_report_capability_manifest_set_output_outcome(
+        &snapshot->capabilities,
+        peak_general_listener_requested_output_capability(
+            snapshot, attempted_mode),
+        peak_general_listener_output_capability(actual_mode));
+}
+
+static void
+peak_general_listener_commit_output_outcome(
+    const PeakReportSnapshot* snapshot,
+    PeakOutputAggregationMode attempted_mode,
+    PeakOutputAggregationMode actual_mode)
+{
+    peak_report_capability_set_output_outcome(
+        peak_general_listener_requested_output_capability(
+            snapshot, attempted_mode),
+        peak_general_listener_output_capability(actual_mode));
+}
+
 gboolean
 peak_general_listener_print_with_mpi_job_policy(
     PeakOutputAggregationMode aggregation_mode,
@@ -8590,8 +8644,21 @@ peak_general_listener_print_with_mpi_job_policy(
         if (local_snapshot != NULL) {
             local_snapshot->degraded_mask |=
                 peak_report_snapshot_degraded_mask();
+            peak_general_listener_project_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_LOCAL);
+            peak_general_listener_commit_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_LOCAL);
             write_succeeded = peak_general_listener_write_report(
                 local_snapshot, TRUE, TRUE, active_mpi_job);
+        } else {
+            peak_report_capability_set_output_outcome(
+                peak_general_listener_requested_output_capability(
+                    NULL, aggregation_mode),
+                0);
         }
         /* All ranks have completed the preflight agreement.  Do not enter a
          * payload collective after an allocation failure or a poisoned MPI
@@ -8603,6 +8670,10 @@ peak_general_listener_print_with_mpi_job_policy(
 #ifdef HAVE_MPI
         if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI) {
             PeakReportSnapshot* aggregate = NULL;
+            peak_general_listener_project_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_MPI);
             PeakMpiReportTransportResult result =
                 peak_mpi_report_transport_reduce(local_snapshot, &aggregate);
 
@@ -8621,6 +8692,10 @@ peak_general_listener_print_with_mpi_job_policy(
                     peak_general_listener_write_report(
                         aggregate, TRUE, FALSE, FALSE);
                 peak_report_snapshot_destroy(aggregate);
+                peak_general_listener_commit_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_MPI);
                 used_mpi_aggregation = TRUE;
             } else if (result == PEAK_MPI_REPORT_TRANSPORT_PEER_COMPLETE) {
                 PeakReportMarkerSwap marker_swap =
@@ -8628,42 +8703,108 @@ peak_general_listener_print_with_mpi_job_policy(
 
                 peak_general_listener_commit_report_marker_swap(&marker_swap);
                 write_succeeded = TRUE;
+                peak_general_listener_commit_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_MPI);
                 used_mpi_aggregation = TRUE;
             } else if (result == PEAK_MPI_REPORT_TRANSPORT_FAILED_CLOSED &&
                        peak_general_listener_socket_reduce_fallback_enabled()) {
                 g_printerr("[peak] MPI reducer failed; trying PEAK-owned socket aggregation fallback without further MPI calls\n");
+                peak_general_listener_project_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_SOCKET);
                 write_succeeded = peak_general_listener_run_socket_report(
                     local_snapshot,
                     active_mpi_job ?
                         PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED :
                         PEAK_SOCKET_REPORT_RANK_ENV_ONLY);
-                if (!write_succeeded) {
+                if (write_succeeded) {
+                    peak_general_listener_commit_output_outcome(
+                        local_snapshot,
+                        aggregation_mode,
+                        PEAK_OUTPUT_AGGREGATION_SOCKET);
+                } else {
                     g_printerr("[peak] MPI reducer socket fallback failed; writing rank-local output\n");
+                    peak_general_listener_project_output_outcome(
+                        local_snapshot,
+                        aggregation_mode,
+                        PEAK_OUTPUT_AGGREGATION_LOCAL);
+                    peak_general_listener_commit_output_outcome(
+                        local_snapshot,
+                        aggregation_mode,
+                        PEAK_OUTPUT_AGGREGATION_LOCAL);
                     write_succeeded = peak_general_listener_write_report(
                         local_snapshot, TRUE, TRUE, active_mpi_job);
                 }
             } else {
+                peak_general_listener_project_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_LOCAL);
+                peak_general_listener_commit_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_LOCAL);
                 write_succeeded = peak_general_listener_write_report(
                     local_snapshot, TRUE, TRUE, active_mpi_job);
             }
         } else if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_SOCKET) {
+            peak_general_listener_project_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_SOCKET);
             write_succeeded = peak_general_listener_run_socket_report(
                 local_snapshot,
                 active_mpi_job ?
                     PEAK_SOCKET_REPORT_RANK_ENV_REQUIRED :
                     PEAK_SOCKET_REPORT_RANK_MPI_OR_ENV);
-            if (!write_succeeded &&
+            if (write_succeeded) {
+                peak_general_listener_commit_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_SOCKET);
+            } else if (
                 peak_general_listener_socket_reduce_fallback_enabled()) {
                 g_printerr("[peak] Socket aggregation failed; falling back to rank-local output\n");
+                peak_general_listener_project_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_LOCAL);
+                peak_general_listener_commit_output_outcome(
+                    local_snapshot,
+                    aggregation_mode,
+                    PEAK_OUTPUT_AGGREGATION_LOCAL);
                 write_succeeded = peak_general_listener_write_report(
                     local_snapshot, TRUE, TRUE, active_mpi_job);
+            } else {
+                peak_report_capability_set_output_outcome(
+                    peak_general_listener_requested_output_capability(
+                        local_snapshot, aggregation_mode),
+                    0);
             }
         } else {
+            peak_general_listener_project_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_LOCAL);
+            peak_general_listener_commit_output_outcome(
+                local_snapshot,
+                aggregation_mode,
+                PEAK_OUTPUT_AGGREGATION_LOCAL);
             write_succeeded = peak_general_listener_write_report(
                 local_snapshot, TRUE, TRUE, active_mpi_job);
         }
 #else
-        (void)aggregation_mode;
+        peak_general_listener_project_output_outcome(
+            local_snapshot,
+            aggregation_mode,
+            PEAK_OUTPUT_AGGREGATION_LOCAL);
+        peak_general_listener_commit_output_outcome(
+            local_snapshot,
+            aggregation_mode,
+            PEAK_OUTPUT_AGGREGATION_LOCAL);
         write_succeeded = peak_general_listener_write_report(
             local_snapshot, TRUE, TRUE, active_mpi_job);
 #endif
@@ -8674,6 +8815,10 @@ peak_general_listener_print_with_mpi_job_policy(
 #endif
         peak_report_snapshot_note_degraded(PEAK_PROFILER_DEGRADED_REPORT,
                                            "final report snapshot allocation failed");
+        peak_report_capability_set_output_outcome(
+            peak_general_listener_requested_output_capability(
+                NULL, aggregation_mode),
+            0);
     }
 
     peak_report_snapshot_destroy(local_snapshot);

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -8576,6 +8576,12 @@ peak_general_listener_print_with_mpi_job_policy(
             &local_report);
         report_capture_ready = local_snapshot != NULL;
     }
+    if (local_snapshot != NULL) {
+        local_snapshot->degraded_mask |=
+            peak_report_snapshot_degraded_mask();
+        local_snapshot->capabilities =
+            peak_report_capability_manifest();
+    }
 
 #ifdef HAVE_MPI
     if (aggregation_mode == PEAK_OUTPUT_AGGREGATION_MPI &&

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -1039,6 +1039,10 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     int any_duplicate_names = 0;
     unsigned int local_degraded_mask;
     unsigned int aggregate_degraded_mask = 0;
+    unsigned int local_capability_any[10];
+    unsigned int aggregate_capability_any[10] = {0};
+    unsigned int local_capability_all[5];
+    unsigned int aggregate_capability_all[5] = {0};
     uint64_t* slot_hashes;
     uint64_t* min_slot_hashes;
     uint64_t* max_slot_hashes;
@@ -1066,6 +1070,37 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
                                     MPI_UNSIGNED,
                                     MPI_BOR,
                                     "degraded-mode-mask")) {
+        peak_mpi_report_transport_refresh_degraded_metadata(local);
+        return peak_mpi_report_transport_collective_failure();
+    }
+
+    local_capability_any[0] = local->capabilities.requested;
+    local_capability_any[1] = local->capabilities.compiled;
+    local_capability_any[2] = local->capabilities.active;
+    local_capability_any[3] = local->capabilities.partial;
+    local_capability_any[4] = local->capabilities.retained;
+    local_capability_any[5] = local->capabilities.failed;
+    local_capability_any[6] = local->capabilities.cuda_compiled_apis;
+    local_capability_any[7] = local->capabilities.cuda_found_apis;
+    local_capability_any[8] = local->capabilities.cuda_installed_apis;
+    local_capability_any[9] = local->capabilities.cuda_failed_apis;
+    local_capability_all[0] = local->capabilities.compiled;
+    local_capability_all[1] = local->capabilities.active;
+    local_capability_all[2] = local->capabilities.cuda_compiled_apis;
+    local_capability_all[3] = local->capabilities.cuda_found_apis;
+    local_capability_all[4] = local->capabilities.cuda_installed_apis;
+    if (!peak_mpi_allreduce_checked(local_capability_any,
+                                    aggregate_capability_any,
+                                    10,
+                                    MPI_UNSIGNED,
+                                    MPI_BOR,
+                                    "capability-any") ||
+        !peak_mpi_allreduce_checked(local_capability_all,
+                                    aggregate_capability_all,
+                                    5,
+                                    MPI_UNSIGNED,
+                                    MPI_BAND,
+                                    "capability-all")) {
         peak_mpi_report_transport_refresh_degraded_metadata(local);
         return peak_mpi_report_transport_collective_failure();
     }
@@ -1412,6 +1447,27 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     aggregate->dropped_calls = mpi_dropped_calls;
     aggregate->dropped_threads = mpi_dropped_threads;
     aggregate->degraded_mask = aggregate_degraded_mask;
+    aggregate->capabilities.requested = aggregate_capability_any[0];
+    aggregate->capabilities.compiled = aggregate_capability_all[0];
+    aggregate->capabilities.active = aggregate_capability_all[1];
+    aggregate->capabilities.partial = aggregate_capability_any[3] |
+        (aggregate_capability_any[2] ^ aggregate_capability_all[1]);
+    aggregate->capabilities.partial |= aggregate_capability_any[0] &
+        (aggregate_capability_any[1] ^ aggregate_capability_all[0]);
+    aggregate->capabilities.retained = aggregate_capability_any[4];
+    aggregate->capabilities.failed = aggregate_capability_any[5];
+    aggregate->capabilities.cuda_compiled_apis =
+        aggregate_capability_all[2];
+    aggregate->capabilities.cuda_found_apis =
+        aggregate_capability_all[3];
+    aggregate->capabilities.cuda_installed_apis =
+        aggregate_capability_all[4];
+    aggregate->capabilities.cuda_failed_apis =
+        aggregate_capability_any[9];
+    if ((aggregate_capability_any[7] ^ aggregate_capability_all[3]) != 0 ||
+        (aggregate_capability_any[8] ^ aggregate_capability_all[4]) != 0) {
+        aggregate->capabilities.partial |= PEAK_CAPABILITY_CUDA;
+    }
     peak_mpi_report_transport_set_overhead(
         aggregate,
         all_accounting_valid != 0,

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -38,6 +38,23 @@ enum {
 
 static _Atomic unsigned long peak_report_formatter_temp_counter;
 
+typedef struct {
+    uint32_t mask;
+    const char* name;
+} PeakReportCapabilityName;
+
+static const PeakReportCapabilityName peak_report_capability_names[] = {
+    { PEAK_CAPABILITY_CPU_TARGET, "cpu-target" },
+    { PEAK_CAPABILITY_STRICT_MUTATION, "strict-mutation" },
+    { PEAK_CAPABILITY_CUDA, "cuda" },
+    { PEAK_CAPABILITY_MEMORY, "memory" },
+    { PEAK_CAPABILITY_JIT, "jit" },
+    { PEAK_CAPABILITY_DYNAMIC_DSO, "dynamic-dso" },
+    { PEAK_CAPABILITY_MPI_REPORT, "mpi-report" },
+    { PEAK_CAPABILITY_SOCKET_REPORT, "socket-report" },
+    { PEAK_CAPABILITY_LOCAL_REPORT, "local-report" },
+};
+
 static long
 peak_report_formatter_name_max(int dirfd)
 {
@@ -573,6 +590,15 @@ peak_report_formatter_write_csv_name(FILE* csv, const char* name)
 static bool
 peak_report_formatter_has_csv_output(const PeakReportSnapshot* snapshot)
 {
+    const PeakProfilerCapabilityManifest* capabilities =
+        &snapshot->capabilities;
+
+    if (snapshot->degraded_mask != PEAK_PROFILER_DEGRADED_NONE ||
+        capabilities->requested != 0 || capabilities->active != 0 ||
+        capabilities->partial != 0 || capabilities->retained != 0 ||
+        capabilities->failed != 0) {
+        return true;
+    }
     if (snapshot->dropped_calls != 0 || snapshot->dropped_threads != 0) {
         return true;
     }
@@ -751,7 +777,11 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         "function,"
         "count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
-        "dropped_calls,dropped_threads\n";
+        "dropped_calls,dropped_threads,"
+        "capability_requested,capability_compiled,capability_active,"
+        "capability_partial,capability_retained,capability_failed,"
+        "cuda_compiled_apis,cuda_found_apis,cuda_installed_apis,"
+        "cuda_failed_apis,degraded_mask\n";
     char* temp_csv;
     PeakReportCsvDestination destination = {.dirfd = -1};
     FILE* csv;
@@ -824,7 +854,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
                   fprintf(
                       csv,
                       ",%lu,%lu,%.12Lg,%.9e,%.9e,%.9e,%.9e,%.9e,%.9e,%.9e,"
-                      "%llu,%llu\n",
+                      "%llu,%llu,0,0,0,0,0,0,0,0,0,0,0\n",
                       snapshot->num_calls[i],
                       peak_report_calls_per_active_thread(
                           snapshot->num_calls[i], snapshot->thread_count[i]),
@@ -845,9 +875,54 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(
                       csv, "PEAK_ACCOUNTING_DIAGNOSTICS") &&
                   fprintf(csv,
-                          ",0,0,0,0,0,0,0,0,0,0,%llu,%llu\n",
+                          ",0,0,0,0,0,0,0,0,0,0,%llu,%llu,"
+                          "0,0,0,0,0,0,0,0,0,0,0\n",
                           (unsigned long long)snapshot->dropped_calls,
                           (unsigned long long)snapshot->dropped_threads) >= 0;
+    }
+    for (size_t capability = 0;
+         success && capability < sizeof(peak_report_capability_names) /
+                                     sizeof(peak_report_capability_names[0]);
+         capability++) {
+        const uint32_t mask = peak_report_capability_names[capability].mask;
+        char row_name[64];
+
+        if (snprintf(row_name, sizeof(row_name), "PEAK_CAPABILITY_%s",
+                     peak_report_capability_names[capability].name) >=
+            (int)sizeof(row_name)) {
+            success = false;
+            break;
+        }
+        success = peak_report_formatter_write_csv_name(csv, row_name) &&
+                  fprintf(
+                      csv,
+                      ",0,0,0,0,0,0,0,0,0,0,0,0,%d,%d,%d,%d,%d,%d,"
+                      "0,0,0,0,0\n",
+                      (snapshot->capabilities.requested & mask) != 0,
+                      (snapshot->capabilities.compiled & mask) != 0,
+                      (snapshot->capabilities.active & mask) != 0,
+                      (snapshot->capabilities.partial & mask) != 0,
+                      (snapshot->capabilities.retained & mask) != 0,
+                      (snapshot->capabilities.failed & mask) != 0) >= 0;
+    }
+    if (success) {
+        success = peak_report_formatter_write_csv_name(
+                      csv, "PEAK_CUDA_API_COVERAGE") &&
+                  fprintf(csv,
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          "%u,%u,%u,%u,0\n",
+                          snapshot->capabilities.cuda_compiled_apis,
+                          snapshot->capabilities.cuda_found_apis,
+                          snapshot->capabilities.cuda_installed_apis,
+                          snapshot->capabilities.cuda_failed_apis) >= 0;
+    }
+    if (success) {
+        success = peak_report_formatter_write_csv_name(
+                      csv, "PEAK_DEGRADED_CAPABILITIES") &&
+                  fprintf(csv,
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          "0,0,0,0,%u\n",
+                          snapshot->degraded_mask) >= 0;
     }
     if (!success || ferror(csv)) {
         success = false;
@@ -1027,28 +1102,15 @@ peak_report_formatter_write_text(
                         reasons[0] != '\0' ? reasons : "unknown");
     }
     {
-        static const struct {
-            uint32_t mask;
-            const char* name;
-        } capability_names[] = {
-            { PEAK_CAPABILITY_CPU_TARGET, "cpu-target" },
-            { PEAK_CAPABILITY_STRICT_MUTATION, "strict-mutation" },
-            { PEAK_CAPABILITY_CUDA, "cuda" },
-            { PEAK_CAPABILITY_MEMORY, "memory" },
-            { PEAK_CAPABILITY_JIT, "jit" },
-            { PEAK_CAPABILITY_DYNAMIC_DSO, "dynamic-dso" },
-            { PEAK_CAPABILITY_MPI_REPORT, "mpi-report" },
-            { PEAK_CAPABILITY_SOCKET_REPORT, "socket-report" },
-            { PEAK_CAPABILITY_LOCAL_REPORT, "local-report" },
-        };
         for (size_t capability = 0;
-             capability < sizeof(capability_names) /
-                              sizeof(capability_names[0]);
+             capability < sizeof(peak_report_capability_names) /
+                              sizeof(peak_report_capability_names[0]);
              capability++) {
-            const uint32_t mask = capability_names[capability].mask;
+            const uint32_t mask =
+                peak_report_capability_names[capability].mask;
             peak_log_report(
                 "Profiler capability [%s]: requested=%d compiled=%d active=%d partial=%d retained=%d failed=%d\n",
-                capability_names[capability].name,
+                peak_report_capability_names[capability].name,
                 (snapshot->capabilities.requested & mask) != 0,
                 (snapshot->capabilities.compiled & mask) != 0,
                 (snapshot->capabilities.active & mask) != 0,

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -1026,6 +1026,43 @@ peak_report_formatter_write_text(
         peak_log_report("Profiler degraded mode: enabled reasons=%s\n",
                         reasons[0] != '\0' ? reasons : "unknown");
     }
+    {
+        static const struct {
+            uint32_t mask;
+            const char* name;
+        } capability_names[] = {
+            { PEAK_CAPABILITY_CPU_TARGET, "cpu-target" },
+            { PEAK_CAPABILITY_STRICT_MUTATION, "strict-mutation" },
+            { PEAK_CAPABILITY_CUDA, "cuda" },
+            { PEAK_CAPABILITY_MEMORY, "memory" },
+            { PEAK_CAPABILITY_JIT, "jit" },
+            { PEAK_CAPABILITY_DYNAMIC_DSO, "dynamic-dso" },
+            { PEAK_CAPABILITY_MPI_REPORT, "mpi-report" },
+            { PEAK_CAPABILITY_SOCKET_REPORT, "socket-report" },
+            { PEAK_CAPABILITY_LOCAL_REPORT, "local-report" },
+        };
+        for (size_t capability = 0;
+             capability < sizeof(capability_names) /
+                              sizeof(capability_names[0]);
+             capability++) {
+            const uint32_t mask = capability_names[capability].mask;
+            peak_log_report(
+                "Profiler capability [%s]: requested=%d compiled=%d active=%d partial=%d retained=%d failed=%d\n",
+                capability_names[capability].name,
+                (snapshot->capabilities.requested & mask) != 0,
+                (snapshot->capabilities.compiled & mask) != 0,
+                (snapshot->capabilities.active & mask) != 0,
+                (snapshot->capabilities.partial & mask) != 0,
+                (snapshot->capabilities.retained & mask) != 0,
+                (snapshot->capabilities.failed & mask) != 0);
+        }
+        peak_log_report(
+            "Profiler CUDA API coverage: compiled=0x%08x found=0x%08x installed=0x%08x failed=0x%08x\n",
+            snapshot->capabilities.cuda_compiled_apis,
+            snapshot->capabilities.cuda_found_apis,
+            snapshot->capabilities.cuda_installed_apis,
+            snapshot->capabilities.cuda_failed_apis);
+    }
     if (snapshot->dropped_calls != 0 || snapshot->dropped_threads != 0) {
         peak_log_report("Accounting diagnostics: dropped_calls=%llu dropped_threads=%llu "
                         "(untracked, overflow, or unowned callers excluded)\n",

--- a/src/general_listener/report_snapshot.c
+++ b/src/general_listener/report_snapshot.c
@@ -84,6 +84,90 @@ PEAK_CAPABILITY_NOTE(peak_report_capability_note_failed,
 
 #undef PEAK_CAPABILITY_NOTE
 
+static uint32_t
+peak_report_capability_replace_mask(uint32_t value,
+                                    uint32_t mask,
+                                    uint32_t replacement)
+{
+    return (value & ~mask) | (replacement & mask);
+}
+
+void
+peak_report_capability_manifest_set_output_outcome(
+    PeakProfilerCapabilityManifest* manifest,
+    uint32_t requested,
+    uint32_t active)
+{
+    uint32_t mismatch;
+
+    if (manifest == NULL) {
+        return;
+    }
+    requested &= PEAK_CAPABILITY_REPORT_TRANSPORTS;
+    active &= PEAK_CAPABILITY_REPORT_TRANSPORTS;
+    mismatch = requested != active ? requested : 0;
+    manifest->requested |= requested;
+    manifest->active = peak_report_capability_replace_mask(
+        manifest->active,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        active);
+    manifest->partial = peak_report_capability_replace_mask(
+        manifest->partial,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        mismatch);
+    manifest->failed = peak_report_capability_replace_mask(
+        manifest->failed,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        mismatch);
+}
+
+static void
+peak_report_capability_atomic_replace_mask(_Atomic uint32_t* destination,
+                                           uint32_t mask,
+                                           uint32_t replacement)
+{
+    uint32_t observed = atomic_load_explicit(destination,
+                                             memory_order_acquire);
+
+    for (;;) {
+        uint32_t desired = peak_report_capability_replace_mask(
+            observed, mask, replacement);
+        if (atomic_compare_exchange_weak_explicit(destination,
+                                                  &observed,
+                                                  desired,
+                                                  memory_order_acq_rel,
+                                                  memory_order_acquire)) {
+            return;
+        }
+    }
+}
+
+void
+peak_report_capability_set_output_outcome(uint32_t requested,
+                                          uint32_t active)
+{
+    uint32_t mismatch;
+
+    requested &= PEAK_CAPABILITY_REPORT_TRANSPORTS;
+    active &= PEAK_CAPABILITY_REPORT_TRANSPORTS;
+    mismatch = requested != active ? requested : 0;
+    atomic_fetch_or_explicit(&peak_capability_requested,
+                             requested,
+                             memory_order_acq_rel);
+    peak_report_capability_atomic_replace_mask(
+        &peak_capability_active,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        active);
+    peak_report_capability_atomic_replace_mask(
+        &peak_capability_partial,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        mismatch);
+    peak_report_capability_atomic_replace_mask(
+        &peak_capability_failed,
+        PEAK_CAPABILITY_REPORT_TRANSPORTS,
+        mismatch);
+}
+
 void
 peak_report_capability_set_cuda_apis(uint32_t compiled,
                                      uint32_t found,

--- a/src/general_listener/report_snapshot.c
+++ b/src/general_listener/report_snapshot.c
@@ -8,6 +8,16 @@
 static PeakReportOverhead peak_report_snapshot_transport_overhead;
 static _Atomic uint32_t peak_report_snapshot_degraded = 0;
 static _Atomic uint32_t peak_report_snapshot_warned = 0;
+static _Atomic uint32_t peak_capability_requested = 0;
+static _Atomic uint32_t peak_capability_compiled = 0;
+static _Atomic uint32_t peak_capability_active = 0;
+static _Atomic uint32_t peak_capability_partial = 0;
+static _Atomic uint32_t peak_capability_retained = 0;
+static _Atomic uint32_t peak_capability_failed = 0;
+static _Atomic uint32_t peak_cuda_compiled_apis = 0;
+static _Atomic uint32_t peak_cuda_found_apis = 0;
+static _Atomic uint32_t peak_cuda_installed_apis = 0;
+static _Atomic uint32_t peak_cuda_failed_apis = 0;
 
 typedef struct {
     uint32_t mask;
@@ -19,7 +29,140 @@ static const PeakReportDegradedReason peak_report_degraded_reasons[] = {
     { PEAK_PROFILER_DEGRADED_REPORT, "report-allocation" },
     { PEAK_PROFILER_DEGRADED_MEMORY_TRACKING, "memory-tracking" },
     { PEAK_PROFILER_DEGRADED_EXIT_INTERPOSER, "exit-interposer" },
+    { PEAK_PROFILER_DEGRADED_CUDA, "cuda" },
+    { PEAK_PROFILER_DEGRADED_JIT, "jit" },
+    { PEAK_PROFILER_DEGRADED_DYNAMIC_DSO, "dynamic-dso" },
 };
+
+void
+peak_report_capability_reset(const PeakProfilerCapabilityManifest* manifest)
+{
+    const PeakProfilerCapabilityManifest empty = {0};
+    const PeakProfilerCapabilityManifest* value =
+        manifest != NULL ? manifest : &empty;
+
+    atomic_store_explicit(&peak_capability_requested, value->requested,
+                          memory_order_release);
+    atomic_store_explicit(&peak_capability_compiled, value->compiled,
+                          memory_order_release);
+    atomic_store_explicit(&peak_capability_active, value->active,
+                          memory_order_release);
+    atomic_store_explicit(&peak_capability_partial, value->partial,
+                          memory_order_release);
+    atomic_store_explicit(&peak_capability_retained, value->retained,
+                          memory_order_release);
+    atomic_store_explicit(&peak_capability_failed, value->failed,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_compiled_apis,
+                          value->cuda_compiled_apis,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_found_apis, value->cuda_found_apis,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_installed_apis,
+                          value->cuda_installed_apis,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_failed_apis, value->cuda_failed_apis,
+                          memory_order_release);
+}
+
+#define PEAK_CAPABILITY_NOTE(_name, _field)                                  \
+    void _name(uint32_t mask)                                                \
+    {                                                                        \
+        atomic_fetch_or_explicit(&_field, mask, memory_order_acq_rel);        \
+    }
+
+PEAK_CAPABILITY_NOTE(peak_report_capability_note_requested,
+                     peak_capability_requested)
+PEAK_CAPABILITY_NOTE(peak_report_capability_note_active,
+                     peak_capability_active)
+PEAK_CAPABILITY_NOTE(peak_report_capability_note_partial,
+                     peak_capability_partial)
+PEAK_CAPABILITY_NOTE(peak_report_capability_note_retained,
+                     peak_capability_retained)
+PEAK_CAPABILITY_NOTE(peak_report_capability_note_failed,
+                     peak_capability_failed)
+
+#undef PEAK_CAPABILITY_NOTE
+
+void
+peak_report_capability_set_cuda_apis(uint32_t compiled,
+                                     uint32_t found,
+                                     uint32_t installed,
+                                     uint32_t failed)
+{
+    atomic_store_explicit(&peak_cuda_compiled_apis, compiled,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_found_apis, found,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_installed_apis, installed,
+                          memory_order_release);
+    atomic_store_explicit(&peak_cuda_failed_apis, failed,
+                          memory_order_release);
+}
+
+PeakProfilerCapabilityManifest
+peak_report_capability_manifest(void)
+{
+    PeakProfilerCapabilityManifest manifest = {0};
+
+    manifest.requested = atomic_load_explicit(&peak_capability_requested,
+                                               memory_order_acquire);
+    manifest.compiled = atomic_load_explicit(&peak_capability_compiled,
+                                              memory_order_acquire);
+    manifest.active = atomic_load_explicit(&peak_capability_active,
+                                            memory_order_acquire);
+    manifest.partial = atomic_load_explicit(&peak_capability_partial,
+                                             memory_order_acquire);
+    manifest.retained = atomic_load_explicit(&peak_capability_retained,
+                                              memory_order_acquire);
+    manifest.failed = atomic_load_explicit(&peak_capability_failed,
+                                            memory_order_acquire);
+    manifest.cuda_compiled_apis = atomic_load_explicit(
+        &peak_cuda_compiled_apis, memory_order_acquire);
+    manifest.cuda_found_apis = atomic_load_explicit(
+        &peak_cuda_found_apis, memory_order_acquire);
+    manifest.cuda_installed_apis = atomic_load_explicit(
+        &peak_cuda_installed_apis, memory_order_acquire);
+    manifest.cuda_failed_apis = atomic_load_explicit(
+        &peak_cuda_failed_apis, memory_order_acquire);
+    return manifest;
+}
+
+void
+peak_report_capability_manifest_merge(
+    PeakProfilerCapabilityManifest* aggregate,
+    const PeakProfilerCapabilityManifest* incoming)
+{
+    uint32_t active_difference;
+    uint32_t compiled_difference;
+    uint32_t cuda_found_difference;
+    uint32_t cuda_installed_difference;
+
+    if (aggregate == NULL || incoming == NULL) {
+        return;
+    }
+    active_difference = aggregate->active ^ incoming->active;
+    compiled_difference = aggregate->compiled ^ incoming->compiled;
+    cuda_found_difference =
+        aggregate->cuda_found_apis ^ incoming->cuda_found_apis;
+    cuda_installed_difference =
+        aggregate->cuda_installed_apis ^ incoming->cuda_installed_apis;
+    aggregate->requested |= incoming->requested;
+    aggregate->compiled &= incoming->compiled;
+    aggregate->active &= incoming->active;
+    aggregate->partial |= incoming->partial | active_difference;
+    aggregate->partial |= aggregate->requested & compiled_difference;
+    if (cuda_found_difference != 0 ||
+        cuda_installed_difference != 0) {
+        aggregate->partial |= PEAK_CAPABILITY_CUDA;
+    }
+    aggregate->retained |= incoming->retained;
+    aggregate->failed |= incoming->failed;
+    aggregate->cuda_compiled_apis &= incoming->cuda_compiled_apis;
+    aggregate->cuda_found_apis &= incoming->cuda_found_apis;
+    aggregate->cuda_installed_apis &= incoming->cuda_installed_apis;
+    aggregate->cuda_failed_apis |= incoming->cuda_failed_apis;
+}
 
 void
 peak_report_snapshot_note_degraded(uint32_t mask, const char* reason)
@@ -165,6 +308,7 @@ peak_report_snapshot_create(size_t hook_count)
     snapshot->hook_count = hook_count;
     snapshot->rank_count = 1;
     snapshot->degraded_mask = peak_report_snapshot_degraded_mask();
+    snapshot->capabilities = peak_report_capability_manifest();
     if (!peak_report_snapshot_allocate_arrays(snapshot)) {
         peak_report_snapshot_destroy(snapshot);
         return NULL;
@@ -261,6 +405,7 @@ peak_report_snapshot_clone(
     copy->dropped_calls = source->dropped_calls;
     copy->dropped_threads = source->dropped_threads;
     copy->degraded_mask = source->degraded_mask;
+    copy->capabilities = source->capabilities;
     copy->rank_count = source->rank_count;
     copy->overhead = source->overhead;
     return copy;

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -78,7 +78,7 @@
     "PEAK_TEST_OUTPUT_AGGREGATION_SESSION_ALLOC_FAIL"
 
 #define PEAK_SOCKET_REDUCE_MAGIC 0x5045414b52454431ULL
-#define PEAK_SOCKET_REDUCE_VERSION 13U
+#define PEAK_SOCKET_REDUCE_VERSION 14U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT 0x41U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT_CONFIRM 0x42U
 #define PEAK_SOCKET_REDUCE_GATHER_REGISTERED 0x01U
@@ -126,6 +126,17 @@ typedef struct {
     uint64_t dropped_threads;
     uint32_t local_ranks;
     uint32_t accounting_valid;
+    uint32_t degraded_mask;
+    uint32_t capability_requested;
+    uint32_t capability_compiled;
+    uint32_t capability_active;
+    uint32_t capability_partial;
+    uint32_t capability_retained;
+    uint32_t capability_failed;
+    uint32_t cuda_compiled_apis;
+    uint32_t cuda_found_apis;
+    uint32_t cuda_installed_apis;
+    uint32_t cuda_failed_apis;
 } PeakSocketReduceHeader;
 
 typedef struct {
@@ -155,19 +166,19 @@ typedef struct {
 } PeakSocketReduceRecord;
 
 /*
- * Wire-v13 intentionally targets a homogeneous job: every rank must use the
+ * Wire-v14 intentionally targets a homogeneous job: every rank must use the
  * same byte order, floating-point representation, and 64-bit Linux C ABI.
  * Lock the layouts so an accidental field or packing change cannot silently
  * corrupt a report without another wire-version bump.
  */
-_Static_assert(sizeof(PeakSocketReduceHeader) == 168,
-               "wire-v13 header layout changed");
+_Static_assert(sizeof(PeakSocketReduceHeader) == 216,
+               "wire-v14 header layout changed");
 _Static_assert(sizeof(PeakSocketReduceReleaseFrame) == 40,
-               "wire-v13 control-frame layout changed");
+               "wire-v14 control-frame layout changed");
 _Static_assert(sizeof(PeakSocketReduceRecord) == 80,
-               "wire-v13 record layout changed");
+               "wire-v14 record layout changed");
 _Static_assert(sizeof(unsigned long) == sizeof(uint64_t),
-               "wire-v13 requires a 64-bit unsigned long");
+               "wire-v14 requires a 64-bit unsigned long");
 
 struct PeakSocketReportSession {
     bool* release_targets;
@@ -2302,6 +2313,8 @@ typedef struct {
     uint64_t* dropped_calls;
     uint64_t* dropped_threads;
     bool* accounting_valid;
+    uint32_t* degraded_mask;
+    PeakProfilerCapabilityManifest* capabilities;
 } PeakSocketGatherAggregate;
 
 static bool
@@ -2333,6 +2346,8 @@ peak_socket_gather_prepare_receipt(
     const PeakReportRankTuple* tuple;
 
     if (connection == NULL || aggregate == NULL ||
+        aggregate->degraded_mask == NULL ||
+        aggregate->capabilities == NULL ||
         connection->record_index != aggregate->hook_count ||
         connection->record_bytes != 0 ||
         !peak_report_maxima_consider(aggregate->maxima,
@@ -2363,6 +2378,26 @@ peak_socket_gather_prepare_receipt(
         *aggregate->dropped_threads, connection->header.dropped_threads);
     *aggregate->accounting_valid =
         *aggregate->accounting_valid && tuple->accounting_valid;
+    *aggregate->degraded_mask |= connection->header.degraded_mask;
+    {
+        PeakProfilerCapabilityManifest peer_capabilities = {
+            .requested = connection->header.capability_requested,
+            .compiled = connection->header.capability_compiled,
+            .active = connection->header.capability_active,
+            .partial = connection->header.capability_partial,
+            .retained = connection->header.capability_retained,
+            .failed = connection->header.capability_failed,
+            .cuda_compiled_apis =
+                connection->header.cuda_compiled_apis,
+            .cuda_found_apis = connection->header.cuda_found_apis,
+            .cuda_installed_apis =
+                connection->header.cuda_installed_apis,
+            .cuda_failed_apis = connection->header.cuda_failed_apis,
+        };
+
+        peak_report_capability_manifest_merge(
+            aggregate->capabilities, &peer_capabilities);
+    }
 #ifdef PEAK_ENABLE_TEST_HOOKS
     if (peak_socket_test_telemetry.root_payload_count <
         UINT32_MAX) {
@@ -3398,6 +3433,17 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     header.session_token = session_token;
     header.dropped_calls = local->dropped_calls;
     header.dropped_threads = local->dropped_threads;
+    header.degraded_mask = local->degraded_mask;
+    header.capability_requested = local->capabilities.requested;
+    header.capability_compiled = local->capabilities.compiled;
+    header.capability_active = local->capabilities.active;
+    header.capability_partial = local->capabilities.partial;
+    header.capability_retained = local->capabilities.retained;
+    header.capability_failed = local->capabilities.failed;
+    header.cuda_compiled_apis = local->capabilities.cuda_compiled_apis;
+    header.cuda_found_apis = local->capabilities.cuda_found_apis;
+    header.cuda_installed_apis = local->capabilities.cuda_installed_apis;
+    header.cuda_failed_apis = local->capabilities.cuda_failed_apis;
     peak_socket_reduce_header_set_report_tuple(&header, &local_report_tuple);
 
     if (rank != 0) {
@@ -3451,6 +3497,9 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     uint64_t socket_dropped_calls = local->dropped_calls;
     uint64_t socket_dropped_threads = local->dropped_threads;
     bool socket_accounting_valid = local->overhead.accounting_valid;
+    uint32_t socket_degraded_mask = local->degraded_mask;
+    PeakProfilerCapabilityManifest socket_capabilities =
+        local->capabilities;
     unsigned int received = 0;
     bool failed;
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -3498,6 +3547,8 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     gather_aggregate.dropped_calls = &socket_dropped_calls;
     gather_aggregate.dropped_threads = &socket_dropped_threads;
     gather_aggregate.accounting_valid = &socket_accounting_valid;
+    gather_aggregate.degraded_mask = &socket_degraded_mask;
+    gather_aggregate.capabilities = &socket_capabilities;
 #ifdef PEAK_ENABLE_TEST_HOOKS
     {
         int listener_ready = peak_socket_test_listener_ready_signal_root();
@@ -3576,6 +3627,8 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     free(aggregate_records);
     aggregate->dropped_calls = socket_dropped_calls;
     aggregate->dropped_threads = socket_dropped_threads;
+    aggregate->degraded_mask = socket_degraded_mask;
+    aggregate->capabilities = socket_capabilities;
     aggregate->rank_count = size;
     peak_socket_report_set_aggregate_overhead(
         aggregate,

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -876,6 +877,25 @@ peak_jit_provider_enable(void)
                    0,
                    "enabled");
     peak_general_listener_controller_wake();
+}
+
+gboolean
+peak_jit_provider_requested(void)
+{
+    const char* value = getenv(PEAK_JIT_ENABLE_ENV);
+
+    /* This query runs before Gum initializes its embedded GLib runtime. */
+    return value != NULL &&
+           (strcmp(value, "1") == 0 ||
+            strcasecmp(value, "true") == 0 ||
+            strcasecmp(value, "yes") == 0 ||
+            strcasecmp(value, "on") == 0);
+}
+
+gboolean
+peak_jit_provider_is_active(void)
+{
+    return peak_jit_provider_enabled;
 }
 
 void

--- a/src/peak.c
+++ b/src/peak.c
@@ -107,6 +107,15 @@ gboolean peak_gpu_monitor_all = false;
 gboolean peak_truncate_function_name = false;
 gboolean peak_memory_profile = false;
 gboolean peak_memory_track_all = false;
+typedef struct {
+    gboolean cpu;
+    gboolean gpu;
+    gboolean memory;
+    gboolean jit;
+} PeakRequestedWork;
+static PeakRequestedWork peak_requested_work;
+static PeakOutputAggregationMode peak_requested_output_aggregation =
+    PEAK_OUTPUT_AGGREGATION_LOCAL;
 #ifdef HAVE_MPI
 static int found_MPI;
 #endif
@@ -219,6 +228,14 @@ static _Atomic int peak_test_activation_pause = 0;
 static _Atomic int peak_test_activation_held = 0;
 static _Atomic int peak_test_activation_released = 0;
 static _Atomic int peak_test_fail_heartbeat_create = 0;
+
+PEAK_API int
+peak_test_cpu_target_storage_allocated(void)
+{
+    return peak_target_thread_called != NULL ||
+           peak_target_thread_called_count != 0 ||
+           peak_need_detach != NULL || peak_detached != NULL;
+}
 
 void
 peak_test_fail_heartbeat_create_once(void)
@@ -730,10 +747,77 @@ peak_fini_cancellation_restore(int saved_state)
 static gboolean
 peak_has_requested_work(void)
 {
-    return peak_hook_address_count > 0 ||
-           peak_gpu_hook_address_count > 0 ||
-           peak_gpu_monitor_all ||
-           peak_memory_profile;
+    return peak_requested_work.cpu ||
+           peak_requested_work.gpu ||
+           peak_requested_work.memory ||
+           peak_requested_work.jit;
+}
+
+static void
+peak_freeze_capability_requests(void)
+{
+    PeakProfilerCapabilityManifest manifest = {0};
+
+    manifest.compiled =
+        PEAK_CAPABILITY_CPU_TARGET |
+        PEAK_CAPABILITY_STRICT_MUTATION |
+        PEAK_CAPABILITY_LOCAL_REPORT |
+        PEAK_CAPABILITY_SOCKET_REPORT;
+#ifdef HAVE_CUDA
+    manifest.compiled |= PEAK_CAPABILITY_CUDA;
+    manifest.cuda_compiled_apis =
+        cuda_interceptor_compiled_api_mask();
+#endif
+#if !defined(__APPLE__)
+    manifest.compiled |=
+        PEAK_CAPABILITY_MEMORY |
+        PEAK_CAPABILITY_JIT |
+        PEAK_CAPABILITY_DYNAMIC_DSO;
+#endif
+#ifdef HAVE_MPI
+    manifest.compiled |= PEAK_CAPABILITY_MPI_REPORT;
+#endif
+    if (peak_requested_work.cpu) {
+        manifest.requested |=
+            PEAK_CAPABILITY_CPU_TARGET |
+            PEAK_CAPABILITY_STRICT_MUTATION;
+    }
+    if (peak_requested_work.gpu) {
+        manifest.requested |= PEAK_CAPABILITY_CUDA;
+    }
+    if (peak_requested_work.memory) {
+        manifest.requested |= PEAK_CAPABILITY_MEMORY;
+    }
+    if (peak_requested_work.jit) {
+        manifest.requested |= PEAK_CAPABILITY_JIT;
+    }
+    peak_report_capability_reset(&manifest);
+}
+
+static uint32_t
+peak_output_capability(PeakOutputAggregationMode mode)
+{
+    if (mode == PEAK_OUTPUT_AGGREGATION_MPI) {
+        return PEAK_CAPABILITY_MPI_REPORT;
+    }
+    if (mode == PEAK_OUTPUT_AGGREGATION_SOCKET) {
+        return PEAK_CAPABILITY_SOCKET_REPORT;
+    }
+    return PEAK_CAPABILITY_LOCAL_REPORT;
+}
+
+static void
+peak_note_output_capability(PeakOutputAggregationMode actual)
+{
+    const uint32_t requested =
+        peak_output_capability(peak_requested_output_aggregation);
+    const uint32_t active = peak_output_capability(actual);
+
+    peak_report_capability_note_active(active);
+    if (requested != active) {
+        peak_report_capability_note_partial(requested);
+        peak_report_capability_note_failed(requested);
+    }
 }
 
 #ifdef HAVE_MPI
@@ -977,22 +1061,65 @@ peak_activate_runtime(void)
     }
 #ifdef HAVE_MPI
     if (found_MPI && mpi_interceptor_attach() != 0) {
+        if (peak_requested_output_aggregation ==
+            PEAK_OUTPUT_AGGREGATION_MPI) {
+            peak_report_capability_note_failed(
+                PEAK_CAPABILITY_MPI_REPORT);
+        }
         found_MPI = 0;
     }
 #endif
 #ifdef HAVE_CUDA
-    cuda_interceptor_attach();
+    if (peak_requested_work.gpu) {
+        int cuda_attach_result = cuda_interceptor_attach();
+        PeakCudaCapabilities capabilities =
+            cuda_interceptor_get_capabilities();
+
+        peak_report_capability_set_cuda_apis(
+            capabilities.compiled_apis,
+            capabilities.found_apis,
+            capabilities.installed_apis,
+            capabilities.failed_apis);
+        if (capabilities.active) {
+            peak_report_capability_note_active(PEAK_CAPABILITY_CUDA);
+        }
+        if (capabilities.partial) {
+            peak_report_capability_note_partial(PEAK_CAPABILITY_CUDA);
+        }
+        if (cuda_attach_result != GUM_REPLACE_OK || !capabilities.active) {
+            peak_report_capability_note_failed(PEAK_CAPABILITY_CUDA);
+        }
+        if (!capabilities.active) {
+            peak_report_snapshot_note_degraded(
+                PEAK_PROFILER_DEGRADED_CUDA,
+                "CUDA interception unavailable");
+        }
+    }
 #endif
     /* General-listener hooks depend on pthread and MPI interception setup. */
-    peak_target_thread_called = g_new0(gboolean*, peak_hook_address_count);
-    peak_target_thread_called_count = peak_hook_address_count;
-    for (gint i = 0; i < peak_hook_address_count; i++) {
-        peak_target_thread_called[i] = g_new0(gboolean, peak_max_num_threads);
+    if (peak_requested_work.cpu) {
+        peak_target_thread_called =
+            g_new0(gboolean*, peak_hook_address_count);
+        peak_target_thread_called_count = peak_hook_address_count;
+        for (gint i = 0; i < peak_hook_address_count; i++) {
+            peak_target_thread_called[i] =
+                g_new0(gboolean, peak_max_num_threads);
+        }
+        peak_need_detach = g_new0(gboolean, peak_hook_address_count);
+        peak_detached = g_new0(gboolean, peak_hook_address_count);
     }
-    peak_need_detach = g_new0(gboolean, peak_hook_address_count);
-    peak_detached = g_new0(gboolean, peak_hook_address_count);
 #if !defined(__APPLE__)
-    peak_jit_provider_enable();
+    if (peak_requested_work.jit) {
+        peak_jit_provider_enable();
+        if (peak_jit_provider_is_active()) {
+            peak_report_capability_note_active(PEAK_CAPABILITY_JIT);
+        } else {
+            peak_report_capability_note_failed(PEAK_CAPABILITY_JIT);
+            peak_report_snapshot_note_degraded(
+                PEAK_PROFILER_DEGRADED_JIT,
+                "JIT provider unavailable");
+        }
+    }
 #endif
     /*
      * This is the post-MPI module rescan. Gum initialization and this scan
@@ -1000,12 +1127,27 @@ peak_activate_runtime(void)
      * libfabric, libnuma, and any other providers that MPI_Init loaded before
      * target attachment begins.
      */
-    peak_general_listener_attach();
+    if (peak_requested_work.cpu) {
+        peak_general_listener_attach();
+        peak_report_capability_note_active(
+            PEAK_CAPABILITY_CPU_TARGET |
+            PEAK_CAPABILITY_STRICT_MUTATION);
+    }
 #if !defined(__APPLE__)
-    gboolean need_dynamic_attach = peak_general_listener_needs_dynamic_attach();
+    gboolean need_dynamic_attach = peak_requested_work.cpu &&
+        peak_general_listener_needs_dynamic_attach();
     gboolean dynamic_attach_listener_ready = FALSE;
     if (need_dynamic_attach) {
+        peak_report_capability_note_requested(
+            PEAK_CAPABILITY_DYNAMIC_DSO);
         dynamic_attach_listener_ready = dlopen_interceptor_attach() == 0;
+        if (!dynamic_attach_listener_ready) {
+            peak_report_capability_note_failed(
+                PEAK_CAPABILITY_DYNAMIC_DSO);
+            peak_report_snapshot_note_degraded(
+                PEAK_PROFILER_DEGRADED_DYNAMIC_DSO,
+                "dynamic DSO listener unavailable");
+        }
     }
 #endif
     peak_main_time = peak_second();
@@ -1046,18 +1188,24 @@ peak_activate_runtime(void)
         PeakMallocInterceptorAttachResult memory_attach_result =
             malloc_interceptor_attach();
         if (memory_attach_result != PEAK_MALLOC_ATTACH_OK) {
+            peak_report_capability_note_failed(PEAK_CAPABILITY_MEMORY);
             peak_report_snapshot_note_degraded(
                 PEAK_PROFILER_DEGRADED_MEMORY_TRACKING,
                 memory_attach_result == PEAK_MALLOC_ATTACH_ROLLED_BACK
                     ? "memory interceptor installation rolled back safely"
                     : "memory tracking setup failed before installation");
             peak_memory_profile = false;
+        } else {
+            peak_report_capability_note_active(PEAK_CAPABILITY_MEMORY);
         }
     }
-    peak_general_listener_controller_start();
+    if (peak_requested_work.cpu || peak_requested_work.jit) {
+        peak_general_listener_controller_start();
+    }
 #if !defined(__APPLE__)
     if (dynamic_attach_listener_ready) {
         dlopen_interceptor_enable_dynamic_attach();
+        peak_report_capability_note_active(PEAK_CAPABILITY_DYNAMIC_DSO);
     }
 #endif
     if (heartbeat_time != 0) {
@@ -1233,6 +1381,16 @@ void peak_init()
     peak_memory_profile = false;
     peak_memory_track_all = false;
 #endif
+    peak_requested_work.cpu = peak_hook_address_count > 0;
+    peak_requested_work.gpu =
+        peak_gpu_hook_address_count > 0 || peak_gpu_monitor_all;
+    peak_requested_work.memory = peak_memory_profile;
+#if defined(__APPLE__)
+    peak_requested_work.jit = FALSE;
+#else
+    peak_requested_work.jit = peak_jit_provider_requested();
+#endif
+    peak_freeze_capability_requests();
 
     gboolean has_requested_work = peak_has_requested_work();
     peak_set_process_requests_work(has_requested_work);
@@ -1274,10 +1432,16 @@ void peak_init()
     if (activate_post_mpi_init) {
         found_MPI = 1;
     }
+    peak_requested_output_aggregation =
+        found_MPI ? peak_output_aggregation_mode()
+                  : PEAK_OUTPUT_AGGREGATION_LOCAL;
     peak_detach_controller_configure_mpi_process(found_MPI != 0);
 #else
+    peak_requested_output_aggregation = PEAK_OUTPUT_AGGREGATION_LOCAL;
     peak_detach_controller_configure_mpi_process(FALSE);
 #endif
+    peak_report_capability_note_requested(
+        peak_output_capability(peak_requested_output_aggregation));
     atomic_store_explicit(&peak_runtime_activation_state,
                           PEAK_RUNTIME_ACTIVATION_READY,
                           memory_order_release);
@@ -1365,7 +1529,9 @@ peak_fini_impl(void)
         g_free(heartbeat_overhead);
         heartbeat_overhead = NULL;
     }
-    peak_jit_provider_disable();
+    if (peak_requested_work.jit) {
+        peak_jit_provider_disable();
+    }
 #if !defined(__APPLE__)
     if (
 #ifdef HAVE_MPI
@@ -1408,7 +1574,7 @@ peak_fini_impl(void)
         atomic_load_explicit(&peak_exit_status_value, memory_order_acquire);
     int abnormal_exit = exit_status_known == 2 && exit_status != 0;
     PeakOutputAggregationMode aggregation_mode =
-        found_MPI ? peak_output_aggregation_mode()
+        found_MPI ? peak_requested_output_aggregation
                   : PEAK_OUTPUT_AGGREGATION_LOCAL;
     int local_requested_mpi_finalize =
         mpi_interceptor_finalize_was_requested();
@@ -1462,6 +1628,7 @@ peak_fini_impl(void)
         } else if (found_MPI && mpi_collectives_failed_closed && mpi_log_rank) {
             g_printerr("[peak] PEAK MPI collective path was already failed closed; writing rank-local output without touching MPI again\n");
         }
+        peak_note_output_capability(output_mode);
         used_mpi_aggregation =
             peak_general_listener_print_with_mpi_job_policy(
                 output_mode,
@@ -1563,6 +1730,7 @@ peak_fini_impl(void)
                    mpi_log_rank) {
             g_printerr("[peak] Aggregate output was not proven safe; writing rank-local output before process exit\n");
         }
+        peak_note_output_capability(output_mode);
         used_mpi_aggregation =
             peak_general_listener_print_with_mpi_job_policy(
                 output_mode,
@@ -1587,6 +1755,7 @@ peak_fini_impl(void)
         }
     }
     #ifdef HAVE_CUDA
+    if (peak_requested_work.gpu) {
         cuda_interceptor_print_with_mpi_job_policy(
             (mpi_reducer_failed_closed ||
              (output_mode == PEAK_OUTPUT_AGGREGATION_MPI &&
@@ -1612,6 +1781,7 @@ peak_fini_impl(void)
         if (!mpi_finalize_path) {
             cuda_interceptor_dettach();
         }
+    }
     #else
         (void)used_mpi_aggregation;
     #endif
@@ -1729,11 +1899,14 @@ peak_fini_impl(void)
         return;
     }
 #else
+    peak_note_output_capability(PEAK_OUTPUT_AGGREGATION_LOCAL);
     (void)peak_general_listener_print(0, NULL);
     #ifdef HAVE_CUDA
+    if (peak_requested_work.gpu) {
     cuda_interceptor_print_with_mpi_job_policy(
         PEAK_OUTPUT_AGGREGATION_LOCAL, FALSE);
     cuda_interceptor_dettach();
+    }
     #endif
 #endif
     gboolean general_listener_shutdown_flushed = peak_general_listener_dettach();

--- a/src/peak.c
+++ b/src/peak.c
@@ -760,9 +760,17 @@ peak_freeze_capability_requests(void)
 
     manifest.compiled =
         PEAK_CAPABILITY_CPU_TARGET |
-        PEAK_CAPABILITY_STRICT_MUTATION |
         PEAK_CAPABILITY_LOCAL_REPORT |
         PEAK_CAPABILITY_SOCKET_REPORT;
+#if defined(PEAK_HAVE_GUM_PEAK_PC_API) || \
+    defined(PEAK_HAVE_GUM_DARWIN_PATCH_API)
+    manifest.compiled |= PEAK_CAPABILITY_STRICT_MUTATION;
+#endif
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (getenv("PEAK_TEST_HIDE_COMPILED_STRICT_MUTATION") != NULL) {
+        manifest.compiled &= ~PEAK_CAPABILITY_STRICT_MUTATION;
+    }
+#endif
 #ifdef HAVE_CUDA
     manifest.compiled |= PEAK_CAPABILITY_CUDA;
     manifest.cuda_compiled_apis =
@@ -807,6 +815,12 @@ peak_disable_uncompiled_requested_work(void)
         peak_report_capability_manifest();
     uint32_t unavailable = manifest.requested & ~manifest.compiled;
 
+    if ((unavailable & PEAK_CAPABILITY_STRICT_MUTATION) != 0) {
+        peak_report_capability_note_partial(
+            PEAK_CAPABILITY_STRICT_MUTATION);
+        peak_report_capability_note_failed(
+            PEAK_CAPABILITY_STRICT_MUTATION);
+    }
     if ((unavailable & PEAK_CAPABILITY_CUDA) != 0) {
         peak_requested_work.gpu = FALSE;
         peak_report_capability_note_failed(PEAK_CAPABILITY_CUDA);
@@ -1159,9 +1173,12 @@ peak_activate_runtime(void)
      */
     if (peak_requested_work.cpu) {
         peak_general_listener_attach();
-        peak_report_capability_note_active(
-            PEAK_CAPABILITY_CPU_TARGET |
-            PEAK_CAPABILITY_STRICT_MUTATION);
+        peak_report_capability_note_active(PEAK_CAPABILITY_CPU_TARGET);
+        if ((peak_report_capability_manifest().compiled &
+             PEAK_CAPABILITY_STRICT_MUTATION) != 0) {
+            peak_report_capability_note_active(
+                PEAK_CAPABILITY_STRICT_MUTATION);
+        }
     }
 #if !defined(__APPLE__)
     gboolean need_dynamic_attach = peak_requested_work.cpu &&

--- a/src/peak.c
+++ b/src/peak.c
@@ -1037,6 +1037,7 @@ peak_activate_runtime(void)
 {
     int expected = PEAK_RUNTIME_ACTIVATION_READY;
     gboolean jit_provider_active = FALSE;
+    gboolean strict_mutation_active = FALSE;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
     peak_test_activation_pause_before_claim();
@@ -1167,7 +1168,6 @@ peak_activate_runtime(void)
      */
     if (peak_requested_work.cpu) {
         PeakProfilerCapabilityManifest capabilities;
-        gboolean strict_mutation_active;
 
         peak_general_listener_attach();
         peak_report_capability_note_active(PEAK_CAPABILITY_CPU_TARGET);
@@ -1208,7 +1208,8 @@ peak_activate_runtime(void)
 #endif
     peak_main_time = peak_second();
     peak_general_listener_note_runtime_start(peak_main_time);
-    if (peak_requested_work.cpu && heartbeat_time != 0) {
+    if (peak_requested_work.cpu && strict_mutation_active &&
+        heartbeat_time != 0) {
 #ifdef PEAK_ENABLE_TEST_HOOKS
         if (getenv("PEAK_TEST_FAIL_HEARTBEAT_SETUP_ALLOCATION") != NULL) {
             heartbeat_overhead = NULL;
@@ -1231,7 +1232,8 @@ peak_activate_runtime(void)
             heartbeat_time = 0;
         }
     }
-    if (peak_requested_work.cpu && heartbeat_time != 0) {
+    if (peak_requested_work.cpu && strict_mutation_active &&
+        heartbeat_time != 0) {
         args->heartbeat_time = heartbeat_time;
         args->check_interval = check_interval;
         args->hb_min_us = hb_min_us;
@@ -1264,7 +1266,8 @@ peak_activate_runtime(void)
         peak_report_capability_note_active(PEAK_CAPABILITY_DYNAMIC_DSO);
     }
 #endif
-    if (peak_requested_work.cpu && heartbeat_time != 0) {
+    if (peak_requested_work.cpu && strict_mutation_active &&
+        heartbeat_time != 0) {
         pthread_mutex_lock(&heartbeat_mutex);
         atomic_store(&heartbeat_running, true);
         pthread_mutex_unlock(&heartbeat_mutex);

--- a/src/peak.c
+++ b/src/peak.c
@@ -821,7 +821,11 @@ peak_disable_uncompiled_requested_work(void)
         peak_report_capability_note_failed(PEAK_CAPABILITY_MEMORY);
         peak_report_snapshot_note_degraded(
             PEAK_PROFILER_DEGRADED_MEMORY_TRACKING,
+#if defined(__APPLE__)
+            "rejecting PEAK_MEMORY_PROFILE on macOS; only named CPU profiling is supported");
+#else
             "requested memory backend is not compiled into this PEAK build");
+#endif
     }
     if ((unavailable & PEAK_CAPABILITY_JIT) != 0) {
         peak_requested_work.jit = FALSE;

--- a/src/peak.c
+++ b/src/peak.c
@@ -815,12 +815,6 @@ peak_disable_uncompiled_requested_work(void)
         peak_report_capability_manifest();
     uint32_t unavailable = manifest.requested & ~manifest.compiled;
 
-    if ((unavailable & PEAK_CAPABILITY_STRICT_MUTATION) != 0) {
-        peak_report_capability_note_partial(
-            PEAK_CAPABILITY_STRICT_MUTATION);
-        peak_report_capability_note_failed(
-            PEAK_CAPABILITY_STRICT_MUTATION);
-    }
     if ((unavailable & PEAK_CAPABILITY_CUDA) != 0) {
         peak_requested_work.gpu = FALSE;
         peak_report_capability_note_failed(PEAK_CAPABILITY_CUDA);
@@ -1172,11 +1166,26 @@ peak_activate_runtime(void)
      * target attachment begins.
      */
     if (peak_requested_work.cpu) {
+        PeakProfilerCapabilityManifest capabilities;
+        gboolean strict_mutation_active;
+
         peak_general_listener_attach();
         peak_report_capability_note_active(PEAK_CAPABILITY_CPU_TARGET);
-        if ((peak_report_capability_manifest().compiled &
-             PEAK_CAPABILITY_STRICT_MUTATION) != 0) {
+        capabilities = peak_report_capability_manifest();
+        strict_mutation_active =
+            (capabilities.compiled &
+             PEAK_CAPABILITY_STRICT_MUTATION) != 0;
+#if !defined(PEAK_HAVE_GUM_DARWIN_PATCH_API)
+        strict_mutation_active = strict_mutation_active &&
+            peak_detach_controller_strict_batch_supported();
+#endif
+        if (strict_mutation_active) {
             peak_report_capability_note_active(
+                PEAK_CAPABILITY_STRICT_MUTATION);
+        } else {
+            peak_report_capability_note_partial(
+                PEAK_CAPABILITY_STRICT_MUTATION);
+            peak_report_capability_note_failed(
                 PEAK_CAPABILITY_STRICT_MUTATION);
         }
     }

--- a/src/peak.c
+++ b/src/peak.c
@@ -767,6 +767,12 @@ peak_freeze_capability_requests(void)
     manifest.compiled |= PEAK_CAPABILITY_CUDA;
     manifest.cuda_compiled_apis =
         cuda_interceptor_compiled_api_mask();
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (getenv("PEAK_TEST_HIDE_COMPILED_CUDA") != NULL) {
+        manifest.compiled &= ~PEAK_CAPABILITY_CUDA;
+        manifest.cuda_compiled_apis = 0;
+    }
+#endif
 #endif
 #if !defined(__APPLE__)
     manifest.compiled |=
@@ -794,6 +800,38 @@ peak_freeze_capability_requests(void)
     peak_report_capability_reset(&manifest);
 }
 
+static void
+peak_disable_uncompiled_requested_work(void)
+{
+    PeakProfilerCapabilityManifest manifest =
+        peak_report_capability_manifest();
+    uint32_t unavailable = manifest.requested & ~manifest.compiled;
+
+    if ((unavailable & PEAK_CAPABILITY_CUDA) != 0) {
+        peak_requested_work.gpu = FALSE;
+        peak_report_capability_note_failed(PEAK_CAPABILITY_CUDA);
+        peak_report_snapshot_note_degraded(
+            PEAK_PROFILER_DEGRADED_CUDA,
+            "requested CUDA backend is not compiled into this PEAK build");
+    }
+    if ((unavailable & PEAK_CAPABILITY_MEMORY) != 0) {
+        peak_requested_work.memory = FALSE;
+        peak_memory_profile = FALSE;
+        peak_memory_track_all = FALSE;
+        peak_report_capability_note_failed(PEAK_CAPABILITY_MEMORY);
+        peak_report_snapshot_note_degraded(
+            PEAK_PROFILER_DEGRADED_MEMORY_TRACKING,
+            "requested memory backend is not compiled into this PEAK build");
+    }
+    if ((unavailable & PEAK_CAPABILITY_JIT) != 0) {
+        peak_requested_work.jit = FALSE;
+        peak_report_capability_note_failed(PEAK_CAPABILITY_JIT);
+        peak_report_snapshot_note_degraded(
+            PEAK_PROFILER_DEGRADED_JIT,
+            "requested JIT backend is not compiled into this PEAK build");
+    }
+}
+
 static uint32_t
 peak_output_capability(PeakOutputAggregationMode mode)
 {
@@ -804,20 +842,6 @@ peak_output_capability(PeakOutputAggregationMode mode)
         return PEAK_CAPABILITY_SOCKET_REPORT;
     }
     return PEAK_CAPABILITY_LOCAL_REPORT;
-}
-
-static void
-peak_note_output_capability(PeakOutputAggregationMode actual)
-{
-    const uint32_t requested =
-        peak_output_capability(peak_requested_output_aggregation);
-    const uint32_t active = peak_output_capability(actual);
-
-    peak_report_capability_note_active(active);
-    if (requested != active) {
-        peak_report_capability_note_partial(requested);
-        peak_report_capability_note_failed(requested);
-    }
 }
 
 #ifdef HAVE_MPI
@@ -1000,6 +1024,7 @@ static void
 peak_activate_runtime(void)
 {
     int expected = PEAK_RUNTIME_ACTIVATION_READY;
+    gboolean jit_provider_active = FALSE;
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
     peak_test_activation_pause_before_claim();
@@ -1111,7 +1136,8 @@ peak_activate_runtime(void)
 #if !defined(__APPLE__)
     if (peak_requested_work.jit) {
         peak_jit_provider_enable();
-        if (peak_jit_provider_is_active()) {
+        jit_provider_active = peak_jit_provider_is_active();
+        if (jit_provider_active) {
             peak_report_capability_note_active(PEAK_CAPABILITY_JIT);
         } else {
             peak_report_capability_note_failed(PEAK_CAPABILITY_JIT);
@@ -1152,7 +1178,7 @@ peak_activate_runtime(void)
 #endif
     peak_main_time = peak_second();
     peak_general_listener_note_runtime_start(peak_main_time);
-    if (heartbeat_time != 0) {
+    if (peak_requested_work.cpu && heartbeat_time != 0) {
 #ifdef PEAK_ENABLE_TEST_HOOKS
         if (getenv("PEAK_TEST_FAIL_HEARTBEAT_SETUP_ALLOCATION") != NULL) {
             heartbeat_overhead = NULL;
@@ -1175,7 +1201,7 @@ peak_activate_runtime(void)
             heartbeat_time = 0;
         }
     }
-    if (heartbeat_time != 0) {
+    if (peak_requested_work.cpu && heartbeat_time != 0) {
         args->heartbeat_time = heartbeat_time;
         args->check_interval = check_interval;
         args->hb_min_us = hb_min_us;
@@ -1199,7 +1225,7 @@ peak_activate_runtime(void)
             peak_report_capability_note_active(PEAK_CAPABILITY_MEMORY);
         }
     }
-    if (peak_requested_work.cpu || peak_requested_work.jit) {
+    if (peak_requested_work.cpu || jit_provider_active) {
         peak_general_listener_controller_start();
     }
 #if !defined(__APPLE__)
@@ -1208,7 +1234,7 @@ peak_activate_runtime(void)
         peak_report_capability_note_active(PEAK_CAPABILITY_DYNAMIC_DSO);
     }
 #endif
-    if (heartbeat_time != 0) {
+    if (peak_requested_work.cpu && heartbeat_time != 0) {
         pthread_mutex_lock(&heartbeat_mutex);
         atomic_store(&heartbeat_running, true);
         pthread_mutex_unlock(&heartbeat_mutex);
@@ -1332,6 +1358,26 @@ peak_test_parse_max_num_threads(void)
 {
     return peak_parse_max_num_threads();
 }
+
+PEAK_API uint32_t
+peak_test_capability_failed_mask(void)
+{
+    return peak_report_capability_manifest().failed;
+}
+
+PEAK_API int
+peak_test_runtime_active(void)
+{
+    return atomic_load_explicit(&peak_runtime_active,
+                                memory_order_acquire);
+}
+
+PEAK_API int
+peak_test_heartbeat_started(void)
+{
+    return atomic_load_explicit(&peak_heartbeat_started,
+                                memory_order_acquire);
+}
 #endif
 
 void peak_init()
@@ -1373,24 +1419,13 @@ void peak_init()
     hb_ema_a = numeric_config.heartbeat_ema_alpha;
     peak_memory_profile = parse_env_to_bool(PEAK_MEMORY_PROFILE);
     peak_memory_track_all = parse_env_to_bool(PEAK_MEMORY_TRACK_ALL);
-#if defined(__APPLE__)
-    if (peak_memory_profile) {
-        peak_log_warn(
-            "[peak] rejecting PEAK_MEMORY_PROFILE on macOS; only named CPU profiling is supported\n");
-    }
-    peak_memory_profile = false;
-    peak_memory_track_all = false;
-#endif
     peak_requested_work.cpu = peak_hook_address_count > 0;
     peak_requested_work.gpu =
         peak_gpu_hook_address_count > 0 || peak_gpu_monitor_all;
     peak_requested_work.memory = peak_memory_profile;
-#if defined(__APPLE__)
-    peak_requested_work.jit = FALSE;
-#else
     peak_requested_work.jit = peak_jit_provider_requested();
-#endif
     peak_freeze_capability_requests();
+    peak_disable_uncompiled_requested_work();
 
     gboolean has_requested_work = peak_has_requested_work();
     peak_set_process_requests_work(has_requested_work);
@@ -1628,7 +1663,6 @@ peak_fini_impl(void)
         } else if (found_MPI && mpi_collectives_failed_closed && mpi_log_rank) {
             g_printerr("[peak] PEAK MPI collective path was already failed closed; writing rank-local output without touching MPI again\n");
         }
-        peak_note_output_capability(output_mode);
         used_mpi_aggregation =
             peak_general_listener_print_with_mpi_job_policy(
                 output_mode,
@@ -1730,7 +1764,6 @@ peak_fini_impl(void)
                    mpi_log_rank) {
             g_printerr("[peak] Aggregate output was not proven safe; writing rank-local output before process exit\n");
         }
-        peak_note_output_capability(output_mode);
         used_mpi_aggregation =
             peak_general_listener_print_with_mpi_job_policy(
                 output_mode,
@@ -1899,7 +1932,6 @@ peak_fini_impl(void)
         return;
     }
 #else
-    peak_note_output_capability(PEAK_OUTPUT_AGGREGATION_LOCAL);
     (void)peak_general_listener_print(0, NULL);
     #ifdef HAVE_CUDA
     if (peak_requested_work.gpu) {

--- a/src/utils/process_filter.c
+++ b/src/utils/process_filter.c
@@ -250,7 +250,8 @@ peak_process_requests_work(void)
         peak_env_nonempty(PEAK_GPU_TARGET_ENV) ||
         peak_env_nonempty(PEAK_GPU_TARGET_FILE_ENV) ||
         peak_env_truthy(getenv(PEAK_GPU_MONITOR_ALL_ENV)) ||
-        peak_env_truthy(getenv(PEAK_MEMORY_PROFILE_ENV));
+        peak_env_truthy(getenv(PEAK_MEMORY_PROFILE_ENV)) ||
+        peak_env_truthy(getenv(PEAK_JIT_ENABLE_ENV));
 
     int expected = PEAK_PROFILE_DECISION_UNKNOWN;
     if (!__atomic_compare_exchange_n(&peak_process_requests_work_cache,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -187,6 +187,28 @@ if(BUILD_TESTING)
         PROPERTIES
             PASS_REGULAR_EXPRESSION "report_snapshot_test_ok")
 
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        add_executable(test_uncompiled_backend_gating
+            report/test_uncompiled_backend_gating.c)
+        set_target_properties(test_uncompiled_backend_gating
+            PROPERTIES ENABLE_EXPORTS ON)
+        target_link_libraries(test_uncompiled_backend_gating
+            PRIVATE ${CMAKE_DL_LIBS})
+        add_test(NAME test_uncompiled_cuda_backend_fail_open
+            COMMAND ${Python3_EXECUTABLE}
+                    ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                    --exit-code 0
+                    --stdout-regex "failed_mask=0x4 runtime_active=0 heartbeat_started=0"
+                    --stderr-regex "requested CUDA backend is not compiled into this PEAK build"
+                    --stderr-count-regex "disabling non-critical profiler subsystem"
+                    --stderr-count 1
+                    -- $<TARGET_FILE:test_uncompiled_backend_gating>)
+        set_tests_properties(test_uncompiled_cuda_backend_fail_open
+            PROPERTIES
+                ENVIRONMENT "PEAK_GPU_MONITOR_ALL=1;PEAK_TEST_HIDE_COMPILED_CUDA=1;${PRELOAD_VAR}"
+                TIMEOUT 15)
+    endif()
+
     add_executable(test_report_snapshot_cxx_link
         report/test_report_snapshot_cxx_link.cpp
         ${PROJECT_SOURCE_DIR}/src/general_listener/report_snapshot.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,6 +207,18 @@ if(BUILD_TESTING)
             PROPERTIES
                 ENVIRONMENT "PEAK_GPU_MONITOR_ALL=1;PEAK_TEST_HIDE_COMPILED_CUDA=1;${PRELOAD_VAR}"
                 TIMEOUT 15)
+
+        add_test(NAME test_uncompiled_strict_mutation_capability
+            COMMAND ${Python3_EXECUTABLE}
+                    ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                    --exit-code 0
+                    --stdout-regex "failed_mask=0x2 runtime_active=1 heartbeat_started=0"
+                    --stderr-regex "Profiler capability \\[strict-mutation\\]: requested=1 compiled=0 active=0 partial=1 retained=0 failed=1"
+                    -- $<TARGET_FILE:test_uncompiled_backend_gating>)
+        set_tests_properties(test_uncompiled_strict_mutation_capability
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=main;PEAK_HEARTBEAT_INTERVAL=0;PEAK_TEXT_OUTPUT=1;PEAK_TEST_HIDE_COMPILED_STRICT_MUTATION=1;${PRELOAD_VAR}"
+                TIMEOUT 15)
     endif()
 
     add_executable(test_report_snapshot_cxx_link

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -217,7 +217,7 @@ if(BUILD_TESTING)
                     -- $<TARGET_FILE:test_uncompiled_backend_gating>)
         set_tests_properties(test_uncompiled_strict_mutation_capability
             PROPERTIES
-                ENVIRONMENT "PEAK_TARGET=main;PEAK_HEARTBEAT_INTERVAL=0;PEAK_TEXT_OUTPUT=1;PEAK_TEST_HIDE_COMPILED_STRICT_MUTATION=1;${PRELOAD_VAR}"
+                ENVIRONMENT "PEAK_TARGET=main;PEAK_HEARTBEAT_INTERVAL=0.1;PEAK_TEXT_OUTPUT=1;PEAK_TEST_HIDE_COMPILED_STRICT_MUTATION=1;${PRELOAD_VAR}"
                 TIMEOUT 15)
     endif()
 

--- a/test/cuda/CMakeLists.txt
+++ b/test/cuda/CMakeLists.txt
@@ -63,7 +63,8 @@ else()
     message(STATUS "Skipping CUDA OpenMP/MPI test because OpenMP C or MPI CXX was not found")
 endif()
 
-peak_add_cuda_fixture(test_cuda_event_recycling test_event_recycling.cu)
+peak_add_cuda_fixture(test_cuda_event_recycling test_event_recycling.cu
+    ${CMAKE_DL_LIBS})
 peak_add_cuda_fixture(test_cuda_error_transparency test_error_transparency.cu
     ${PEAK_CUDA_DRIVER_TEST_LIBRARY})
 if(PEAK_CUDA_DRIVER_TEST_LIBRARY)
@@ -81,6 +82,10 @@ else()
 endif()
 peak_add_cuda_fixture(test_cuda_finalization_deadline
     test_finalization_deadline.cu ${CMAKE_DL_LIBS})
+add_executable(test_optional_backend_gating
+    test_optional_backend_gating.c)
+set_target_properties(test_optional_backend_gating PROPERTIES ENABLE_EXPORTS ON)
+target_link_libraries(test_optional_backend_gating PRIVATE ${CMAKE_DL_LIBS})
 if (PEAK_CUDA_DRIVER_TEST_LIBRARY)
     peak_add_cuda_fixture(benchmark_cuda_launch_overhead
         benchmark_launch_overhead.cu
@@ -91,10 +96,40 @@ else()
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND Python3_EXECUTABLE)
+    add_test(NAME test_optional_backend_gating_runtime
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stdout-regex "cuda_attach_calls=0"
+                --stderr-regex "Profiler capability \\[cuda\\]: requested=0 compiled=1 active=0 partial=0 retained=0 failed=0"
+                -- $<TARGET_FILE:test_optional_backend_gating>)
+    set_tests_properties(test_optional_backend_gating_runtime
+        PROPERTIES
+            ENVIRONMENT "PEAK_TARGET=peak_optional_backend_cpu_target;PEAK_HEARTBEAT_INTERVAL=0;LD_PRELOAD=$<TARGET_FILE:peak>"
+            TIMEOUT 15)
+    add_test(NAME test_unavailable_jit_backend_fail_open
+        COMMAND ${Python3_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/test/utils/run_expect_exit.py
+                --exit-code 0
+                --stdout-regex "cuda_attach_calls=0"
+                --stderr-regex "Profiler capability \\[jit\\]: requested=1 compiled=1 active=0 partial=0 retained=0 failed=1"
+                --stderr-count-regex "disabling non-critical profiler subsystem"
+                --stderr-count 1
+                -- $<TARGET_FILE:test_optional_backend_gating>)
+    set_tests_properties(test_unavailable_jit_backend_fail_open
+        PROPERTIES
+            ENVIRONMENT "PEAK_TARGET=;PEAK_JIT_ENABLE=1;PEAK_JIT_PROVIDER=unsupported;PEAK_HEARTBEAT_INTERVAL=0;LD_PRELOAD=$<TARGET_FILE:peak>"
+            TIMEOUT 15)
     add_test(NAME test_cuda_event_recycling_runtime
         COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
                 sampling
+                --exe $<TARGET_FILE:test_cuda_event_recycling>
+                --peak $<TARGET_FILE:peak>)
+    add_test(NAME test_cuda_partial_capability_runtime
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_cuda_regressions.py
+                partial-capability
                 --exe $<TARGET_FILE:test_cuda_event_recycling>
                 --peak $<TARGET_FILE:peak>)
     add_test(NAME test_cuda_error_transparency_runtime
@@ -133,7 +168,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND Python3_EXECUTABLE)
     endif()
 
     set(_peak_cuda_runtime_tests
+        test_optional_backend_gating_runtime
+        test_unavailable_jit_backend_fail_open
         test_cuda_event_recycling_runtime
+        test_cuda_partial_capability_runtime
         test_cuda_error_transparency_runtime
         test_cuda_finalization_deadline_runtime)
     if (TARGET benchmark_cuda_launch_overhead)
@@ -152,6 +190,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND Python3_EXECUTABLE)
             SKIP_RETURN_CODE 77)
     set(_peak_cuda_correctness_tests
         test_cuda_event_recycling_runtime
+        test_cuda_partial_capability_runtime
         test_cuda_error_transparency_runtime
         test_cuda_finalization_deadline_runtime)
     if (PEAK_CUDA_DRIVER_TEST_LIBRARY)

--- a/test/cuda/run_cuda_regressions.py
+++ b/test/cuda/run_cuda_regressions.py
@@ -110,6 +110,48 @@ def run_error_transparency(args: argparse.Namespace, directory: Path) -> None:
     print("cuda_error_transparency_validation_ok")
 
 
+def run_partial_capability(args: argparse.Namespace, directory: Path) -> None:
+    baseline = run_process([str(args.exe)], clean_environment(), 20.0,
+                           directory)
+    require_success("partial-capability-baseline", baseline)
+    profile = run_process(
+        [str(args.exe)],
+        profiled_environment(
+            args.peak,
+            PEAK_GPU_MONITOR_ALL="1",
+            PEAK_TEST_FAIL_CUDA_REPLACEMENT="cudaLaunchKernel",
+        ),
+        30.0,
+        directory,
+    )
+    require_success("partial-capability-profile", profile,
+                    allow_skip=False)
+    require_contains(profile.output, "cuda_event_recycling_ok",
+                     "partial CUDA application completion")
+    require_contains(profile.output, "cpu_target_storage=0",
+                     "GPU-only CPU target storage gating")
+    require_contains(
+        profile.output,
+        "Profiler capability [cuda]: requested=1 compiled=1 active=1 "
+        "partial=1 retained=0 failed=1",
+        "partial CUDA capability manifest",
+    )
+    coverage = re.search(
+        r"Profiler CUDA API coverage: compiled=0x([0-9a-f]+) "
+        r"found=0x([0-9a-f]+) installed=0x([0-9a-f]+) "
+        r"failed=0x([0-9a-f]+)",
+        profile.output,
+    )
+    if coverage is None or int(coverage.group(4), 16) == 0:
+        raise RuntimeError("partial CUDA capability report omitted the "
+                           "failed API mask")
+    if profile.output.count(
+            "disabling non-critical profiler subsystem") != 0:
+        raise RuntimeError("partial CUDA activation incorrectly disabled the "
+                           "remaining CUDA backend")
+    print("cuda_partial_capability_validation_ok")
+
+
 def print_result(label: str, result: RunResult) -> None:
     print(f"[{label}] stdout:")
     print(result.stdout.rstrip())
@@ -1019,7 +1061,7 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("case", choices=(
         "sampling", "capture", "context", "finalization", "benchmark",
-        "errors"))
+        "errors", "partial-capability"))
     parser.add_argument("--exe", type=Path, required=True)
     parser.add_argument("--peak", type=Path, required=True)
     parser.add_argument("--samples", type=int, default=3)
@@ -1071,6 +1113,8 @@ def main() -> int:
             run_finalization(args, directory)
         elif args.case == "errors":
             run_error_transparency(args, directory)
+        elif args.case == "partial-capability":
+            run_partial_capability(args, directory)
         else:
             run_benchmark(args, directory)
     return 0

--- a/test/cuda/run_cuda_regressions.py
+++ b/test/cuda/run_cuda_regressions.py
@@ -130,6 +130,8 @@ def run_partial_capability(args: argparse.Namespace, directory: Path) -> None:
                      "partial CUDA application completion")
     require_contains(profile.output, "cpu_target_storage=0",
                      "GPU-only CPU target storage gating")
+    require_contains(profile.output, "heartbeat_started=0",
+                     "GPU-only heartbeat gating")
     require_contains(
         profile.output,
         "Profiler capability [cuda]: requested=1 compiled=1 active=1 "
@@ -694,6 +696,12 @@ def run_finalization(args: argparse.Namespace, directory: Path) -> None:
     require_contains(forced.output,
                      "cuda_forced_incomplete_finalization_ok",
                      "forced-incomplete application output")
+    require_contains(
+        forced.output,
+        "Profiler capability [cuda]: requested=1 compiled=1 active=1 "
+        "partial=1 retained=1 failed=0",
+        "forced-incomplete retained CUDA capability manifest",
+    )
     require_contains(forced.output, "CUDA incomplete event context=",
                      "forced-incomplete context diagnostic")
     require_contains(forced.output, "device=",

--- a/test/cuda/run_cuda_regressions.py
+++ b/test/cuda/run_cuda_regressions.py
@@ -119,6 +119,7 @@ def run_partial_capability(args: argparse.Namespace, directory: Path) -> None:
         profiled_environment(
             args.peak,
             PEAK_GPU_MONITOR_ALL="1",
+            PEAK_HEARTBEAT_INTERVAL="0.1",
             PEAK_TEST_FAIL_CUDA_REPLACEMENT="cudaLaunchKernel",
         ),
         30.0,

--- a/test/cuda/test_event_recycling.cu
+++ b/test/cuda/test_event_recycling.cu
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdio>
+#include <dlfcn.h>
 #include <thread>
 
 namespace {
@@ -28,6 +29,10 @@ peak_cuda_recycling_late_marker_kernel(unsigned int* value)
 int
 main()
 {
+    using PeakCpuTargetStorageFn = int (*)(void);
+    PeakCpuTargetStorageFn cpu_target_storage =
+        reinterpret_cast<PeakCpuTargetStorageFn>(dlsym(
+            RTLD_DEFAULT, "peak_test_cpu_target_storage_allocated"));
     int requirement = peak_cuda_test_require_devices(1, nullptr);
     if (requirement != 0) {
         return requirement;
@@ -79,7 +84,9 @@ main()
     }
 
     std::printf("cuda_event_recycling_ok capacity=%d launches=%d "
-                "late_marker=1 per_launch_synchronizations=0 result=%u\n",
-                kPoolCapacity, kSustainedLaunches + 1, value);
+                "late_marker=1 per_launch_synchronizations=0 result=%u "
+                "cpu_target_storage=%d\n",
+                kPoolCapacity, kSustainedLaunches + 1, value,
+                cpu_target_storage != nullptr ? cpu_target_storage() : -1);
     return 0;
 }

--- a/test/cuda/test_event_recycling.cu
+++ b/test/cuda/test_event_recycling.cu
@@ -30,9 +30,13 @@ int
 main()
 {
     using PeakCpuTargetStorageFn = int (*)(void);
+    using PeakHeartbeatStartedFn = int (*)(void);
     PeakCpuTargetStorageFn cpu_target_storage =
         reinterpret_cast<PeakCpuTargetStorageFn>(dlsym(
             RTLD_DEFAULT, "peak_test_cpu_target_storage_allocated"));
+    PeakHeartbeatStartedFn heartbeat_started =
+        reinterpret_cast<PeakHeartbeatStartedFn>(dlsym(
+            RTLD_DEFAULT, "peak_test_heartbeat_started"));
     int requirement = peak_cuda_test_require_devices(1, nullptr);
     if (requirement != 0) {
         return requirement;
@@ -85,8 +89,9 @@ main()
 
     std::printf("cuda_event_recycling_ok capacity=%d launches=%d "
                 "late_marker=1 per_launch_synchronizations=0 result=%u "
-                "cpu_target_storage=%d\n",
+                "cpu_target_storage=%d heartbeat_started=%d\n",
                 kPoolCapacity, kSustainedLaunches + 1, value,
-                cpu_target_storage != nullptr ? cpu_target_storage() : -1);
+                cpu_target_storage != nullptr ? cpu_target_storage() : -1,
+                heartbeat_started != nullptr ? heartbeat_started() : -1);
     return 0;
 }

--- a/test/cuda/test_optional_backend_gating.c
+++ b/test/cuda/test_optional_backend_gating.c
@@ -1,8 +1,11 @@
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <stdint.h>
 #include <stdio.h>
 
 typedef unsigned long long (*PeakCudaAttachCallCountFn)(void);
+typedef uint32_t (*PeakCapabilityMaskFn)(void);
+typedef int (*PeakRuntimeStateFn)(void);
 
 __attribute__((noinline)) int
 peak_optional_backend_cpu_target(void)
@@ -21,15 +24,30 @@ main(void)
     PeakCudaAttachCallCountFn attach_call_count =
         (PeakCudaAttachCallCountFn)dlsym(
             RTLD_DEFAULT, "peak_cuda_test_attach_call_count");
+    PeakCapabilityMaskFn failed_mask =
+        (PeakCapabilityMaskFn)dlsym(
+            RTLD_DEFAULT, "peak_test_capability_failed_mask");
+    PeakRuntimeStateFn runtime_active =
+        (PeakRuntimeStateFn)dlsym(
+            RTLD_DEFAULT, "peak_test_runtime_active");
+    PeakRuntimeStateFn heartbeat_started =
+        (PeakRuntimeStateFn)dlsym(
+            RTLD_DEFAULT, "peak_test_heartbeat_started");
 
     if (peak_optional_backend_cpu_target() != 496) {
         return 3;
     }
-    if (attach_call_count == NULL) {
-        fprintf(stderr, "CUDA attach counter is unavailable\n");
+    if (attach_call_count == NULL || failed_mask == NULL ||
+        runtime_active == NULL || heartbeat_started == NULL) {
+        fprintf(stderr, "PEAK optional-backend test hooks are unavailable\n");
         return 2;
     }
     unsigned long long calls = attach_call_count();
-    printf("cuda_attach_calls=%llu\n", calls);
+    printf("cuda_attach_calls=%llu failed_mask=0x%x runtime_active=%d "
+           "heartbeat_started=%d\n",
+           calls,
+           failed_mask(),
+           runtime_active(),
+           heartbeat_started());
     return calls == 0 ? 0 : 1;
 }

--- a/test/cuda/test_optional_backend_gating.c
+++ b/test/cuda/test_optional_backend_gating.c
@@ -1,0 +1,35 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+
+typedef unsigned long long (*PeakCudaAttachCallCountFn)(void);
+
+__attribute__((noinline)) int
+peak_optional_backend_cpu_target(void)
+{
+    volatile int value = 0;
+
+    for (int iteration = 0; iteration < 32; iteration++) {
+        value += iteration;
+    }
+    return value;
+}
+
+int
+main(void)
+{
+    PeakCudaAttachCallCountFn attach_call_count =
+        (PeakCudaAttachCallCountFn)dlsym(
+            RTLD_DEFAULT, "peak_cuda_test_attach_call_count");
+
+    if (peak_optional_backend_cpu_target() != 496) {
+        return 3;
+    }
+    if (attach_call_count == NULL) {
+        fprintf(stderr, "CUDA attach counter is unavailable\n");
+        return 2;
+    }
+    unsigned long long calls = attach_call_count();
+    printf("cuda_attach_calls=%llu\n", calls);
+    return calls == 0 ? 0 : 1;
+}

--- a/test/detach_runtime/run_detach_milc_like_ab_check.py
+++ b/test/detach_runtime/run_detach_milc_like_ab_check.py
@@ -2512,10 +2512,20 @@ def run_synthetic_policy_diagnostics():
         output.seek(0)
         return output
 
-    valid_stats_values = [
-        "target", "1", "1", "1", "0", "0", "0", "0", "0", "0", "1e-6",
-        "0", "0",
-    ]
+    def synthetic_stats_values(function="target", dropped_calls="0",
+                               dropped_threads="0", target=True):
+        row = {field: "0" for field in STATS_CSV_FIELDS}
+        row["function"] = function
+        row["dropped_calls"] = dropped_calls
+        row["dropped_threads"] = dropped_threads
+        if target:
+            row["count"] = "1"
+            row["per_thread"] = "1"
+            row["per_rank"] = "1"
+            row["overhead_s"] = "1e-6"
+        return [row[field] for field in STATS_CSV_FIELDS]
+
+    valid_stats_values = synthetic_stats_values()
     valid_stats_rows = validated_profiled_stats_rows(
         synthetic_stats_csv(STATS_CSV_FIELDS, valid_stats_values),
         {"target"},
@@ -2525,8 +2535,13 @@ def run_synthetic_policy_diagnostics():
     diagnostics_stats_rows = validated_profiled_stats_rows(
         synthetic_stats_csv(
             STATS_CSV_FIELDS,
-            valid_stats_values[:-2] + ["7", "3"],
-            [[ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 10 + ["7", "3"]],
+            synthetic_stats_values(dropped_calls="7", dropped_threads="3"),
+            [synthetic_stats_values(
+                ACCOUNTING_DIAGNOSTICS_FUNCTION,
+                dropped_calls="7",
+                dropped_threads="3",
+                target=False,
+            )],
         ),
         {"target"},
     )
@@ -2537,7 +2552,9 @@ def run_synthetic_policy_diagnostics():
         lambda: validated_profiled_stats_rows(
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
-                valid_stats_values[:-2] + ["7", "3"],
+                synthetic_stats_values(
+                    dropped_calls="7", dropped_threads="3"
+                ),
             ),
             {"target"},
         ),
@@ -2547,8 +2564,15 @@ def run_synthetic_policy_diagnostics():
         lambda: validated_profiled_stats_rows(
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
-                valid_stats_values[:-2] + ["7", "3"],
-                [[ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 10 + ["8", "3"]],
+                synthetic_stats_values(
+                    dropped_calls="7", dropped_threads="3"
+                ),
+                [synthetic_stats_values(
+                    ACCOUNTING_DIAGNOSTICS_FUNCTION,
+                    dropped_calls="8",
+                    dropped_threads="3",
+                    target=False,
+                )],
             ),
             {"target"},
         ),
@@ -2558,10 +2582,22 @@ def run_synthetic_policy_diagnostics():
         lambda: validated_profiled_stats_rows(
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
-                valid_stats_values[:-2] + ["7", "3"],
+                synthetic_stats_values(
+                    dropped_calls="7", dropped_threads="3"
+                ),
                 [
-                    [ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 10 + ["7", "3"],
-                    [ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 10 + ["7", "3"],
+                    synthetic_stats_values(
+                        ACCOUNTING_DIAGNOSTICS_FUNCTION,
+                        dropped_calls="7",
+                        dropped_threads="3",
+                        target=False,
+                    ),
+                    synthetic_stats_values(
+                        ACCOUNTING_DIAGNOSTICS_FUNCTION,
+                        dropped_calls="7",
+                        dropped_threads="3",
+                        target=False,
+                    ),
                 ],
             ),
             {"target"},
@@ -2573,7 +2609,9 @@ def run_synthetic_policy_diagnostics():
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
                 valid_stats_values,
-                [[ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 12],
+                [synthetic_stats_values(
+                    ACCOUNTING_DIAGNOSTICS_FUNCTION, target=False
+                )],
             ),
             {"target"},
         ),
@@ -2583,19 +2621,32 @@ def run_synthetic_policy_diagnostics():
         lambda: validated_profiled_stats_rows(
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
-                valid_stats_values[:-2] + ["7", "3"],
-                [["target-two"] + valid_stats_values[1:-2] + ["8", "3"]],
+                synthetic_stats_values(
+                    dropped_calls="7", dropped_threads="3"
+                ),
+                [synthetic_stats_values(
+                    "target-two", dropped_calls="8", dropped_threads="3"
+                )],
             ),
             {"target", "target-two"},
         ),
     )
+    nonzero_metric_diagnostics = synthetic_stats_values(
+        ACCOUNTING_DIAGNOSTICS_FUNCTION,
+        dropped_calls="7",
+        dropped_threads="3",
+        target=False,
+    )
+    nonzero_metric_diagnostics[STATS_CSV_FIELDS.index("count")] = "1"
     expect_assertion(
         "nonzero accounting diagnostics metric",
         lambda: validated_profiled_stats_rows(
             synthetic_stats_csv(
                 STATS_CSV_FIELDS,
-                valid_stats_values[:-2] + ["7", "3"],
-                [[ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["1"] + ["0"] * 9 + ["7", "3"]],
+                synthetic_stats_values(
+                    dropped_calls="7", dropped_threads="3"
+                ),
+                [nonzero_metric_diagnostics],
             ),
             {"target"},
         ),
@@ -2603,7 +2654,12 @@ def run_synthetic_policy_diagnostics():
     diagnostics_only_rows = validated_profiled_stats_rows(
         synthetic_stats_csv(
             STATS_CSV_FIELDS,
-            [ACCOUNTING_DIAGNOSTICS_FUNCTION] + ["0"] * 10 + ["7", "3"],
+            synthetic_stats_values(
+                ACCOUNTING_DIAGNOSTICS_FUNCTION,
+                dropped_calls="7",
+                dropped_threads="3",
+                target=False,
+            ),
         ),
         {"target"},
     )
@@ -2657,7 +2713,9 @@ def run_synthetic_policy_diagnostics():
         ),
     )
     malformed_diagnostic_values = list(valid_stats_values)
-    malformed_diagnostic_values[-1] = "3.5"
+    malformed_diagnostic_values[
+        STATS_CSV_FIELDS.index("dropped_threads")
+    ] = "3.5"
     expect_assertion(
         "malformed accounting diagnostic",
         lambda: validated_profiled_stats_rows(

--- a/test/detach_runtime/run_detach_milc_like_ab_check.py
+++ b/test/detach_runtime/run_detach_milc_like_ab_check.py
@@ -29,14 +29,33 @@ STATS_CSV_FIELDS = (
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
+    "capability_requested",
+    "capability_compiled",
+    "capability_active",
+    "capability_partial",
+    "capability_retained",
+    "capability_failed",
+    "cuda_compiled_apis",
+    "cuda_found_apis",
+    "cuda_installed_apis",
+    "cuda_failed_apis",
+    "degraded_mask",
 )
 PEAK_STATS_NAME_RE = re.compile(
     r"^milc-like-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
     r"h[A-Za-z0-9_.-]+-r[A-Za-z0-9_-]+-p\d+-q[0-9a-f]{16}\.csv$"
 )
 STATS_CSV_METRIC_FIELDS = STATS_CSV_FIELDS[4:11]
-STATS_CSV_DIAGNOSTIC_FIELDS = STATS_CSV_FIELDS[11:]
+STATS_CSV_DIAGNOSTIC_FIELDS = ("dropped_calls", "dropped_threads")
+STATS_CSV_CAPABILITY_FIELDS = STATS_CSV_FIELDS[13:]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
+CAPABILITY_METADATA_FUNCTION_RE = re.compile(
+    r"^PEAK_CAPABILITY_[a-z-]+$"
+)
+CAPABILITY_METADATA_FUNCTIONS = {
+    "PEAK_CUDA_API_COVERAGE",
+    "PEAK_DEGRADED_CAPABILITIES",
+}
 HOT_TARGETS = [
     f"peak_milc_hot_{phase}_s{slot:02d}"
     for phase in range(TARGET_PHASES)
@@ -922,6 +941,29 @@ def validated_profiled_stats_rows(handle, allowed_targets, rank_count=1):
                     for field in STATS_CSV_FIELDS)):
             raise AssertionError(f"stats CSV row has missing/extra values: {row}")
         function = row["function"]
+        if (CAPABILITY_METADATA_FUNCTION_RE.fullmatch(function) or
+                function in CAPABILITY_METADATA_FUNCTIONS):
+            if function in seen:
+                raise AssertionError(
+                    f"duplicate stats CSV metadata row: {function!r}"
+                )
+            for field in STATS_CSV_FIELDS[1:13]:
+                try:
+                    if float(row[field]) != 0.0:
+                        raise AssertionError(
+                            f"nonzero metadata metric {field}: {row}"
+                        )
+                except ValueError as exc:
+                    raise AssertionError(
+                        f"invalid metadata metric {field}: {row}"
+                    ) from exc
+            for field in STATS_CSV_CAPABILITY_FIELDS:
+                if not re.fullmatch(r"[0-9]+", row[field]):
+                    raise AssertionError(
+                        f"invalid capability metadata {field}: {row}"
+                    )
+            seen.add(function)
+            continue
         if function == ACCOUNTING_DIAGNOSTICS_FUNCTION:
             if diagnostics is not None:
                 raise AssertionError("duplicate accounting diagnostics row")

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -86,8 +86,25 @@ STATS_FIELDS = [
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
+    "capability_requested",
+    "capability_compiled",
+    "capability_active",
+    "capability_partial",
+    "capability_retained",
+    "capability_failed",
+    "cuda_compiled_apis",
+    "cuda_found_apis",
+    "cuda_installed_apis",
+    "cuda_failed_apis",
+    "degraded_mask",
 ]
+STATS_ACCOUNTING_FIELDS = ["dropped_calls", "dropped_threads"]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
+CAPABILITY_METADATA_FUNCTION_RE = re.compile(r"^PEAK_CAPABILITY_[a-z-]+$")
+CAPABILITY_METADATA_FUNCTIONS = {
+    "PEAK_CUDA_API_COVERAGE",
+    "PEAK_DEGRADED_CAPABILITIES",
+}
 SOCKET_TEST_PORT_MIN = 20000
 SOCKET_TEST_PORT_MAX = 30000
 SOCKET_TEST_PORT_ATTEMPTS = 128
@@ -189,19 +206,25 @@ def require_valid_accounting_diagnostics(name, rows):
                 raise AssertionError(
                     f"invalid accounting diagnostics metric {field}: {name}"
                 ) from exc
-        for field in STATS_FIELDS[11:]:
+        for field in STATS_ACCOUNTING_FIELDS:
             if not re.fullmatch(r"[0-9]+", row.get(field, "") or ""):
                 raise AssertionError(
                     f"invalid accounting diagnostic {field}: {name}"
                 )
-        diagnostics_values = tuple(int(row[field]) for field in STATS_FIELDS[11:])
+        diagnostics_values = tuple(
+            int(row[field]) for field in STATS_ACCOUNTING_FIELDS
+        )
 
     target_values = None
     for row in rows:
         if row.get("function") == ACCOUNTING_DIAGNOSTICS_FUNCTION:
             continue
+        function = row.get("function", "")
+        if (CAPABILITY_METADATA_FUNCTION_RE.fullmatch(function) or
+                function in CAPABILITY_METADATA_FUNCTIONS):
+            continue
         values = []
-        for field in STATS_FIELDS[11:]:
+        for field in STATS_ACCOUNTING_FIELDS:
             value = row.get(field, "") or ""
             if not re.fullmatch(r"[0-9]+", value):
                 raise AssertionError(
@@ -232,10 +255,11 @@ def require_valid_accounting_diagnostics(name, rows):
 
 def run_synthetic_stats_diagnostics():
     def row(function, dropped_calls="0", dropped_threads="0"):
-        return dict(zip(
-            STATS_FIELDS,
-            [function] + ["0"] * 10 + [dropped_calls, dropped_threads],
-        ))
+        values = {field: "0" for field in STATS_FIELDS}
+        values["function"] = function
+        values["dropped_calls"] = dropped_calls
+        values["dropped_threads"] = dropped_threads
+        return values
 
     def expect_assertion(label, callback):
         try:

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -253,6 +253,39 @@ def require_valid_accounting_diagnostics(name, rows):
         raise AssertionError(f"accounting diagnostics mismatch: {name}")
 
 
+def require_transport_capability_outcome(name, rows, requested, active):
+    by_name = {row.get("function", ""): row for row in rows}
+    requested_row = by_name.get(f"PEAK_CAPABILITY_{requested}-report")
+    active_row = by_name.get(f"PEAK_CAPABILITY_{active}-report")
+    if requested_row is None or active_row is None:
+        raise AssertionError(f"missing transport capability rows: {name}")
+    expected_requested = {
+        "capability_requested": "1",
+        "capability_active": "0" if requested != active else "1",
+        "capability_partial": "1" if requested != active else "0",
+        "capability_failed": "1" if requested != active else "0",
+    }
+    for field, expected in expected_requested.items():
+        if requested_row.get(field) != expected:
+            raise AssertionError(
+                f"incorrect {requested} transport {field} in {name}: "
+                f"expected {expected}, got {requested_row.get(field)!r}"
+            )
+    if requested != active:
+        expected_active = {
+            "capability_requested": "0",
+            "capability_active": "1",
+            "capability_partial": "0",
+            "capability_failed": "0",
+        }
+        for field, expected in expected_active.items():
+            if active_row.get(field) != expected:
+                raise AssertionError(
+                    f"incorrect {active} fallback {field} in {name}: "
+                    f"expected {expected}, got {active_row.get(field)!r}"
+                )
+
+
 def run_synthetic_stats_diagnostics():
     def row(function, dropped_calls="0", dropped_threads="0"):
         values = {field: "0" for field in STATS_FIELDS}
@@ -1261,6 +1294,12 @@ def main():
                 stats_rows.extend(rows)
         for name, evidence in stats_file_evidence.items():
             require_valid_accounting_diagnostics(name, evidence["rows"])
+            if args.mode in {
+                    "finalize-clean-output-socket-bad-host",
+                    "finalize-clean-output-socket-token-mismatch"}:
+                require_transport_capability_outcome(
+                    name, evidence["rows"], "socket", "local"
+                )
         selected_stats_files = [
             path for path in stats_files
             if nprocs == 1 or stats_name.fullmatch(path.name)["rank"] == "0"

--- a/test/report/fake_mpi/mpi.h
+++ b/test/report/fake_mpi/mpi.h
@@ -45,6 +45,7 @@ typedef struct {
 #define MPI_SUM 3
 #define MPI_MAXLOC 4
 #define MPI_BOR 5
+#define MPI_BAND 6
 
 #define MPI_REQUEST_NULL ((MPI_Request){0, 0})
 

--- a/test/report/test_mpi_report_request_lifetime.c
+++ b/test/report/test_mpi_report_request_lifetime.c
@@ -15,8 +15,8 @@ enum {
     TEST_COLLECTIVE_ALLREDUCE = 0,
     TEST_COLLECTIVE_REDUCE = 1,
     TEST_COLLECTIVE_BCAST = 2,
-    TEST_COLLECTIVE_COUNT = 59,
-    TEST_UNIQUE_LABEL_COUNT = 34,
+    TEST_COLLECTIVE_COUNT = 61,
+    TEST_UNIQUE_LABEL_COUNT = 36,
 };
 
 typedef enum {
@@ -386,6 +386,17 @@ fixture_snapshot(void)
     snapshot->thread_count[1] = 2;
     snapshot->dropped_calls = 7;
     snapshot->dropped_threads = 3;
+    snapshot->degraded_mask = PEAK_PROFILER_DEGRADED_CUDA;
+    snapshot->capabilities.requested =
+        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.compiled = snapshot->capabilities.requested;
+    snapshot->capabilities.active = PEAK_CAPABILITY_CPU_TARGET;
+    snapshot->capabilities.partial = PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.failed = PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.cuda_compiled_apis = 0x7U;
+    snapshot->capabilities.cuda_found_apis = 0x3U;
+    snapshot->capabilities.cuda_installed_apis = 0x1U;
+    snapshot->capabilities.cuda_failed_apis = 0x2U;
     snapshot->overhead_per_call = 1e-7;
     snapshot->overhead.valid = true;
     snapshot->overhead.accounting_valid = true;
@@ -461,16 +472,18 @@ validate_golden_trace(void)
         failures++;
     }
     EXPECT(1, "degraded-mode-mask", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED, MPI_BOR, -1);
-    EXPECT(2, "elapsed-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
-    EXPECT(3, "accounting-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
-    EXPECT(4, "hook-count-min", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MIN, -1);
-    EXPECT(5, "hook-count-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MAX, -1);
-    EXPECT(6, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
-    EXPECT(7, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
-    EXPECT(8, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(9, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
-    for (int ordinal = 10; ordinal <= 39; ordinal++) {
-        int field = (ordinal - 10) % 5;
+    EXPECT(2, "capability-any", TEST_COLLECTIVE_ALLREDUCE, 10, MPI_UNSIGNED, MPI_BOR, -1);
+    EXPECT(3, "capability-all", TEST_COLLECTIVE_ALLREDUCE, 5, MPI_UNSIGNED, MPI_BAND, -1);
+    EXPECT(4, "elapsed-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
+    EXPECT(5, "accounting-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
+    EXPECT(6, "hook-count-min", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MIN, -1);
+    EXPECT(7, "hook-count-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MAX, -1);
+    EXPECT(8, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
+    EXPECT(9, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
+    EXPECT(10, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(11, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
+    for (int ordinal = 12; ordinal <= 41; ordinal++) {
+        int field = (ordinal - 12) % 5;
         EXPECT(ordinal,
                bcast_labels[field],
                TEST_COLLECTIVE_BCAST,
@@ -479,26 +492,26 @@ validate_golden_trace(void)
                MPI_OP_NULL,
                0);
     }
-    EXPECT(40, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(41, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(42, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(43, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(44, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(45, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(46, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(47, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(48, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(49, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(50, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(51, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(52, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(53, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(54, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
-    EXPECT(55, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
-    EXPECT(56, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(57, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(58, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(59, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(42, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(43, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(44, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(45, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(46, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(47, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(48, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(49, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(50, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(51, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(52, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(53, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(54, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(55, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(56, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
+    EXPECT(57, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
+    EXPECT(58, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(59, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(60, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(61, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
 
 #undef EXPECT
 
@@ -547,6 +560,10 @@ run_success_case(int rank, int size)
             aggregate->reattached[1] != local->reattached[1] ||
             aggregate->dropped_calls != local->dropped_calls ||
             aggregate->dropped_threads != local->dropped_threads ||
+            aggregate->degraded_mask != local->degraded_mask ||
+            memcmp(&aggregate->capabilities,
+                   &local->capabilities,
+                   sizeof(local->capabilities)) != 0 ||
             !aggregate->overhead.per_rank_max ||
             aggregate->overhead.per_rank_maxima.owner_ranks[0] != 0) {
             failures++;

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -229,6 +229,17 @@ create_fixture(const char* name)
     snapshot->overhead_per_call = 0.01;
     snapshot->dropped_calls = 7;
     snapshot->dropped_threads = 3;
+    snapshot->degraded_mask = PEAK_PROFILER_DEGRADED_CUDA;
+    snapshot->capabilities.requested =
+        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.compiled = snapshot->capabilities.requested;
+    snapshot->capabilities.active = PEAK_CAPABILITY_CPU_TARGET;
+    snapshot->capabilities.partial = PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.failed = PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.cuda_compiled_apis = 7;
+    snapshot->capabilities.cuda_found_apis = 3;
+    snapshot->capabilities.cuda_installed_apis = 1;
+    snapshot->capabilities.cuda_failed_apis = 2;
     snapshot->rank_count = 2;
 
     snapshot->instrumented[1] = 0;
@@ -261,11 +272,39 @@ check_csv_golden(const char* csv_path)
 {
     static const char expected[] =
         "function,count,per_thread,per_rank,call_max_s,call_min_s,"
-        "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,dropped_calls,dropped_threads\n"
+        "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
+        "dropped_calls,dropped_threads,capability_requested,"
+        "capability_compiled,capability_active,capability_partial,"
+        "capability_retained,capability_failed,cuda_compiled_apis,"
+        "cuda_found_apis,cuda_installed_apis,cuda_failed_apis,"
+        "degraded_mask\n"
         "\"alpha\",5,3,2.5,5.000000000e-01,1.250000000e-01,"
         "1.250000000e+00,1.250000000e+00,7.500000000e-01,"
-        "2.500000000e-01,5.000000000e-02,7,3\n"
-        "\"PEAK_ACCOUNTING_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,7,3\n";
+        "2.500000000e-01,5.000000000e-02,7,3,0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_ACCOUNTING_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,7,3,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_cpu-target\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "1,1,1,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_strict-mutation\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_cuda\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "1,1,0,1,0,1,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_memory\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_dynamic-dso\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_mpi-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_socket-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_local-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CUDA_API_COVERAGE\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,7,3,1,2,0\n"
+        "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,16\n";
     PeakReportSnapshot* snapshot = create_fixture("alpha");
     PeakReportSnapshot* prepared = peak_report_snapshot_clone(snapshot);
     char* actual;
@@ -550,6 +589,30 @@ check_no_output(const char* csv_path)
     assert(text[0] == '\0');
     assert(access(csv_path, F_OK) != 0);
     free(text);
+    peak_report_snapshot_destroy(snapshot);
+}
+
+static void
+check_capability_only_output(const char* csv_path)
+{
+    PeakReportSnapshot* snapshot = peak_report_snapshot_create(0);
+    char* contents;
+
+    assert(snapshot != NULL);
+    snapshot->degraded_mask = PEAK_PROFILER_DEGRADED_JIT;
+    snapshot->capabilities.requested = PEAK_CAPABILITY_JIT;
+    snapshot->capabilities.compiled = PEAK_CAPABILITY_JIT;
+    snapshot->capabilities.failed = PEAK_CAPABILITY_JIT;
+    assert(peak_report_formatter_write_csv(snapshot));
+    contents = read_file(csv_path);
+    assert(strstr(contents,
+                  "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,"
+                  "1,1,0,0,0,1,0,0,0,0,0\n") != NULL);
+    assert(strstr(contents,
+                  "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,"
+                  "0,0,0,0,0,0,0,0,0,0,0,0,0,32\n") != NULL);
+    free(contents);
+    assert(unlink(csv_path) == 0);
     peak_report_snapshot_destroy(snapshot);
 }
 
@@ -1094,6 +1157,7 @@ main(void)
     check_rank_local_csv_names(stats_base, csv_path);
     check_csv_permissions(csv_path);
     check_no_output(csv_path);
+    check_capability_only_output(csv_path);
     check_dropped_only_output(csv_path);
     check_text_name_policy();
     check_text_flush_failure();

--- a/test/report/test_report_snapshot.c
+++ b/test/report/test_report_snapshot.c
@@ -8,6 +8,7 @@ int main(void)
 {
     PeakReportSnapshot* snapshot = peak_report_snapshot_create(2);
     PeakReportSnapshot* copy;
+    PeakProfilerCapabilityManifest manifest = {0};
 
     assert(snapshot != NULL);
     assert(snapshot->hook_count == 2);
@@ -54,6 +55,49 @@ int main(void)
     assert(snapshot->exclusive_time[0] == 3.0);
     assert(peak_report_snapshot_set_name(copy, 1, "first"));
     assert(peak_report_snapshot_has_duplicate_names(copy));
+
+    manifest.requested = PEAK_CAPABILITY_MPI_REPORT;
+    manifest.compiled = PEAK_CAPABILITY_REPORT_TRANSPORTS;
+    manifest.active = PEAK_CAPABILITY_CPU_TARGET |
+                      PEAK_CAPABILITY_MPI_REPORT;
+    manifest.partial = PEAK_CAPABILITY_CUDA;
+    manifest.failed = PEAK_CAPABILITY_CUDA;
+    peak_report_capability_manifest_set_output_outcome(
+        &manifest,
+        PEAK_CAPABILITY_MPI_REPORT,
+        PEAK_CAPABILITY_SOCKET_REPORT);
+    assert((manifest.active & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_SOCKET_REPORT);
+    assert((manifest.partial & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
+    assert((manifest.failed & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
+    assert((manifest.active & PEAK_CAPABILITY_CPU_TARGET) != 0);
+    assert((manifest.partial & PEAK_CAPABILITY_CUDA) != 0);
+    assert((manifest.failed & PEAK_CAPABILITY_CUDA) != 0);
+
+    peak_report_capability_manifest_set_output_outcome(
+        &manifest,
+        PEAK_CAPABILITY_MPI_REPORT,
+        PEAK_CAPABILITY_LOCAL_REPORT);
+    assert((manifest.active & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_LOCAL_REPORT);
+    assert((manifest.partial & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
+    assert((manifest.failed & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
+
+    peak_report_capability_reset(&manifest);
+    peak_report_capability_set_output_outcome(
+        PEAK_CAPABILITY_MPI_REPORT,
+        PEAK_CAPABILITY_LOCAL_REPORT);
+    manifest = peak_report_capability_manifest();
+    assert((manifest.active & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_LOCAL_REPORT);
+    assert((manifest.partial & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
+    assert((manifest.failed & PEAK_CAPABILITY_REPORT_TRANSPORTS) ==
+           PEAK_CAPABILITY_MPI_REPORT);
 
     peak_report_snapshot_destroy(copy);
     peak_report_snapshot_destroy(snapshot);

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -460,6 +460,25 @@ fixture_snapshot(int rank, bool mismatch_name)
         snapshot->dropped_calls = rank == 0 ? 7U : 11U;
         snapshot->dropped_threads = rank == 0 ? 2U : 3U;
     }
+    snapshot->degraded_mask = rank == 0
+        ? PEAK_PROFILER_DEGRADED_MEMORY_TRACKING
+        : PEAK_PROFILER_DEGRADED_CUDA;
+    snapshot->capabilities.requested =
+        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.compiled =
+        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.active = rank == 0
+        ? PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA
+        : PEAK_CAPABILITY_CPU_TARGET;
+    snapshot->capabilities.partial = rank == 0
+        ? 0 : PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.failed = rank == 0
+        ? 0 : PEAK_CAPABILITY_CUDA;
+    snapshot->capabilities.cuda_compiled_apis = 0x7U;
+    snapshot->capabilities.cuda_found_apis = rank == 0 ? 0x7U : 0x3U;
+    snapshot->capabilities.cuda_installed_apis =
+        rank == 0 ? 0x3U : 0x1U;
+    snapshot->capabilities.cuda_failed_apis = rank == 0 ? 0 : 0x2U;
 
     snapshot->overhead_per_call = rank == 0 ? 1e-7 : 9e-7;
     snapshot->overhead.valid = true;
@@ -524,7 +543,21 @@ aggregate_matches(const PeakReportSnapshot* aggregate)
         aggregate->dropped_calls !=
             (test_saturate_dropped_counters ? UINT64_MAX - 1 : 18U) ||
         aggregate->dropped_threads !=
-            (test_saturate_dropped_counters ? UINT64_MAX - 1 : 5U)) {
+            (test_saturate_dropped_counters ? UINT64_MAX - 1 : 5U) ||
+        aggregate->degraded_mask !=
+            (PEAK_PROFILER_DEGRADED_MEMORY_TRACKING |
+             PEAK_PROFILER_DEGRADED_CUDA) ||
+        aggregate->capabilities.requested !=
+            (PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA) ||
+        aggregate->capabilities.compiled !=
+            (PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA) ||
+        aggregate->capabilities.active != PEAK_CAPABILITY_CPU_TARGET ||
+        aggregate->capabilities.partial != PEAK_CAPABILITY_CUDA ||
+        aggregate->capabilities.failed != PEAK_CAPABILITY_CUDA ||
+        aggregate->capabilities.cuda_compiled_apis != 0x7U ||
+        aggregate->capabilities.cuda_found_apis != 0x3U ||
+        aggregate->capabilities.cuda_installed_apis != 0x1U ||
+        aggregate->capabilities.cuda_failed_apis != 0x2U) {
         return false;
     }
 
@@ -880,8 +913,8 @@ run_two_rank_case_with_peer_start_delay(int port,
         action == TEST_GATHER_PAYLOAD_DROP_FAILURE) {
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_AFTER_BYTES",
-            /* wire-v13 header (168 bytes) plus 17 payload bytes. */
-            action == TEST_GATHER_DROP_FAILURE ? "1" : "185",
+            /* wire-v14 header (216 bytes) plus 17 payload bytes. */
+            action == TEST_GATHER_DROP_FAILURE ? "1" : "233",
             1);
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_RANK",
@@ -1000,7 +1033,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         peer_ready_fds[0] = -1;
         memset(&telemetry, 0, sizeof(telemetry));
         peak_socket_report_test_telemetry_get(&telemetry);
-        if (telemetry.wire_version != 13U ||
+        if (telemetry.wire_version != 14U ||
             telemetry.peer_receipt_received !=
                 peer_registration_expected ||
             telemetry.peer_confirmation_sent !=
@@ -1069,7 +1102,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         peak_socket_report_test_receipt_barrier_set(-1, -1);
     }
     if (!peer_exits_before_connect &&
-        (root_telemetry.wire_version != 13U ||
+        (root_telemetry.wire_version != 14U ||
          (!gather_must_fail &&
           root_telemetry.root_receipt_session_nonce == 0) ||
         (!early_drop_may_skip_accept &&
@@ -1375,7 +1408,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_socket_report_transport_abort(peer_session);
         peak_report_snapshot_destroy(peer_aggregate);
         if (peer_cpu_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-            telemetry.wire_version != 13U ||
+            telemetry.wire_version != 14U ||
             !telemetry.peer_receipt_received ||
             !telemetry.peer_confirmation_sent ||
             !telemetry.peer_release_started ||
@@ -1403,7 +1436,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_report_snapshot_destroy(peer_cuda);
         if ((!cuda_schema_mismatch &&
              (peer_cuda_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-              telemetry.wire_version != 13U ||
+              telemetry.wire_version != 14U ||
               !telemetry.peer_receipt_received ||
               !telemetry.peer_confirmation_sent ||
               !telemetry.peer_release_started ||
@@ -1428,7 +1461,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
     memset(&telemetry, 0, sizeof(telemetry));
     peak_socket_report_test_telemetry_get(&telemetry);
     if (cpu_status != PEAK_SOCKET_REPORT_ROOT_PREPARED || session == NULL ||
-        !aggregate_matches(aggregate) || telemetry.wire_version != 13U ||
+        !aggregate_matches(aggregate) || telemetry.wire_version != 14U ||
         telemetry.root_payload_count != 1U ||
         telemetry.root_receipt_count != 1U ||
         telemetry.root_confirmation_count != 1U ||
@@ -1484,7 +1517,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
             }
         } else if (cuda_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
                    session == NULL || !aggregate_matches(aggregate) ||
-                   telemetry.wire_version != 13U ||
+                   telemetry.wire_version != 14U ||
                    telemetry.root_payload_count != 1U ||
                    telemetry.root_receipt_count != 1U ||
                    telemetry.root_confirmation_count != 1U ||
@@ -1845,7 +1878,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
                 &peer_aggregate);
             memset(&telemetry, 0, sizeof(telemetry));
             peak_socket_report_test_telemetry_get(&telemetry);
-            if (telemetry.wire_version != 13U ||
+            if (telemetry.wire_version != 14U ||
                 !telemetry.peer_receipt_received ||
                 !telemetry.peer_confirmation_sent ||
                 !telemetry.peer_release_started ||
@@ -1875,7 +1908,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
         peak_socket_report_test_telemetry_get(&root_telemetry);
         if (root_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
             session == NULL || aggregate == NULL ||
-            root_telemetry.wire_version != 13U ||
+            root_telemetry.wire_version != 14U ||
             root_telemetry.root_payload_count != (uint32_t)(size - 1) ||
             root_telemetry.root_receipt_count != (uint32_t)(size - 1) ||
             root_telemetry.root_confirmation_count !=
@@ -2034,7 +2067,7 @@ run_duplicate_rank_case(int port)
         peak_socket_report_test_telemetry_get(&telemetry);
         if (status != PEAK_SOCKET_REPORT_FAILED ||
             session != NULL || aggregate != NULL ||
-            telemetry.wire_version != 13U ||
+            telemetry.wire_version != 14U ||
             telemetry.root_payload_count > 1U ||
             telemetry.root_receipt_count >
                 telemetry.root_payload_count ||

--- a/test/report/test_uncompiled_backend_gating.c
+++ b/test/report/test_uncompiled_backend_gating.c
@@ -1,0 +1,30 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef uint32_t (*PeakCapabilityMaskFn)(void);
+typedef int (*PeakRuntimeStateFn)(void);
+
+int
+main(void)
+{
+    PeakCapabilityMaskFn failed_mask =
+        (PeakCapabilityMaskFn)dlsym(
+            RTLD_DEFAULT, "peak_test_capability_failed_mask");
+    PeakRuntimeStateFn runtime_active =
+        (PeakRuntimeStateFn)dlsym(
+            RTLD_DEFAULT, "peak_test_runtime_active");
+    PeakRuntimeStateFn heartbeat_started =
+        (PeakRuntimeStateFn)dlsym(
+            RTLD_DEFAULT, "peak_test_heartbeat_started");
+
+    if (failed_mask == NULL || runtime_active == NULL ||
+        heartbeat_started == NULL) {
+        fputs("PEAK backend-gating test hooks are unavailable\n", stderr);
+        return 2;
+    }
+    printf("failed_mask=0x%x runtime_active=%d heartbeat_started=%d\n",
+           failed_mask(), runtime_active(), heartbeat_started());
+    return 0;
+}

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1469,7 +1469,7 @@ def check_final_report_snapshot_order(repo_root):
         socket_prepare_receipt,
         re.DOTALL,
     ) is not None
-    require("#define PEAK_SOCKET_REDUCE_VERSION 13U" in socket_transport and
+    require("#define PEAK_SOCKET_REDUCE_VERSION 14U" in socket_transport and
             "peak_socket_reduce_header_set_report_tuple" in socket_result and
             "peak_socket_reduce_header_report_tuple" in
                 socket_validate_header and

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -193,15 +193,24 @@ def check_darwin_strict_lifecycle(repo_root):
     memory_parse = init.find(
         "peak_memory_profile = parse_env_to_bool(PEAK_MEMORY_PROFILE)"
     )
-    memory_reject = init.find("rejecting PEAK_MEMORY_PROFILE on macOS")
+    memory_request = init.find(
+        "peak_requested_work.memory = peak_memory_profile"
+    )
+    capability_freeze = init.find("peak_freeze_capability_requests()")
+    unavailable_disable = init.find(
+        "peak_disable_uncompiled_requested_work()"
+    )
     requested_work = init.find("gboolean has_requested_work")
-    require(0 <= memory_parse < memory_reject < requested_work and
-            "peak_memory_profile = false;" in
-            init[memory_reject:requested_work] and
-            "peak_memory_track_all = false;" in
-            init[memory_reject:requested_work],
-            "macOS must reject memory profiling before deciding whether any "
-            "supported work was requested")
+    disable_uncompiled = extract_function(
+        peak, "peak_disable_uncompiled_requested_work"
+    )
+    require(0 <= memory_parse < memory_request < capability_freeze <
+            unavailable_disable < requested_work and
+            "peak_requested_work.memory = FALSE;" in disable_uncompiled and
+            "peak_memory_profile = FALSE;" in disable_uncompiled and
+            "peak_memory_track_all = FALSE;" in disable_uncompiled,
+            "unsupported memory profiling must remain requested in the "
+            "manifest, then be removed from work-to-activate")
 
     dynamic_attach = activation.find("dlopen_interceptor_attach()")
     dynamic_attach_guard = activation.rfind(

--- a/test/static_checks/check_gum_mutation_allowlist.py
+++ b/test/static_checks/check_gum_mutation_allowlist.py
@@ -74,7 +74,7 @@ EXPECTED = {
     ("support-init", "src/cuda_interceptor.cpp"): {
         "begin_transaction": 1,
         "end_transaction": 1,
-        "replace_fast": 10,
+        "replace_fast": 1,
         "revert": 5,
     },
     ("support-shutdown-debt", "src/cuda_interceptor.cpp"): {
@@ -116,6 +116,7 @@ FUNCTION_ANCHORS = {
         "mpi_interceptor_dettach": "support-shutdown-debt",
     },
     "src/cuda_interceptor.cpp": {
+        "peak_cuda_replace_fast": "support-init",
         "cuda_interceptor_attach": "support-init",
         "cuda_interceptor_dettach": "support-shutdown-debt",
     },


### PR DESCRIPTION
## Summary

- activate CPU, CUDA, memory, and JIT backends only when their work is both requested and compiled
- fail open with one degraded warning and an accurate failed capability when a requested optional backend is unavailable
- report requested, compiled, active, partial, retained, and failed backend capabilities through text, stats CSV, MPI, and socket reports
- record the transport that actually produced the report, including MPI/socket fallback to rank-local output
- record CUDA state retained by bounded finalization and fail-closed teardown decisions
- report strict mutation independently from CPU profiling, including non-patched Gum builds where CPU profiling remains active but strict mutation is unavailable
- avoid the CPU heartbeat thread when strict mutation is unavailable and for GPU-only, memory-only, and JIT-only workloads, and start the controller only for active JIT work
- expose per-API CUDA replacement coverage and preserve partial CUDA operation without disabling the subsystem

## Validation

- true no-CUDA build: unavailable requested CUDA is failed/degraded and does not activate the shared runtime or heartbeat
- focused report snapshot, formatter, socket fallback, MPI lifecycle, optional-backend gating, portability, and static tests with GCC and Clang
- ASan/UBSan report snapshot test
- non-patched-Gum equivalent regression with a nonzero heartbeat interval: CPU remains active, strict mutation reports requested, uncompiled, inactive, partial, and failed, and no heartbeat thread starts
- RTX 5090 CUDA regressions for GPU-only heartbeat gating with a nonzero interval, partial capability state, and forced bounded-finalization retention
- GitHub Actions: 16/16 checks passed on exact head `a87b327a35d14ff5f8575513fc389d353d0a0927`, including GCC, Clang, macOS, Intel MPI, MPICH, Open MPI, controlled dependencies, detach benchmarks, and TSan
- `git diff --check`

Closes #90
