### PR TITLE
Bound profiler-owned lifecycle waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ in detail.
 | `PEAK_VERBOSITY` | `silent`, `report`/`quiet`, `warn`, `info`, or `debug`; numeric levels `0` through `4` are also accepted. |
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
 | `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. |
+| `PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS` | Maximum wait for another thread to finish deferred runtime activation. On timeout, dependent teardown/report work is skipped. Default: `5000`. |
+| `PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS` | Maximum wait for a `pthread_create()` caller to publish child slot metadata. On timeout, the child runs untracked and late metadata is discarded safely. Default: `5000`. |
 
 Every text and stats CSV report includes a capability manifest for CPU targets,
 strict mutation, CUDA, memory tracking, JIT input, dynamic DSO discovery, and
@@ -310,6 +312,7 @@ reported partial and failed.
 | `PEAK_MPI_FINALIZE_POLICY` | Report during MPI finalization (`report`, the default for every transport) or explicitly defer PEAK output until process exit (`defer`). Unless `PEAK_MPI_REAL_FINALIZE=0`, `defer` calls the real finalizer immediately and therefore bypasses the Intel MPI 2019 compatibility skip. |
 | `PEAK_MPI_REAL_FINALIZE` | Override for the real MPI finalizer. Healthy non-Intel-MPI-2019 jobs enable it by default; Intel MPI 2019 skips its crash-prone finalizer unless set to `1`. Setting it to `0` also disables the immediate real-finalizer call in `defer` mode. Setting it to `1` cannot override a failed collective safety gate on the default `report` path. |
 | `PEAK_MPI_FINALIZE_REQUEST_TIMEOUT_MS` | Timeout for the proof-first MPI aggregation finalization-participation check. Default: `10000`. |
+| `PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS` | Maximum wait for another thread in the same process to complete the one-owner real MPI finalizer path. On timeout, PEAK fails closed without making a second MPI call. Default: `5000`. |
 | `PEAK_MPI_REPORT_RELEASE_TIMEOUT_MS` | Baseline timeout for the post-publication all-rank release gate. For socket/local output this same gate also proves finalize participation. Default: `180000`; only a path that attempted socket publication raises the effective timeout to at least the peer release budget plus two socket-phase margins (`300000` for a singleton-size default and scale-adjusted for larger jobs). |
 | `PEAK_MPI_OUTPUT_AGGREGATION_TIMEOUT_MS` | Timeout for each MPI payload reduction. Default: `5000`. |
 | `PEAK_OUTPUT_AGGREGATION_HOST` | Override the socket reducer host. |
@@ -457,6 +460,7 @@ semantics, module lifetime, and supported boundaries.
 | `PEAK_MEMORY_TRACK_ALL` | On Linux, track all allocation events instead of filtering by target backtraces. |
 | `PEAK_MEMLOG_PATH` | Memory CSV output prefix. Default: `./peak_memlog`. |
 | `PEAK_MEMLOG_CHUNK_EVENTS` | Experimental memory-profiler fixed export capacity. A positive decimal value reserves that many events plus at most one 64-event reservation block of slack per tracked thread; when full, new events are dropped and reported at finalization. The mapping never grows or moves. |
+| `PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS` | Maximum wait for admitted memory-log writers after shutdown closes admission. On timeout, PEAK retains the live mapping and skips export/destructive cleanup. Default: `5000`. |
 | `PEAK_MEMLOG_OTF2_DIR` | Override the directory for memory-profile OTF2 output. |
 
 CUDA kernel identity state is also fixed at attach time. The primary identity

--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -116,6 +116,9 @@ PEAK_EXEC_API int peak_test_activation_after_claim_is_held(void);
 /** Releases an activation paused after claiming ownership. */
 PEAK_EXEC_API void peak_test_activation_after_claim_release(void);
 
+/** Returns the number of threads blocked on activation publication. */
+PEAK_EXEC_API unsigned int peak_test_activation_waiter_count(void);
+
 /** @} */
 #endif
 

--- a/include/exec_interceptor.h
+++ b/include/exec_interceptor.h
@@ -107,6 +107,15 @@ PEAK_EXEC_API int peak_test_activation_is_held(void);
 /** Releases an activation paused by `peak_test_activation_pause_enable()`. */
 PEAK_EXEC_API void peak_test_activation_release(void);
 
+/** Pauses the next runtime activation after it claims ownership. */
+PEAK_EXEC_API void peak_test_activation_pause_after_claim_enable(void);
+
+/** Returns nonzero while activation is paused after claiming ownership. */
+PEAK_EXEC_API int peak_test_activation_after_claim_is_held(void);
+
+/** Releases an activation paused after claiming ownership. */
+PEAK_EXEC_API void peak_test_activation_after_claim_release(void);
+
 /** @} */
 #endif
 

--- a/include/internal/pthread_slot_registry.h
+++ b/include/internal/pthread_slot_registry.h
@@ -14,6 +14,12 @@ typedef struct {
     uint64_t generation;
 } PeakPthreadSlotToken;
 
+typedef enum {
+    PEAK_PTHREAD_START_PENDING = 0,
+    PEAK_PTHREAD_START_READY = 1,
+    PEAK_PTHREAD_START_ABANDONED = 2,
+} PeakPthreadStartHandshakeState;
+
 typedef struct {
     pthread_t tid;
     PeakPthreadSlotToken token;
@@ -56,7 +62,11 @@ size_t peak_pthread_slot_registry_snapshot(PeakPthreadSlotRegistry* registry,
                                            size_t* slots,
                                            size_t capacity,
                                            bool* complete);
-void peak_pthread_slot_registry_publish_ready(_Atomic int* ready);
-void peak_pthread_slot_registry_wait_ready(const _Atomic int* ready);
+bool peak_pthread_slot_registry_publish_ready(_Atomic int* state);
+PeakPthreadStartHandshakeState peak_pthread_slot_registry_wait_ready(
+    _Atomic int* state, unsigned int timeout_ms);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+unsigned int peak_pthread_slot_registry_test_wake_waiters(void);
+#endif
 
 #endif /* PEAK_PTHREAD_SLOT_REGISTRY_H */

--- a/include/mpi_interceptor.h
+++ b/include/mpi_interceptor.h
@@ -85,6 +85,16 @@ PEAK_MPI_INTERCEPTOR_API int
 mpi_interceptor_test_wait_for_finalize_owner(void);
 PEAK_MPI_INTERCEPTOR_API int
 mpi_interceptor_test_collectives_failed_closed(void);
+PEAK_MPI_INTERCEPTOR_API unsigned int
+mpi_interceptor_test_finalize_waiter_count(void);
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_publish_finalize_result(int result);
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_prepare_original_finalize_stub(void);
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_call_original_finalize_once(void);
+PEAK_MPI_INTERCEPTOR_API unsigned int
+mpi_interceptor_test_original_finalize_call_count(void);
 #endif
 
 /**

--- a/include/mpi_interceptor.h
+++ b/include/mpi_interceptor.h
@@ -78,6 +78,15 @@ int mpi_interceptor_finalize_was_requested();
  */
 int mpi_interceptor_finalize_path_active();
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_set_finalize_in_progress(void);
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_wait_for_finalize_owner(void);
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_collectives_failed_closed(void);
+#endif
+
 /**
  * @brief Controls whether the intercepted finalizer may call real PMPI_Finalize.
  *

--- a/include/pthread_listener.h
+++ b/include/pthread_listener.h
@@ -100,6 +100,12 @@ int pthread_listener_test_stale_generation_remove_preserves_mapping(
     pthread_t thread);
 int pthread_listener_test_untracked_create_removes_ambiguous_mapping(
     pthread_t thread);
+PEAK_PTHREAD_LISTENER_API void
+pthread_listener_test_pause_start_publication_enable(void);
+PEAK_PTHREAD_LISTENER_API void
+pthread_listener_test_release_start_publication(void);
+PEAK_PTHREAD_LISTENER_API int
+pthread_listener_test_current_thread_has_slot(void);
 #endif
 
 /**

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -658,6 +658,18 @@ peak_memlog_wait_for_writers(void)
     return drained;
 }
 
+static double
+peak_memlog_elapsed_ms(const struct timespec* started)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)(now.tv_sec - started->tv_sec) * 1000.0 +
+           (double)(now.tv_nsec - started->tv_nsec) / 1000000.0;
+}
+
 static int peak_memlog_disable(void) {
     PeakMemLogState state;
 
@@ -953,6 +965,8 @@ static inline int peak_csv_emit_line(int fd_csv, const PeakMemEvent *e) {
 static void peak_memlog_finalize(void) {
     size_t events;
     PeakMemLogState state;
+    struct timespec writer_wait_started;
+    int writer_wait_clock_available;
 
     /* Serialize finalizers; a DISABLED state can still have admitted writers. */
     pthread_mutex_lock(&memlog_finalize_mutex);
@@ -967,7 +981,12 @@ static void peak_memlog_finalize(void) {
         return;
     }
 
+    writer_wait_clock_available =
+        clock_gettime(CLOCK_MONOTONIC, &writer_wait_started) == 0;
     if (!peak_memlog_disable()) {
+        double elapsed_ms = writer_wait_clock_available ?
+            peak_memlog_elapsed_ms(&writer_wait_started) : -1.0;
+
         note_memory_tracking_degraded(
             "memory-log writer drain deadline expired; retaining live log state");
         peak_report_capability_note_partial(PEAK_CAPABILITY_MEMORY);
@@ -975,12 +994,23 @@ static void peak_memlog_finalize(void) {
         peak_report_snapshot_note_degraded(
             PEAK_PROFILER_DEGRADED_MEMORY_TRACKING,
             "memory-log writer drain deadline expired");
-        peak_log_warn(
-            "[peak] memlog: %zu active writer(s) did not drain within %u ms; "
-            "retaining the mapping and skipping export so process exit can continue\n",
-            atomic_load_explicit(&g_memlog.active_writers,
-                                 memory_order_acquire),
-            peak_memlog_writer_timeout_ms);
+        if (elapsed_ms >= 0.0) {
+            peak_log_warn(
+                "[peak] memlog: %zu active writer(s) did not drain after "
+                "%.3f ms (timeout=%u ms); retaining the mapping and skipping "
+                "export so process exit can continue\n",
+                atomic_load_explicit(&g_memlog.active_writers,
+                                     memory_order_acquire),
+                elapsed_ms, peak_memlog_writer_timeout_ms);
+        } else {
+            peak_log_warn(
+                "[peak] memlog: %zu active writer(s) did not drain "
+                "(elapsed unavailable; timeout=%u ms); retaining the mapping "
+                "and skipping export so process exit can continue\n",
+                atomic_load_explicit(&g_memlog.active_writers,
+                                     memory_order_acquire),
+                peak_memlog_writer_timeout_ms);
+        }
         pthread_mutex_unlock(&memlog_finalize_mutex);
         return;
     }

--- a/src/malloc_interceptor.c
+++ b/src/malloc_interceptor.c
@@ -2,6 +2,7 @@
 #include "malloc_interceptor.h"
 #include "malloc_otf2.h"
 #include "internal/general_listener/output_identity.h"
+#include "internal/general_listener/report_snapshot.h"
 #include "logging.h"
 #include "utils/env_parser.h"
 #include <stddef.h>
@@ -62,6 +63,9 @@ typedef struct {
  * ready-flag cache line of physical slots without reducing the configured
  * export capacity. */
 #define PEAK_MEMLOG_MAX_TRACKED_THREADS 4096u
+#define PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS_ENV \
+    "PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS"
+#define PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS_DEFAULT 5000U
 
 /*=========================
   Globals
@@ -72,6 +76,10 @@ extern char**              peak_hook_strings;
 static GumInterceptor*     malloc_interceptor;
 static pthread_mutex_t     caller_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t     memlog_finalize_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t     memlog_writer_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t      memlog_writer_cond;
+static pthread_once_t      memlog_writer_cond_once = PTHREAD_ONCE_INIT;
+static _Atomic int         memlog_writer_cond_ready;
 static pthread_once_t      malloc_tid_cache_once = PTHREAD_ONCE_INIT;
 static PeakAccountingShard accounting_shards[PEAK_ACCOUNTING_SHARD_COUNT];
 static PeakTrackingRadixNode tracking_root;
@@ -107,8 +115,13 @@ static __thread size_t     memlog_reservation_next = 0;
 static __thread size_t     memlog_reservation_end = 0;
 #endif
 static PeakEnvWarningState peak_memlog_capacity_warning_emitted;
+static PeakEnvWarningState peak_memlog_writer_timeout_warning_emitted;
 static _Atomic int         peak_memory_tracking_warning_emitted = 0;
 static _Atomic int         peak_memlog_full = 0;
+static unsigned int        peak_memlog_writer_timeout_ms =
+    PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS_DEFAULT;
+
+static void note_memory_tracking_degraded(const char* reason);
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic PeakMemLogTestFailure g_memlog_test_failure = PEAK_MEMLOG_TEST_FAIL_NONE;
@@ -394,7 +407,15 @@ static int peak_memlog_writer_enter(void) {
 }
 
 static void peak_memlog_writer_leave(void) {
-    atomic_fetch_sub_explicit(&g_memlog.active_writers, 1, memory_order_release);
+    if (atomic_fetch_sub_explicit(&g_memlog.active_writers, 1,
+                                  memory_order_acq_rel) == 1 &&
+        atomic_load_explicit(&memlog_writer_cond_ready,
+                             memory_order_acquire) != 0) {
+        if (pthread_mutex_lock(&memlog_writer_mutex) == 0) {
+            (void)pthread_cond_broadcast(&memlog_writer_cond);
+            (void)pthread_mutex_unlock(&memlog_writer_mutex);
+        }
+    }
 }
 #endif
 
@@ -539,18 +560,114 @@ peak_log_event(uint64_t ts,
                                accounting_shard, accounting_sequence);
 }
 
-static void peak_memlog_disable(void) {
+static void
+peak_memlog_writer_cond_initialize(void)
+{
+#if defined(__linux__)
+    pthread_condattr_t attr;
+    int status;
+
+    if (pthread_condattr_init(&attr) != 0) {
+        return;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&memlog_writer_cond, &attr);
+    }
+    (void)pthread_condattr_destroy(&attr);
+    if (status == 0) {
+        atomic_store_explicit(&memlog_writer_cond_ready, 1,
+                              memory_order_release);
+    }
+#elif defined(__APPLE__)
+    if (pthread_cond_init(&memlog_writer_cond, NULL) == 0) {
+        atomic_store_explicit(&memlog_writer_cond_ready, 1,
+                              memory_order_release);
+    }
+#endif
+}
+
+static int
+peak_memlog_writer_timedwait(const struct timespec* deadline)
+{
+#if defined(__linux__)
+    return pthread_cond_timedwait(&memlog_writer_cond,
+                                  &memlog_writer_mutex,
+                                  deadline);
+#elif defined(__APPLE__)
+    struct timespec now;
+    struct timespec remaining;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return EINVAL;
+    }
+    remaining.tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining.tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining.tv_nsec < 0) {
+        remaining.tv_sec--;
+        remaining.tv_nsec += 1000000000L;
+    }
+    if (remaining.tv_sec < 0 ||
+        (remaining.tv_sec == 0 && remaining.tv_nsec == 0)) {
+        return ETIMEDOUT;
+    }
+    return pthread_cond_timedwait_relative_np(&memlog_writer_cond,
+                                              &memlog_writer_mutex,
+                                              &remaining);
+#else
+    (void)deadline;
+    return ENOTSUP;
+#endif
+}
+
+static int
+peak_memlog_wait_for_writers(void)
+{
+    struct timespec deadline;
+
+    if (atomic_load_explicit(&g_memlog.active_writers,
+                             memory_order_acquire) == 0) {
+        return 1;
+    }
+    if (pthread_once(&memlog_writer_cond_once,
+                     peak_memlog_writer_cond_initialize) != 0 ||
+        atomic_load_explicit(&memlog_writer_cond_ready,
+                             memory_order_acquire) == 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &deadline) != 0) {
+        return 0;
+    }
+    deadline.tv_sec += peak_memlog_writer_timeout_ms / 1000U;
+    deadline.tv_nsec +=
+        (long)(peak_memlog_writer_timeout_ms % 1000U) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+    if (pthread_mutex_lock(&memlog_writer_mutex) != 0) {
+        return 0;
+    }
+    while (atomic_load_explicit(&g_memlog.active_writers,
+                                memory_order_acquire) != 0) {
+        if (peak_memlog_writer_timedwait(&deadline) != 0) {
+            break;
+        }
+    }
+    int drained = atomic_load_explicit(&g_memlog.active_writers,
+                                       memory_order_acquire) == 0;
+    (void)pthread_mutex_unlock(&memlog_writer_mutex);
+    return drained;
+}
+
+static int peak_memlog_disable(void) {
     PeakMemLogState state;
 
     state = atomic_exchange_explicit(&g_memlog.state, PEAK_MEMLOG_DISABLED,
                                      memory_order_acq_rel);
 
     if (state == PEAK_MEMLOG_ACTIVE || state == PEAK_MEMLOG_DISABLED) {
-        while (atomic_load_explicit(&g_memlog.active_writers,
-                                    memory_order_acquire) != 0) {
-            sched_yield();
-        }
+        return peak_memlog_wait_for_writers();
     }
+    return 1;
 }
 
 static size_t peak_memlog_compact_committed(void) {
@@ -668,9 +785,22 @@ static void peak_memlog_open(void) {
     void* base = MAP_FAILED;
     const char* env_capacity;
     const char* output_template;
+    PeakEnvUnsignedSchema writer_timeout_schema = {
+        PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS_ENV,
+        "milliseconds",
+        PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS_DEFAULT,
+        1,
+        UINT_MAX,
+        false,
+        &peak_memlog_writer_timeout_warning_emitted,
+        false,
+    };
 
     if (atomic_load_explicit(&g_memlog.state, memory_order_acquire) !=
         PEAK_MEMLOG_UNINITIALIZED) return;
+
+    peak_memlog_writer_timeout_ms = (unsigned int)
+        peak_parse_env_unsigned(&writer_timeout_schema);
 
     env_capacity = getenv("PEAK_MEMLOG_CHUNK_EVENTS");
     if (env_capacity && !parse_memlog_capacity(&capacity_events)) {
@@ -837,7 +967,23 @@ static void peak_memlog_finalize(void) {
         return;
     }
 
-    peak_memlog_disable();
+    if (!peak_memlog_disable()) {
+        note_memory_tracking_degraded(
+            "memory-log writer drain deadline expired; retaining live log state");
+        peak_report_capability_note_partial(PEAK_CAPABILITY_MEMORY);
+        peak_report_capability_note_retained(PEAK_CAPABILITY_MEMORY);
+        peak_report_snapshot_note_degraded(
+            PEAK_PROFILER_DEGRADED_MEMORY_TRACKING,
+            "memory-log writer drain deadline expired");
+        peak_log_warn(
+            "[peak] memlog: %zu active writer(s) did not drain within %u ms; "
+            "retaining the mapping and skipping export so process exit can continue\n",
+            atomic_load_explicit(&g_memlog.active_writers,
+                                 memory_order_acquire),
+            peak_memlog_writer_timeout_ms);
+        pthread_mutex_unlock(&memlog_finalize_mutex);
+        return;
+    }
     if (!g_memlog.map) {
         atomic_store_explicit(&g_memlog.state, PEAK_MEMLOG_FINALIZED, memory_order_release);
         pthread_mutex_unlock(&memlog_finalize_mutex);

--- a/src/mpi_interceptor.c
+++ b/src/mpi_interceptor.c
@@ -44,6 +44,10 @@ static _Atomic int peak_finalize_wait_warning_emitted;
 static PeakEnvWarningState peak_finalize_timeout_config_warning;
 static unsigned int peak_finalize_owner_timeout_ms =
     PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_DEFAULT;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic unsigned int peak_finalize_test_waiters;
+static _Atomic unsigned int peak_finalize_test_original_calls;
+#endif
 
 static int (*original_pmpi_finalize)(void);
 extern void peak_fini(void);
@@ -171,9 +175,32 @@ mpi_interceptor_finalize_publish_done(int result)
     (void)pthread_mutex_unlock(&peak_finalize_mutex);
 }
 
+static void
+mpi_interceptor_finalize_wait_cancel(void* data)
+{
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_sub_explicit(&peak_finalize_test_waiters, 1,
+                              memory_order_release);
+#endif
+    (void)pthread_mutex_unlock((pthread_mutex_t*)data);
+}
+
+static double
+mpi_interceptor_finalize_elapsed_ms(const struct timespec* started)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)(now.tv_sec - started->tv_sec) * 1000.0 +
+           (double)(now.tv_nsec - started->tv_nsec) / 1000000.0;
+}
+
 static int
 mpi_interceptor_wait_for_finalize_owner(void)
 {
+    struct timespec started;
     struct timespec deadline;
     int state;
     int wait_status = 0;
@@ -182,10 +209,11 @@ mpi_interceptor_wait_for_finalize_owner(void)
                      mpi_interceptor_finalize_cond_initialize) != 0 ||
         !atomic_load_explicit(&peak_finalize_cond_ready,
                               memory_order_acquire) ||
-        clock_gettime(CLOCK_MONOTONIC, &deadline) != 0) {
+        clock_gettime(CLOCK_MONOTONIC, &started) != 0) {
         wait_status = ENOTSUP;
         goto failed_closed;
     }
+    deadline = started;
     deadline.tv_sec += peak_finalize_owner_timeout_ms / 1000U;
     deadline.tv_nsec +=
         (long)(peak_finalize_owner_timeout_ms % 1000U) * 1000000L;
@@ -197,6 +225,12 @@ mpi_interceptor_wait_for_finalize_owner(void)
         wait_status = EINVAL;
         goto failed_closed;
     }
+    pthread_cleanup_push(mpi_interceptor_finalize_wait_cancel,
+                         &peak_finalize_mutex);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_add_explicit(&peak_finalize_test_waiters, 1,
+                              memory_order_release);
+#endif
     while ((state = __atomic_load_n(&peak_finalize_state,
                                      __ATOMIC_ACQUIRE)) ==
            PEAK_MPI_FINALIZE_IN_PROGRESS) {
@@ -205,6 +239,11 @@ mpi_interceptor_wait_for_finalize_owner(void)
             break;
         }
     }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_sub_explicit(&peak_finalize_test_waiters, 1,
+                              memory_order_release);
+#endif
+    pthread_cleanup_pop(0);
     (void)pthread_mutex_unlock(&peak_finalize_mutex);
     if (state == PEAK_MPI_FINALIZE_DONE) {
         return __atomic_load_n(&peak_finalize_result, __ATOMIC_ACQUIRE);
@@ -233,12 +272,26 @@ failed_closed:
             if (atomic_exchange_explicit(
                     &peak_finalize_wait_warning_emitted, 1,
                     memory_order_acq_rel) == 0) {
-                peak_log_warn(
-                    "[peak] MPI finalizer owner did not complete within %u ms "
-                    "(%s); failing closed without another MPI call\n",
-                    peak_finalize_owner_timeout_ms,
-                    wait_status == ETIMEDOUT ? "deadline expired" :
-                                                "wait unavailable");
+                double elapsed_ms = wait_status == ENOTSUP ? -1.0 :
+                    mpi_interceptor_finalize_elapsed_ms(&started);
+
+                if (elapsed_ms >= 0.0) {
+                    peak_log_warn(
+                        "[peak] MPI finalizer owner did not complete after "
+                        "%.3f ms (timeout=%u ms; %s); failing closed without "
+                        "another MPI call\n",
+                        elapsed_ms, peak_finalize_owner_timeout_ms,
+                        wait_status == ETIMEDOUT ? "deadline expired" :
+                                                    "wait unavailable");
+                } else {
+                    peak_log_warn(
+                        "[peak] MPI finalizer owner did not complete "
+                        "(elapsed unavailable; timeout=%u ms; %s); failing "
+                        "closed without another MPI call\n",
+                        peak_finalize_owner_timeout_ms,
+                        wait_status == ETIMEDOUT ? "deadline expired" :
+                                                    "wait unavailable");
+                }
             }
         }
     }
@@ -516,6 +569,16 @@ mpi_interceptor_call_original_finalize_once(void)
     }
 }
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static int
+mpi_interceptor_test_original_finalize_stub(void)
+{
+    atomic_fetch_add_explicit(&peak_finalize_test_original_calls, 1,
+                              memory_order_relaxed);
+    return MPI_SUCCESS;
+}
+#endif
+
 /**
  * @brief Custom implementation of `PMPI_Finalize` function
  *
@@ -604,6 +667,41 @@ PEAK_MPI_INTERCEPTOR_API int
 mpi_interceptor_test_collectives_failed_closed(void)
 {
     return peak_mpi_teardown_collectives_failed_closed() ? 1 : 0;
+}
+
+PEAK_MPI_INTERCEPTOR_API unsigned int
+mpi_interceptor_test_finalize_waiter_count(void)
+{
+    return atomic_load_explicit(&peak_finalize_test_waiters,
+                                memory_order_acquire);
+}
+
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_publish_finalize_result(int result)
+{
+    mpi_interceptor_finalize_publish_done(result);
+}
+
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_prepare_original_finalize_stub(void)
+{
+    original_pmpi_finalize = mpi_interceptor_test_original_finalize_stub;
+    __atomic_store_n(&peak_real_finalize_allowed, 1, __ATOMIC_RELEASE);
+    atomic_store_explicit(&peak_finalize_test_original_calls, 0,
+                          memory_order_relaxed);
+}
+
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_call_original_finalize_once(void)
+{
+    return mpi_interceptor_call_original_finalize_once();
+}
+
+PEAK_MPI_INTERCEPTOR_API unsigned int
+mpi_interceptor_test_original_finalize_call_count(void)
+{
+    return atomic_load_explicit(&peak_finalize_test_original_calls,
+                                memory_order_relaxed);
 }
 #endif
 

--- a/src/mpi_interceptor.c
+++ b/src/mpi_interceptor.c
@@ -1,15 +1,22 @@
 #define _GNU_SOURCE
 #include "mpi_interceptor.h"
 #include "general_listener.h"
+#include "internal/mpi_teardown_guard.h"
 #include "logging.h"
+#include "utils/env_parser.h"
 
 #include <dlfcn.h>
+#include <errno.h>
+#include <limits.h>
 #include <pthread.h>
-#include <sched.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define PEAK_MPI_FINALIZE_POLICY_ENV "PEAK_MPI_FINALIZE_POLICY"
+#define PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_ENV \
+    "PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS"
+#define PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_DEFAULT 5000U
 
 #undef g_printerr
 #define g_printerr(...) peak_log_warn(__VA_ARGS__)
@@ -21,6 +28,7 @@ typedef enum {
     PEAK_MPI_FINALIZE_REQUESTED = 1,
     PEAK_MPI_FINALIZE_IN_PROGRESS = 2,
     PEAK_MPI_FINALIZE_DONE = 3,
+    PEAK_MPI_FINALIZE_FAILED_CLOSED = 4,
 } PeakMpiFinalizeState;
 
 static int peak_finalize_state = PEAK_MPI_FINALIZE_NOT_REQUESTED;
@@ -28,6 +36,14 @@ static int peak_finalize_result = 0;
 static int peak_real_finalize_allowed = 0;
 static int peak_finalize_path_active = 0;
 static gpointer hook_address;
+static pthread_mutex_t peak_finalize_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_finalize_cond;
+static pthread_once_t peak_finalize_cond_once = PTHREAD_ONCE_INIT;
+static _Atomic int peak_finalize_cond_ready;
+static _Atomic int peak_finalize_wait_warning_emitted;
+static PeakEnvWarningState peak_finalize_timeout_config_warning;
+static unsigned int peak_finalize_owner_timeout_ms =
+    PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_DEFAULT;
 
 static int (*original_pmpi_finalize)(void);
 extern void peak_fini(void);
@@ -44,6 +60,190 @@ static pthread_once_t real_pmpi_init_once = PTHREAD_ONCE_INIT;
 static pthread_once_t real_mpi_init_thread_once = PTHREAD_ONCE_INIT;
 static pthread_once_t real_pmpi_init_thread_once = PTHREAD_ONCE_INIT;
 static _Thread_local unsigned int peak_mpi_init_wrapper_depth;
+
+static void
+mpi_interceptor_configure_finalize_owner_timeout(void)
+{
+    PeakEnvUnsignedSchema schema = {
+        PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_ENV,
+        "milliseconds",
+        PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS_DEFAULT,
+        1,
+        UINT_MAX,
+        false,
+        &peak_finalize_timeout_config_warning,
+        false,
+    };
+
+    peak_finalize_owner_timeout_ms =
+        (unsigned int)peak_parse_env_unsigned(&schema);
+}
+
+static void
+mpi_interceptor_finalize_cond_initialize(void)
+{
+#if defined(__linux__)
+    pthread_condattr_t attr;
+    int status;
+
+    if (pthread_condattr_init(&attr) != 0) {
+        return;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&peak_finalize_cond, &attr);
+    }
+    (void)pthread_condattr_destroy(&attr);
+    if (status == 0) {
+        atomic_store_explicit(&peak_finalize_cond_ready, 1,
+                              memory_order_release);
+    }
+#elif defined(__APPLE__)
+    if (pthread_cond_init(&peak_finalize_cond, NULL) == 0) {
+        atomic_store_explicit(&peak_finalize_cond_ready, 1,
+                              memory_order_release);
+    }
+#endif
+}
+
+static int
+mpi_interceptor_finalize_cond_timedwait(const struct timespec* deadline)
+{
+#if defined(__linux__)
+    return pthread_cond_timedwait(&peak_finalize_cond,
+                                  &peak_finalize_mutex,
+                                  deadline);
+#elif defined(__APPLE__)
+    struct timespec now;
+    struct timespec remaining;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return EINVAL;
+    }
+    remaining.tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining.tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining.tv_nsec < 0) {
+        remaining.tv_sec--;
+        remaining.tv_nsec += 1000000000L;
+    }
+    if (remaining.tv_sec < 0 ||
+        (remaining.tv_sec == 0 && remaining.tv_nsec == 0)) {
+        return ETIMEDOUT;
+    }
+    return pthread_cond_timedwait_relative_np(&peak_finalize_cond,
+                                              &peak_finalize_mutex,
+                                              &remaining);
+#else
+    (void)deadline;
+    return ENOTSUP;
+#endif
+}
+
+static void
+mpi_interceptor_finalize_mark_done(void)
+{
+    int state = __atomic_load_n(&peak_finalize_state, __ATOMIC_ACQUIRE);
+
+    while (state == PEAK_MPI_FINALIZE_REQUESTED ||
+           state == PEAK_MPI_FINALIZE_IN_PROGRESS) {
+        if (__atomic_compare_exchange_n(
+                &peak_finalize_state, &state, PEAK_MPI_FINALIZE_DONE,
+                FALSE, __ATOMIC_RELEASE, __ATOMIC_ACQUIRE)) {
+            return;
+        }
+    }
+}
+
+static void
+mpi_interceptor_finalize_publish_done(int result)
+{
+    __atomic_store_n(&peak_finalize_result, result, __ATOMIC_RELEASE);
+    if (pthread_once(&peak_finalize_cond_once,
+                     mpi_interceptor_finalize_cond_initialize) != 0 ||
+        !atomic_load_explicit(&peak_finalize_cond_ready,
+                              memory_order_acquire) ||
+        pthread_mutex_lock(&peak_finalize_mutex) != 0) {
+        mpi_interceptor_finalize_mark_done();
+        return;
+    }
+    mpi_interceptor_finalize_mark_done();
+    (void)pthread_cond_broadcast(&peak_finalize_cond);
+    (void)pthread_mutex_unlock(&peak_finalize_mutex);
+}
+
+static int
+mpi_interceptor_wait_for_finalize_owner(void)
+{
+    struct timespec deadline;
+    int state;
+    int wait_status = 0;
+
+    if (pthread_once(&peak_finalize_cond_once,
+                     mpi_interceptor_finalize_cond_initialize) != 0 ||
+        !atomic_load_explicit(&peak_finalize_cond_ready,
+                              memory_order_acquire) ||
+        clock_gettime(CLOCK_MONOTONIC, &deadline) != 0) {
+        wait_status = ENOTSUP;
+        goto failed_closed;
+    }
+    deadline.tv_sec += peak_finalize_owner_timeout_ms / 1000U;
+    deadline.tv_nsec +=
+        (long)(peak_finalize_owner_timeout_ms % 1000U) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+    if (pthread_mutex_lock(&peak_finalize_mutex) != 0) {
+        wait_status = EINVAL;
+        goto failed_closed;
+    }
+    while ((state = __atomic_load_n(&peak_finalize_state,
+                                     __ATOMIC_ACQUIRE)) ==
+           PEAK_MPI_FINALIZE_IN_PROGRESS) {
+        wait_status = mpi_interceptor_finalize_cond_timedwait(&deadline);
+        if (wait_status != 0) {
+            break;
+        }
+    }
+    (void)pthread_mutex_unlock(&peak_finalize_mutex);
+    if (state == PEAK_MPI_FINALIZE_DONE) {
+        return __atomic_load_n(&peak_finalize_result, __ATOMIC_ACQUIRE);
+    }
+    if (state == PEAK_MPI_FINALIZE_FAILED_CLOSED) {
+        return MPI_ERR_OTHER;
+    }
+    if (state != PEAK_MPI_FINALIZE_IN_PROGRESS) {
+        return 0;
+    }
+
+failed_closed:
+    {
+        int expected = PEAK_MPI_FINALIZE_IN_PROGRESS;
+
+        if (__atomic_compare_exchange_n(
+                &peak_finalize_state,
+                &expected,
+                PEAK_MPI_FINALIZE_FAILED_CLOSED,
+                FALSE,
+                __ATOMIC_ACQ_REL,
+                __ATOMIC_ACQUIRE)) {
+            __atomic_store_n(&peak_real_finalize_allowed, 0,
+                             __ATOMIC_RELEASE);
+            peak_mpi_teardown_collectives_mark_failed_closed();
+            if (atomic_exchange_explicit(
+                    &peak_finalize_wait_warning_emitted, 1,
+                    memory_order_acq_rel) == 0) {
+                peak_log_warn(
+                    "[peak] MPI finalizer owner did not complete within %u ms "
+                    "(%s); failing closed without another MPI call\n",
+                    peak_finalize_owner_timeout_ms,
+                    wait_status == ETIMEDOUT ? "deadline expired" :
+                                                "wait unavailable");
+            }
+        }
+    }
+    return MPI_ERR_OTHER;
+}
 
 static void
 mpi_interceptor_resolve_mpi_init_once(void)
@@ -262,18 +462,13 @@ mpi_interceptor_call_original_finalize_once(void)
 
     if (!mpi_interceptor_real_finalize_enabled() ||
         !__atomic_load_n(&peak_real_finalize_allowed, __ATOMIC_ACQUIRE)) {
-        __atomic_store_n(&peak_finalize_result, 0, __ATOMIC_RELEASE);
-        __atomic_store_n(&peak_finalize_state,
-                         PEAK_MPI_FINALIZE_DONE,
-                         __ATOMIC_RELEASE);
+        mpi_interceptor_finalize_publish_done(0);
         return 0;
     }
 
     if (original_pmpi_finalize == NULL &&
         (!direct_finalize || hook_address == NULL)) {
-        __atomic_store_n(&peak_finalize_state,
-                         PEAK_MPI_FINALIZE_DONE,
-                         __ATOMIC_RELEASE);
+        mpi_interceptor_finalize_publish_done(0);
         return 0;
     }
 
@@ -284,9 +479,12 @@ mpi_interceptor_call_original_finalize_once(void)
             return __atomic_load_n(&peak_finalize_result, __ATOMIC_ACQUIRE);
         }
 
+        if (state == PEAK_MPI_FINALIZE_FAILED_CLOSED) {
+            return MPI_ERR_OTHER;
+        }
+
         if (state == PEAK_MPI_FINALIZE_IN_PROGRESS) {
-            sched_yield();
-            continue;
+            return mpi_interceptor_wait_for_finalize_owner();
         }
 
         if (state != PEAK_MPI_FINALIZE_REQUESTED) {
@@ -313,10 +511,7 @@ mpi_interceptor_call_original_finalize_once(void)
         } else if (original_pmpi_finalize != NULL) {
             result = original_pmpi_finalize();
         }
-        __atomic_store_n(&peak_finalize_result, result, __ATOMIC_RELEASE);
-        __atomic_store_n(&peak_finalize_state,
-                         PEAK_MPI_FINALIZE_DONE,
-                         __ATOMIC_RELEASE);
+        mpi_interceptor_finalize_publish_done(result);
         return result;
     }
 }
@@ -373,6 +568,8 @@ mpi_interceptor_set_real_finalize_allowed(int allowed)
 int mpi_interceptor_attach()
 {
     GumReplaceReturn replace_check = -1;
+
+    mpi_interceptor_configure_finalize_owner_timeout();
     mpi_interceptor = gum_interceptor_obtain();
 
     gum_interceptor_begin_transaction(mpi_interceptor);
@@ -386,6 +583,29 @@ int mpi_interceptor_attach()
     gum_interceptor_end_transaction(mpi_interceptor);
     return replace_check;
 }
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+PEAK_MPI_INTERCEPTOR_API void
+mpi_interceptor_test_set_finalize_in_progress(void)
+{
+    mpi_interceptor_configure_finalize_owner_timeout();
+    __atomic_store_n(&peak_finalize_state,
+                     PEAK_MPI_FINALIZE_IN_PROGRESS,
+                     __ATOMIC_RELEASE);
+}
+
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_wait_for_finalize_owner(void)
+{
+    return mpi_interceptor_wait_for_finalize_owner();
+}
+
+PEAK_MPI_INTERCEPTOR_API int
+mpi_interceptor_test_collectives_failed_closed(void)
+{
+    return peak_mpi_teardown_collectives_failed_closed() ? 1 : 0;
+}
+#endif
 
 void mpi_interceptor_dettach(int allow_delayed_finalize)
 {

--- a/src/mpi_interceptor.c
+++ b/src/mpi_interceptor.c
@@ -513,18 +513,6 @@ mpi_interceptor_call_original_finalize_once(void)
 {
     int direct_finalize = mpi_interceptor_direct_finalize_enabled();
 
-    if (!mpi_interceptor_real_finalize_enabled() ||
-        !__atomic_load_n(&peak_real_finalize_allowed, __ATOMIC_ACQUIRE)) {
-        mpi_interceptor_finalize_publish_done(0);
-        return 0;
-    }
-
-    if (original_pmpi_finalize == NULL &&
-        (!direct_finalize || hook_address == NULL)) {
-        mpi_interceptor_finalize_publish_done(0);
-        return 0;
-    }
-
     for (;;) {
         int state = __atomic_load_n(&peak_finalize_state, __ATOMIC_ACQUIRE);
 
@@ -553,6 +541,15 @@ mpi_interceptor_call_original_finalize_once(void)
                 __ATOMIC_ACQ_REL,
                 __ATOMIC_ACQUIRE)) {
             continue;
+        }
+
+        if (!mpi_interceptor_real_finalize_enabled() ||
+            !__atomic_load_n(&peak_real_finalize_allowed,
+                             __ATOMIC_ACQUIRE) ||
+            (original_pmpi_finalize == NULL &&
+             (!direct_finalize || hook_address == NULL))) {
+            mpi_interceptor_finalize_publish_done(0);
+            return 0;
         }
 
         int result = 0;

--- a/src/peak.c
+++ b/src/peak.c
@@ -152,6 +152,9 @@ static _Atomic int peak_runtime_activation_wait_warning_emitted;
 static PeakEnvWarningState peak_runtime_activation_timeout_warning_emitted;
 static unsigned int peak_runtime_activation_wait_timeout_ms =
     PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_DEFAULT;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static _Atomic unsigned int peak_test_activation_waiters;
+#endif
 static _Atomic unsigned long long peak_exec_checkpoint_counter = 0;
 static _Atomic unsigned int peak_exec_checkpoint_gate = 0;
 #define PEAK_EXEC_CHECKPOINT_GATE_CLOSING (1U << 31)
@@ -222,13 +225,15 @@ peak_runtime_activation_cond_is_ready(void)
 }
 
 static gboolean
-peak_runtime_activation_deadline(struct timespec* deadline)
+peak_runtime_activation_deadline(struct timespec* started,
+                                 struct timespec* deadline)
 {
     unsigned int timeout_ms = peak_runtime_activation_wait_timeout_ms;
 
-    if (clock_gettime(CLOCK_MONOTONIC, deadline) != 0) {
+    if (clock_gettime(CLOCK_MONOTONIC, started) != 0) {
         return FALSE;
     }
+    *deadline = *started;
     deadline->tv_sec += timeout_ms / 1000U;
     deadline->tv_nsec += (long)(timeout_ms % 1000U) * 1000000L;
     if (deadline->tv_nsec >= 1000000000L) {
@@ -236,6 +241,18 @@ peak_runtime_activation_deadline(struct timespec* deadline)
         deadline->tv_nsec -= 1000000000L;
     }
     return TRUE;
+}
+
+static double
+peak_runtime_activation_elapsed_ms(const struct timespec* started)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)(now.tv_sec - started->tv_sec) * 1000.0 +
+           (double)(now.tv_nsec - started->tv_nsec) / 1000000.0;
 }
 
 static int
@@ -272,7 +289,8 @@ peak_runtime_activation_cond_timedwait(const struct timespec* deadline)
 }
 
 static void
-peak_runtime_activation_warn_wait_timeout(const char* reason)
+peak_runtime_activation_warn_wait_timeout(const char* reason,
+                                          double elapsed_ms)
 {
     int expected = 0;
 
@@ -282,17 +300,36 @@ peak_runtime_activation_warn_wait_timeout(const char* reason)
             1,
             memory_order_acq_rel,
             memory_order_acquire)) {
-        peak_log_warn(
-            "[peak] runtime activation did not complete within %u ms (%s); "
-            "skipping dependent PEAK work so the application can continue\n",
-            peak_runtime_activation_wait_timeout_ms,
-            reason);
+        if (elapsed_ms >= 0.0) {
+            peak_log_warn(
+                "[peak] runtime activation did not complete after %.3f ms "
+                "(timeout=%u ms; %s); skipping dependent PEAK work so the "
+                "application can continue\n",
+                elapsed_ms, peak_runtime_activation_wait_timeout_ms, reason);
+        } else {
+            peak_log_warn(
+                "[peak] runtime activation did not complete "
+                "(elapsed unavailable; timeout=%u ms; %s); skipping dependent "
+                "PEAK work so the application can continue\n",
+                peak_runtime_activation_wait_timeout_ms, reason);
+        }
     }
+}
+
+static void
+peak_runtime_activation_wait_cancel(void* data)
+{
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_sub_explicit(&peak_test_activation_waiters, 1,
+                              memory_order_release);
+#endif
+    (void)pthread_mutex_unlock((pthread_mutex_t*)data);
 }
 
 static PeakRuntimeActivationState
 peak_runtime_activation_wait_for_terminal(void)
 {
+    struct timespec started;
     struct timespec deadline;
     int state = atomic_load_explicit(&peak_runtime_activation_state,
                                      memory_order_acquire);
@@ -306,12 +343,23 @@ peak_runtime_activation_wait_for_terminal(void)
         pthread_equal(pthread_self(), peak_runtime_activation_owner)) {
         return PEAK_RUNTIME_ACTIVATION_IN_PROGRESS;
     }
-    if (!peak_runtime_activation_cond_is_ready() ||
-        !peak_runtime_activation_deadline(&deadline) ||
-        pthread_mutex_lock(&peak_runtime_activation_mutex) != 0) {
-        peak_runtime_activation_warn_wait_timeout("wait unavailable");
+    if (!peak_runtime_activation_deadline(&started, &deadline)) {
+        peak_runtime_activation_warn_wait_timeout("wait unavailable", -1.0);
         return PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT;
     }
+    if (!peak_runtime_activation_cond_is_ready() ||
+        pthread_mutex_lock(&peak_runtime_activation_mutex) != 0) {
+        peak_runtime_activation_warn_wait_timeout(
+            "wait unavailable",
+            peak_runtime_activation_elapsed_ms(&started));
+        return PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT;
+    }
+    pthread_cleanup_push(peak_runtime_activation_wait_cancel,
+                         &peak_runtime_activation_mutex);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_add_explicit(&peak_test_activation_waiters, 1,
+                              memory_order_release);
+#endif
     while ((state = atomic_load_explicit(&peak_runtime_activation_state,
                                          memory_order_acquire)) ==
            PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
@@ -320,10 +368,16 @@ peak_runtime_activation_wait_for_terminal(void)
             break;
         }
     }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    atomic_fetch_sub_explicit(&peak_test_activation_waiters, 1,
+                              memory_order_release);
+#endif
+    pthread_cleanup_pop(0);
     (void)pthread_mutex_unlock(&peak_runtime_activation_mutex);
     if (state == PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
         peak_runtime_activation_warn_wait_timeout(
-            wait_status == ETIMEDOUT ? "deadline expired" : "wait failed");
+            wait_status == ETIMEDOUT ? "deadline expired" : "wait failed",
+            peak_runtime_activation_elapsed_ms(&started));
         return PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT;
     }
     return (PeakRuntimeActivationState)state;
@@ -544,6 +598,13 @@ peak_test_activation_after_claim_release(void)
     atomic_store_explicit(&peak_test_activation_after_claim_released,
                           1,
                           memory_order_release);
+}
+
+PEAK_EXEC_API unsigned int
+peak_test_activation_waiter_count(void)
+{
+    return atomic_load_explicit(&peak_test_activation_waiters,
+                                memory_order_acquire);
 }
 
 static void

--- a/src/peak.c
+++ b/src/peak.c
@@ -64,6 +64,9 @@
 #define PEAK_MPI_COLLECTIVE_OUTPUT_ENV         "PEAK_MPI_COLLECTIVE_OUTPUT"
 #define PEAK_MPI_ACTIVATION_POLICY_ENV          "PEAK_MPI_ACTIVATION_POLICY"
 #define PEAK_MPI_REAL_FINALIZE_ENV             "PEAK_MPI_REAL_FINALIZE"
+#define PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_ENV \
+    "PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS"
+#define PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_DEFAULT 5000U
 #ifdef PEAK_ENABLE_TEST_HOOKS
 #define PEAK_TEST_MPI_LIBRARY_VERSION_ENV      "PEAK_TEST_MPI_LIBRARY_VERSION"
 #endif
@@ -120,8 +123,8 @@ static PeakOutputAggregationMode peak_requested_output_aggregation =
 static int found_MPI;
 #endif
 
-static _Atomic int peak_exit_status_known = 0;
-static _Atomic int peak_exit_status_value = 0;
+static _Atomic uint64_t peak_exit_status = 0;
+#define PEAK_EXIT_STATUS_VALID (UINT64_C(1) << 63)
 static _Atomic int peak_runtime_active = 0;
 static _Atomic pid_t peak_runtime_owner_pid = 0;
 static PeakEnvWarningState peak_max_num_threads_warning_emitted;
@@ -134,12 +137,21 @@ typedef enum {
 #if defined(__APPLE__)
     PEAK_RUNTIME_ACTIVATION_REJECTED = 5,
 #endif
+    PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT = 6,
 } PeakRuntimeActivationState;
 static _Atomic int peak_runtime_activation_state =
     PEAK_RUNTIME_ACTIVATION_NOT_READY;
 static _Atomic int peak_deferred_activation_warning_emitted = 0;
 static pthread_t peak_runtime_activation_owner;
 static _Atomic int peak_runtime_activation_owner_known = 0;
+static pthread_mutex_t peak_runtime_activation_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_runtime_activation_cond;
+static pthread_once_t peak_runtime_activation_cond_once = PTHREAD_ONCE_INIT;
+static _Atomic int peak_runtime_activation_cond_ready;
+static _Atomic int peak_runtime_activation_wait_warning_emitted;
+static PeakEnvWarningState peak_runtime_activation_timeout_warning_emitted;
+static unsigned int peak_runtime_activation_wait_timeout_ms =
+    PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_DEFAULT;
 static _Atomic unsigned long long peak_exec_checkpoint_counter = 0;
 static _Atomic unsigned int peak_exec_checkpoint_gate = 0;
 #define PEAK_EXEC_CHECKPOINT_GATE_CLOSING (1U << 31)
@@ -173,6 +185,165 @@ peak_runtime_is_fork_child(void)
     return owner > 0 && getpid() != owner;
 }
 
+static void
+peak_runtime_activation_cond_initialize(void)
+{
+#if defined(__linux__)
+    pthread_condattr_t attr;
+    int status;
+
+    if (pthread_condattr_init(&attr) != 0) {
+        return;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&peak_runtime_activation_cond, &attr);
+    }
+    (void)pthread_condattr_destroy(&attr);
+    if (status == 0) {
+        atomic_store_explicit(&peak_runtime_activation_cond_ready, 1,
+                              memory_order_release);
+    }
+#elif defined(__APPLE__)
+    if (pthread_cond_init(&peak_runtime_activation_cond, NULL) == 0) {
+        atomic_store_explicit(&peak_runtime_activation_cond_ready, 1,
+                              memory_order_release);
+    }
+#endif
+}
+
+static gboolean
+peak_runtime_activation_cond_is_ready(void)
+{
+    return pthread_once(&peak_runtime_activation_cond_once,
+                        peak_runtime_activation_cond_initialize) == 0 &&
+           atomic_load_explicit(&peak_runtime_activation_cond_ready,
+                                memory_order_acquire) != 0;
+}
+
+static gboolean
+peak_runtime_activation_deadline(struct timespec* deadline)
+{
+    unsigned int timeout_ms = peak_runtime_activation_wait_timeout_ms;
+
+    if (clock_gettime(CLOCK_MONOTONIC, deadline) != 0) {
+        return FALSE;
+    }
+    deadline->tv_sec += timeout_ms / 1000U;
+    deadline->tv_nsec += (long)(timeout_ms % 1000U) * 1000000L;
+    if (deadline->tv_nsec >= 1000000000L) {
+        deadline->tv_sec++;
+        deadline->tv_nsec -= 1000000000L;
+    }
+    return TRUE;
+}
+
+static int
+peak_runtime_activation_cond_timedwait(const struct timespec* deadline)
+{
+#if defined(__linux__)
+    return pthread_cond_timedwait(&peak_runtime_activation_cond,
+                                  &peak_runtime_activation_mutex,
+                                  deadline);
+#elif defined(__APPLE__)
+    struct timespec now;
+    struct timespec remaining;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return EINVAL;
+    }
+    remaining.tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining.tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining.tv_nsec < 0) {
+        remaining.tv_sec--;
+        remaining.tv_nsec += 1000000000L;
+    }
+    if (remaining.tv_sec < 0 ||
+        (remaining.tv_sec == 0 && remaining.tv_nsec == 0)) {
+        return ETIMEDOUT;
+    }
+    return pthread_cond_timedwait_relative_np(&peak_runtime_activation_cond,
+                                              &peak_runtime_activation_mutex,
+                                              &remaining);
+#else
+    (void)deadline;
+    return ENOTSUP;
+#endif
+}
+
+static void
+peak_runtime_activation_warn_wait_timeout(const char* reason)
+{
+    int expected = 0;
+
+    if (atomic_compare_exchange_strong_explicit(
+            &peak_runtime_activation_wait_warning_emitted,
+            &expected,
+            1,
+            memory_order_acq_rel,
+            memory_order_acquire)) {
+        peak_log_warn(
+            "[peak] runtime activation did not complete within %u ms (%s); "
+            "skipping dependent PEAK work so the application can continue\n",
+            peak_runtime_activation_wait_timeout_ms,
+            reason);
+    }
+}
+
+static PeakRuntimeActivationState
+peak_runtime_activation_wait_for_terminal(void)
+{
+    struct timespec deadline;
+    int state = atomic_load_explicit(&peak_runtime_activation_state,
+                                     memory_order_acquire);
+    int wait_status = 0;
+
+    if (state != PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
+        return (PeakRuntimeActivationState)state;
+    }
+    if (atomic_load_explicit(&peak_runtime_activation_owner_known,
+                             memory_order_acquire) != 0 &&
+        pthread_equal(pthread_self(), peak_runtime_activation_owner)) {
+        return PEAK_RUNTIME_ACTIVATION_IN_PROGRESS;
+    }
+    if (!peak_runtime_activation_cond_is_ready() ||
+        !peak_runtime_activation_deadline(&deadline) ||
+        pthread_mutex_lock(&peak_runtime_activation_mutex) != 0) {
+        peak_runtime_activation_warn_wait_timeout("wait unavailable");
+        return PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT;
+    }
+    while ((state = atomic_load_explicit(&peak_runtime_activation_state,
+                                         memory_order_acquire)) ==
+           PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
+        wait_status = peak_runtime_activation_cond_timedwait(&deadline);
+        if (wait_status != 0) {
+            break;
+        }
+    }
+    (void)pthread_mutex_unlock(&peak_runtime_activation_mutex);
+    if (state == PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
+        peak_runtime_activation_warn_wait_timeout(
+            wait_status == ETIMEDOUT ? "deadline expired" : "wait failed");
+        return PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT;
+    }
+    return (PeakRuntimeActivationState)state;
+}
+
+static void
+peak_runtime_activation_publish(PeakRuntimeActivationState state)
+{
+    if (!peak_runtime_activation_cond_is_ready() ||
+        pthread_mutex_lock(&peak_runtime_activation_mutex) != 0) {
+        atomic_store_explicit(&peak_runtime_activation_state, state,
+                              memory_order_release);
+        return;
+    }
+    atomic_store_explicit(&peak_runtime_activation_state, state,
+                          memory_order_release);
+    (void)pthread_cond_broadcast(&peak_runtime_activation_cond);
+    (void)pthread_mutex_unlock(&peak_runtime_activation_mutex);
+}
+
 /*
  * Close the READY -> IN_PROGRESS race against process teardown.  Once this
  * function changes READY to CANCELED, an MPI completion can no longer start
@@ -204,15 +375,7 @@ peak_runtime_close_activation_for_teardown(void)
             }
             continue;
         }
-        if (state != PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
-            return (PeakRuntimeActivationState)state;
-        }
-        if (atomic_load_explicit(&peak_runtime_activation_owner_known,
-                                 memory_order_acquire) != 0 &&
-            pthread_equal(pthread_self(), peak_runtime_activation_owner)) {
-            return PEAK_RUNTIME_ACTIVATION_IN_PROGRESS;
-        }
-        sched_yield();
+        return peak_runtime_activation_wait_for_terminal();
     }
 }
 
@@ -227,6 +390,9 @@ static _Atomic int peak_test_fini_completion_wait_count_value = 0;
 static _Atomic int peak_test_activation_pause = 0;
 static _Atomic int peak_test_activation_held = 0;
 static _Atomic int peak_test_activation_released = 0;
+static _Atomic int peak_test_activation_after_claim_pause = 0;
+static _Atomic int peak_test_activation_after_claim_held = 0;
+static _Atomic int peak_test_activation_after_claim_released = 0;
 static _Atomic int peak_test_fail_heartbeat_create = 0;
 
 PEAK_API int
@@ -351,6 +517,35 @@ peak_test_activation_release(void)
                           memory_order_release);
 }
 
+PEAK_EXEC_API void
+peak_test_activation_pause_after_claim_enable(void)
+{
+    atomic_store_explicit(&peak_test_activation_after_claim_released,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_activation_after_claim_held,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&peak_test_activation_after_claim_pause,
+                          1,
+                          memory_order_release);
+}
+
+PEAK_EXEC_API int
+peak_test_activation_after_claim_is_held(void)
+{
+    return atomic_load_explicit(&peak_test_activation_after_claim_held,
+                                memory_order_acquire);
+}
+
+PEAK_EXEC_API void
+peak_test_activation_after_claim_release(void)
+{
+    atomic_store_explicit(&peak_test_activation_after_claim_released,
+                          1,
+                          memory_order_release);
+}
+
 static void
 peak_test_checkpoint_reader_pause_after_acquire(void)
 {
@@ -385,6 +580,25 @@ peak_test_activation_pause_before_claim(void)
         sched_yield();
     }
     atomic_store_explicit(&peak_test_activation_pause,
+                          0,
+                          memory_order_release);
+}
+
+static void
+peak_test_activation_pause_after_claim(void)
+{
+    if (atomic_load_explicit(&peak_test_activation_after_claim_pause,
+                             memory_order_acquire) == 0) {
+        return;
+    }
+    atomic_store_explicit(&peak_test_activation_after_claim_held,
+                          1,
+                          memory_order_release);
+    while (atomic_load_explicit(&peak_test_activation_after_claim_released,
+                                memory_order_acquire) == 0) {
+        sched_yield();
+    }
+    atomic_store_explicit(&peak_test_activation_after_claim_pause,
                           0,
                           memory_order_release);
 }
@@ -1048,11 +1262,8 @@ peak_activate_runtime(void)
             PEAK_RUNTIME_ACTIVATION_IN_PROGRESS,
             memory_order_acq_rel,
             memory_order_acquire)) {
-        while (expected == PEAK_RUNTIME_ACTIVATION_IN_PROGRESS &&
-               atomic_load_explicit(&peak_runtime_activation_state,
-                                    memory_order_acquire) ==
-                   PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
-            sched_yield();
+        if (expected == PEAK_RUNTIME_ACTIVATION_IN_PROGRESS) {
+            (void)peak_runtime_activation_wait_for_terminal();
         }
         return;
     }
@@ -1060,6 +1271,9 @@ peak_activate_runtime(void)
     atomic_store_explicit(&peak_runtime_activation_owner_known,
                           1,
                           memory_order_release);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_test_activation_pause_after_claim();
+#endif
 
 #if defined(__APPLE__)
     /*
@@ -1071,9 +1285,7 @@ peak_activate_runtime(void)
     if (!peak_general_listener_startup_attach_can_skip_stop()) {
         peak_log_warn(
             "[peak] refusing macOS runtime activation because the process is already multithreaded; Darwin Gum bootstrap requires single-threaded startup and no Gum hooks were installed\n");
-        atomic_store_explicit(&peak_runtime_activation_state,
-                              PEAK_RUNTIME_ACTIVATION_REJECTED,
-                              memory_order_release);
+        peak_runtime_activation_publish(PEAK_RUNTIME_ACTIVATION_REJECTED);
         return;
     }
 #endif
@@ -1308,9 +1520,7 @@ peak_activate_runtime(void)
     }
 
     atomic_store_explicit(&peak_runtime_active, 1, memory_order_release);
-    atomic_store_explicit(&peak_runtime_activation_state,
-                          PEAK_RUNTIME_ACTIVATION_ACTIVE,
-                          memory_order_release);
+    peak_runtime_activation_publish(PEAK_RUNTIME_ACTIVATION_ACTIVE);
 }
 
 #ifdef HAVE_MPI
@@ -1417,8 +1627,20 @@ void peak_init()
 {
     peak_output_identity_initialize();
     PeakRuntimeNumericConfig numeric_config;
+    PeakEnvUnsignedSchema activation_wait_timeout_schema = {
+        PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_ENV,
+        "milliseconds",
+        PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS_DEFAULT,
+        1,
+        UINT_MAX,
+        false,
+        &peak_runtime_activation_timeout_warning_emitted,
+        false,
+    };
 
     peak_log_configure();
+    peak_runtime_activation_wait_timeout_ms = (unsigned int)
+        peak_parse_env_unsigned(&activation_wait_timeout_schema);
     peak_max_num_threads = peak_parse_max_num_threads();
     peak_hook_address_count = parse_env_w_delim(PEAK_TARGET_ENV, PEAK_TARGET_DELIM, &peak_hook_strings);
     peak_hook_address_count += load_profiling_symbols(PEAK_TARGET_FILE_ENV, &peak_hook_strings, peak_hook_address_count);
@@ -1636,11 +1858,12 @@ peak_fini_impl(void)
         return;
     }
 #ifdef HAVE_MPI
+    uint64_t published_exit_status =
+        atomic_load_explicit(&peak_exit_status, memory_order_acquire);
     int exit_status_known =
-        atomic_load_explicit(&peak_exit_status_known, memory_order_acquire);
-    int exit_status =
-        atomic_load_explicit(&peak_exit_status_value, memory_order_acquire);
-    int abnormal_exit = exit_status_known == 2 && exit_status != 0;
+        (published_exit_status & PEAK_EXIT_STATUS_VALID) != 0;
+    int exit_status = (int)(int32_t)(uint32_t)published_exit_status;
+    int abnormal_exit = exit_status_known && exit_status != 0;
     PeakOutputAggregationMode aggregation_mode =
         found_MPI ? peak_requested_output_aggregation
                   : PEAK_OUTPUT_AGGREGATION_LOCAL;
@@ -2194,25 +2417,15 @@ peak_resolve_real_exit(void)
 static void
 peak_publish_exit_status(int status)
 {
-    int expected = 0;
+    uint64_t expected = 0;
+    uint64_t published = PEAK_EXIT_STATUS_VALID | (uint32_t)status;
 
-    if (atomic_compare_exchange_strong_explicit(&peak_exit_status_known,
-                                                &expected,
-                                                1,
-                                                memory_order_acq_rel,
-                                                memory_order_acquire)) {
-        atomic_store_explicit(&peak_exit_status_value,
-                              status,
-                              memory_order_release);
-        atomic_store_explicit(&peak_exit_status_known,
-                              2,
-                              memory_order_release);
-    } else {
-        while (atomic_load_explicit(&peak_exit_status_known,
-                                    memory_order_acquire) == 1) {
-            sched_yield();
-        }
-    }
+    (void)atomic_compare_exchange_strong_explicit(
+        &peak_exit_status,
+        &expected,
+        published,
+        memory_order_release,
+        memory_order_relaxed);
 }
 
 PEAK_API void

--- a/src/pthread_listener.c
+++ b/src/pthread_listener.c
@@ -5,6 +5,14 @@
 #include "logging.h"
 #include "internal/pthread_slot_registry.h"
 #include "internal/signal_policy_internal.h"
+#include "utils/env_parser.h"
+
+#include <limits.h>
+#include <sched.h>
+
+#define PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_ENV \
+    "PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS"
+#define PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_DEFAULT 5000U
 
 #undef g_printerr
 #define g_printerr(...) peak_log_warn(__VA_ARGS__)
@@ -21,6 +29,10 @@ static gpointer pthread_create_hook_address;
 static gpointer pthread_join_hook_address;
 extern pthread_t heartbeat_thread;
 extern gulong peak_max_num_threads;
+static unsigned int pthread_start_handshake_timeout_ms =
+    PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_DEFAULT;
+static PeakEnvWarningState pthread_start_timeout_config_warning;
+static _Atomic int pthread_start_timeout_warning_emitted;
 
 static void pthread_listener_iface_init(gpointer g_iface, gpointer iface_data);
 static gboolean pthread_listener_insert_thread_unlocked(pthread_t tid);
@@ -48,6 +60,8 @@ static pthread_once_t pthread_slot_key_once = PTHREAD_ONCE_INIT;
 static gboolean pthread_slot_key_created = FALSE;
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static _Atomic unsigned int pthread_test_fail_slot_publish = 0;
+static _Atomic int pthread_test_pause_start_publication;
+static _Atomic int pthread_test_release_start_publication;
 #endif
 
 static void peak_pthread_slot_destructor(void* data);
@@ -98,8 +112,34 @@ typedef struct {
     gboolean tracked;
     size_t slot;
     uint64_t generation;
-    _Atomic int ready;
+    _Atomic int handshake_state;
+    _Atomic unsigned int references;
 } PeakPthreadStartContext;
+
+static void
+peak_pthread_start_context_release(PeakPthreadStartContext* context)
+{
+    if (context != NULL &&
+        atomic_fetch_sub_explicit(&context->references, 1,
+                                  memory_order_acq_rel) == 1) {
+        g_free(context);
+    }
+}
+
+static void
+peak_pthread_start_warn_abandoned(void)
+{
+    int expected = 0;
+
+    if (atomic_compare_exchange_strong_explicit(
+            &pthread_start_timeout_warning_emitted, &expected, 1,
+            memory_order_acq_rel, memory_order_acquire)) {
+        peak_log_warn(
+            "[peak] pthread child metadata publication did not complete "
+            "within %u ms; running the child untracked\n",
+            pthread_start_handshake_timeout_ms);
+    }
+}
 
 static void
 peak_pthread_slot_destructor(void* data)
@@ -140,9 +180,7 @@ peak_pthread_start_cleanup(void* data)
 {
     PeakPthreadStartContext* context = data;
 
-    if (context != NULL) {
-        g_free(context);
-    }
+    peak_pthread_start_context_release(context);
 }
 
 static void*
@@ -152,9 +190,16 @@ peak_pthread_start(void* data)
     pthread_start_routine_t start_routine = context->start_routine;
     void* start_arg = context->start_arg;
     void* ret = NULL;
+    PeakPthreadStartHandshakeState handshake_state;
 
-    peak_pthread_slot_registry_wait_ready(&context->ready);
-    if (!context->skip_tracking) {
+    pthread_cleanup_push(peak_pthread_start_cleanup, context);
+    handshake_state = peak_pthread_slot_registry_wait_ready(
+        &context->handshake_state, pthread_start_handshake_timeout_ms);
+    if (handshake_state == PEAK_PTHREAD_START_ABANDONED) {
+        peak_pthread_start_warn_abandoned();
+    }
+    if (!context->skip_tracking &&
+        handshake_state == PEAK_PTHREAD_START_READY) {
         if (context->tracked) {
             if (!pthread_listener_publish_current_slot(context->slot,
                                                         context->generation)) {
@@ -169,7 +214,6 @@ peak_pthread_start(void* data)
     }
     (void)peak_signal_policy_unblock_reserved_for_current_thread();
 
-    pthread_cleanup_push(peak_pthread_start_cleanup, context);
     peak_detach_controller_wait_for_mutation_window();
     ret = start_routine(start_arg);
     pthread_cleanup_pop(1);
@@ -247,6 +291,9 @@ pthread_listener_on_enter(GumInvocationListener* listener,
     start_context->start_arg = gum_invocation_context_get_nth_argument(ic, 3);
     start_context->skip_tracking =
         (tid == &heartbeat_thread) || pthread_next_create_is_helper;
+    atomic_init(&start_context->handshake_state,
+                PEAK_PTHREAD_START_PENDING);
+    atomic_init(&start_context->references, 2);
     pthread_next_create_is_helper = FALSE;
     thread_state->start_context = start_context;
     gum_invocation_context_replace_nth_argument(ic, 2, (gpointer)peak_pthread_start);
@@ -261,6 +308,20 @@ pthread_listener_on_leave(GumInvocationListener* listener,
     int create_ret = GPOINTER_TO_INT(gum_invocation_context_get_return_value(ic));
     PeakPthreadStartContext* context = thread_state->start_context;
     if (context != NULL) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (create_ret == 0 &&
+            atomic_load_explicit(&pthread_test_pause_start_publication,
+                                 memory_order_acquire) != 0) {
+            while (atomic_load_explicit(
+                       &pthread_test_release_start_publication,
+                       memory_order_acquire) == 0) {
+                sched_yield();
+            }
+            atomic_store_explicit(&pthread_test_pause_start_publication,
+                                  0,
+                                  memory_order_release);
+        }
+#endif
         if (create_ret == 0) {
             if (tid_mapping_initialized && thread_state->child_tid != NULL) {
                 PeakPthreadSlotToken token;
@@ -287,7 +348,19 @@ pthread_listener_on_leave(GumInvocationListener* listener,
             g_free(context);
             thread_state->start_context = NULL;
         } else {
-            peak_pthread_slot_registry_publish_ready(&context->ready);
+            gboolean published =
+                peak_pthread_slot_registry_publish_ready(
+                    &context->handshake_state);
+
+            if (!published && context->tracked) {
+                (void)peak_pthread_slot_registry_compare_remove(
+                    &pthread_slot_registry,
+                    *thread_state->child_tid,
+                    context->generation,
+                    true);
+                context->tracked = FALSE;
+            }
+            peak_pthread_start_context_release(context);
             thread_state->start_context = NULL;
         }
     }
@@ -375,6 +448,19 @@ peak_pthread_join(pthread_t thread, void **retval)
 
 void pthread_listener_attach()
 {
+    PeakEnvUnsignedSchema handshake_timeout_schema = {
+        PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_ENV,
+        "milliseconds",
+        PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_DEFAULT,
+        1,
+        UINT_MAX,
+        false,
+        &pthread_start_timeout_config_warning,
+        false,
+    };
+
+    pthread_start_handshake_timeout_ms = (unsigned int)
+        peak_parse_env_unsigned(&handshake_timeout_schema);
     tid_mapping_initialized = peak_pthread_slot_registry_init(
         &pthread_slot_registry, peak_max_num_threads);
     if (tid_mapping_initialized) {
@@ -581,6 +667,31 @@ pthread_listener_test_untracked_create_removes_ambiguous_mapping(
 {
     return tid_mapping_initialized &&
         pthread_listener_quarantine_ambiguous_tid_unlocked(thread);
+}
+
+void
+pthread_listener_test_pause_start_publication_enable(void)
+{
+    atomic_store_explicit(&pthread_test_release_start_publication,
+                          0,
+                          memory_order_release);
+    atomic_store_explicit(&pthread_test_pause_start_publication,
+                          1,
+                          memory_order_release);
+}
+
+void
+pthread_listener_test_release_start_publication(void)
+{
+    atomic_store_explicit(&pthread_test_release_start_publication,
+                          1,
+                          memory_order_release);
+}
+
+int
+pthread_listener_test_current_thread_has_slot(void)
+{
+    return pthread_slot_identity.valid ? 1 : 0;
 }
 #endif
 

--- a/src/pthread_listener.c
+++ b/src/pthread_listener.c
@@ -9,6 +9,7 @@
 
 #include <limits.h>
 #include <sched.h>
+#include <time.h>
 
 #define PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_ENV \
     "PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS"
@@ -127,18 +128,38 @@ peak_pthread_start_context_release(PeakPthreadStartContext* context)
 }
 
 static void
-peak_pthread_start_warn_abandoned(void)
+peak_pthread_start_warn_abandoned(double elapsed_ms)
 {
     int expected = 0;
 
     if (atomic_compare_exchange_strong_explicit(
             &pthread_start_timeout_warning_emitted, &expected, 1,
             memory_order_acq_rel, memory_order_acquire)) {
-        peak_log_warn(
-            "[peak] pthread child metadata publication did not complete "
-            "within %u ms; running the child untracked\n",
-            pthread_start_handshake_timeout_ms);
+        if (elapsed_ms >= 0.0) {
+            peak_log_warn(
+                "[peak] pthread child metadata publication did not complete "
+                "after %.3f ms (timeout=%u ms); running the child untracked\n",
+                elapsed_ms, pthread_start_handshake_timeout_ms);
+        } else {
+            peak_log_warn(
+                "[peak] pthread child metadata publication did not complete "
+                "(elapsed unavailable; timeout=%u ms); running the child "
+                "untracked\n",
+                pthread_start_handshake_timeout_ms);
+        }
     }
+}
+
+static double
+peak_pthread_start_elapsed_ms(const struct timespec* started)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)(now.tv_sec - started->tv_sec) * 1000.0 +
+           (double)(now.tv_nsec - started->tv_nsec) / 1000000.0;
 }
 
 static void
@@ -191,12 +212,17 @@ peak_pthread_start(void* data)
     void* start_arg = context->start_arg;
     void* ret = NULL;
     PeakPthreadStartHandshakeState handshake_state;
+    struct timespec wait_started;
+    gboolean wait_clock_available =
+        clock_gettime(CLOCK_MONOTONIC, &wait_started) == 0;
 
     pthread_cleanup_push(peak_pthread_start_cleanup, context);
     handshake_state = peak_pthread_slot_registry_wait_ready(
         &context->handshake_state, pthread_start_handshake_timeout_ms);
     if (handshake_state == PEAK_PTHREAD_START_ABANDONED) {
-        peak_pthread_start_warn_abandoned();
+        peak_pthread_start_warn_abandoned(
+            wait_clock_available ?
+                peak_pthread_start_elapsed_ms(&wait_started) : -1.0);
     }
     if (!context->skip_tracking &&
         handshake_state == PEAK_PTHREAD_START_READY) {

--- a/src/pthread_slot_registry.c
+++ b/src/pthread_slot_registry.c
@@ -1,7 +1,122 @@
 #include "internal/pthread_slot_registry.h"
 
-#include <sched.h>
+#include <errno.h>
 #include <string.h>
+#include <time.h>
+
+static pthread_mutex_t peak_pthread_start_gate_mutex =
+    PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peak_pthread_start_gate_cond;
+static pthread_once_t peak_pthread_start_gate_once = PTHREAD_ONCE_INIT;
+static _Atomic int peak_pthread_start_gate_ready;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static unsigned int peak_pthread_start_test_waiters;
+#endif
+
+static void
+peak_pthread_start_gate_initialize(void)
+{
+#if defined(__linux__)
+    pthread_condattr_t attr;
+    int status;
+
+    if (pthread_condattr_init(&attr) != 0) {
+        return;
+    }
+    status = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (status == 0) {
+        status = pthread_cond_init(&peak_pthread_start_gate_cond, &attr);
+    }
+    (void)pthread_condattr_destroy(&attr);
+    if (status == 0) {
+        atomic_store_explicit(&peak_pthread_start_gate_ready, 1,
+                              memory_order_release);
+    }
+#elif defined(__APPLE__)
+    if (pthread_cond_init(&peak_pthread_start_gate_cond, NULL) == 0) {
+        atomic_store_explicit(&peak_pthread_start_gate_ready, 1,
+                              memory_order_release);
+    }
+#endif
+}
+
+static bool
+peak_pthread_start_gate_is_ready(void)
+{
+    return pthread_once(&peak_pthread_start_gate_once,
+                        peak_pthread_start_gate_initialize) == 0 &&
+           atomic_load_explicit(&peak_pthread_start_gate_ready,
+                                memory_order_acquire) != 0;
+}
+
+static bool
+peak_pthread_start_deadline(struct timespec* deadline,
+                            unsigned int timeout_ms)
+{
+    if (clock_gettime(CLOCK_MONOTONIC, deadline) != 0) {
+        return false;
+    }
+    deadline->tv_sec += timeout_ms / 1000U;
+    deadline->tv_nsec += (long)(timeout_ms % 1000U) * 1000000L;
+    if (deadline->tv_nsec >= 1000000000L) {
+        deadline->tv_sec++;
+        deadline->tv_nsec -= 1000000000L;
+    }
+    return true;
+}
+
+static int
+peak_pthread_start_timedwait(const struct timespec* deadline)
+{
+#if defined(__linux__)
+    return pthread_cond_timedwait(&peak_pthread_start_gate_cond,
+                                  &peak_pthread_start_gate_mutex,
+                                  deadline);
+#elif defined(__APPLE__)
+    struct timespec now;
+    struct timespec remaining;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return EINVAL;
+    }
+    remaining.tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining.tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining.tv_nsec < 0) {
+        remaining.tv_sec--;
+        remaining.tv_nsec += 1000000000L;
+    }
+    if (remaining.tv_sec < 0 ||
+        (remaining.tv_sec == 0 && remaining.tv_nsec == 0)) {
+        return ETIMEDOUT;
+    }
+    return pthread_cond_timedwait_relative_np(&peak_pthread_start_gate_cond,
+                                              &peak_pthread_start_gate_mutex,
+                                              &remaining);
+#else
+    (void)deadline;
+    return ENOTSUP;
+#endif
+}
+
+typedef struct {
+    pthread_mutex_t* mutex;
+    _Atomic int* state;
+} PeakPthreadStartWaitCleanup;
+
+static void
+peak_pthread_start_wait_cancel(void* data)
+{
+    PeakPthreadStartWaitCleanup* cleanup = data;
+    int expected = PEAK_PTHREAD_START_PENDING;
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_pthread_start_test_waiters--;
+#endif
+    (void)atomic_compare_exchange_strong_explicit(
+        cleanup->state, &expected, PEAK_PTHREAD_START_ABANDONED,
+        memory_order_acq_rel, memory_order_acquire);
+    (void)pthread_mutex_unlock(cleanup->mutex);
+}
 
 static bool
 peak_pthread_slot_registry_tid_equal(pthread_t left, pthread_t right)
@@ -216,16 +331,93 @@ peak_pthread_slot_registry_snapshot(PeakPthreadSlotRegistry* registry,
     return count;
 }
 
-void
-peak_pthread_slot_registry_publish_ready(_Atomic int* ready)
+bool
+peak_pthread_slot_registry_publish_ready(_Atomic int* state)
 {
-    atomic_store_explicit(ready, 1, memory_order_release);
+    int expected = PEAK_PTHREAD_START_PENDING;
+    bool published;
+
+    if (!peak_pthread_start_gate_is_ready() ||
+        pthread_mutex_lock(&peak_pthread_start_gate_mutex) != 0) {
+        return atomic_compare_exchange_strong_explicit(
+            state, &expected, PEAK_PTHREAD_START_READY,
+            memory_order_release, memory_order_acquire);
+    }
+    published = atomic_compare_exchange_strong_explicit(
+        state, &expected, PEAK_PTHREAD_START_READY,
+        memory_order_release, memory_order_acquire);
+    if (published) {
+        (void)pthread_cond_broadcast(&peak_pthread_start_gate_cond);
+    }
+    (void)pthread_mutex_unlock(&peak_pthread_start_gate_mutex);
+    return published;
 }
 
-void
-peak_pthread_slot_registry_wait_ready(const _Atomic int* ready)
+PeakPthreadStartHandshakeState
+peak_pthread_slot_registry_wait_ready(_Atomic int* state,
+                                      unsigned int timeout_ms)
 {
-    while (atomic_load_explicit(ready, memory_order_acquire) == 0) {
-        sched_yield();
+    struct timespec deadline;
+    int current = atomic_load_explicit(state, memory_order_acquire);
+    PeakPthreadStartHandshakeState result;
+    PeakPthreadStartWaitCleanup cleanup = {
+        .mutex = &peak_pthread_start_gate_mutex,
+        .state = state,
+    };
+
+    if (current != PEAK_PTHREAD_START_PENDING) {
+        return (PeakPthreadStartHandshakeState)current;
     }
+    if (timeout_ms == 0 || !peak_pthread_start_gate_is_ready() ||
+        !peak_pthread_start_deadline(&deadline, timeout_ms) ||
+        pthread_mutex_lock(&peak_pthread_start_gate_mutex) != 0) {
+        int expected = PEAK_PTHREAD_START_PENDING;
+
+        (void)atomic_compare_exchange_strong_explicit(
+            state, &expected, PEAK_PTHREAD_START_ABANDONED,
+            memory_order_acq_rel, memory_order_acquire);
+        return (PeakPthreadStartHandshakeState)atomic_load_explicit(
+            state, memory_order_acquire);
+    }
+    pthread_cleanup_push(peak_pthread_start_wait_cancel, &cleanup);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_pthread_start_test_waiters++;
+#endif
+    while ((current = atomic_load_explicit(state, memory_order_acquire)) ==
+           PEAK_PTHREAD_START_PENDING) {
+        int wait_status = peak_pthread_start_timedwait(&deadline);
+
+        if (wait_status != 0) {
+            int expected = PEAK_PTHREAD_START_PENDING;
+
+            (void)atomic_compare_exchange_strong_explicit(
+                state, &expected, PEAK_PTHREAD_START_ABANDONED,
+                memory_order_acq_rel, memory_order_acquire);
+            break;
+        }
+    }
+    result = (PeakPthreadStartHandshakeState)atomic_load_explicit(
+        state, memory_order_acquire);
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_pthread_start_test_waiters--;
+#endif
+    pthread_cleanup_pop(0);
+    (void)pthread_mutex_unlock(&peak_pthread_start_gate_mutex);
+    return result;
 }
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+unsigned int
+peak_pthread_slot_registry_test_wake_waiters(void)
+{
+    unsigned int waiters = 0;
+
+    if (peak_pthread_start_gate_is_ready() &&
+        pthread_mutex_lock(&peak_pthread_start_gate_mutex) == 0) {
+        waiters = peak_pthread_start_test_waiters;
+        (void)pthread_cond_broadcast(&peak_pthread_start_gate_cond);
+        (void)pthread_mutex_unlock(&peak_pthread_start_gate_mutex);
+    }
+    return waiters;
+}
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -904,6 +904,16 @@ if(BUILD_TESTING)
                 FAIL_REGULAR_EXPRESSION "fatal|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)
 
+        add_test(NAME test_pthread_start_publication_timeout
+            COMMAND
+                ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
+        set_tests_properties(test_pthread_start_publication_timeout
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS=10;PEAK_TEST_PTHREAD_START_TIMEOUT=1;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "pthread child metadata publication did not complete within 10 ms.*pthread_start_publication_timeout_ok"
+                FAIL_REGULAR_EXPRESSION "fatal|pthread start-timeout.*failed|published late|Gum [^\\r\\n]* failed"
+                TIMEOUT 30)
+
         add_test(NAME test_fastpath_thread_exit_nonwrapper_drops
             COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
         set_tests_properties(test_fastpath_thread_exit_nonwrapper_drops
@@ -2296,6 +2306,24 @@ if(BUILD_TESTING)
                 PASS_REGULAR_EXPRESSION "mpi_activation_exit_race_ok"
                 FAIL_REGULAR_EXPRESSION "mpi_activation_exit_race_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
                 TIMEOUT 15)
+        add_test(NAME test_mpi_activation_wait_is_bounded
+            COMMAND $<TARGET_FILE:test_mpi_activation_exit_race> timeout)
+        set_tests_properties(
+            test_mpi_activation_wait_is_bounded
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=peak_mpi_activation_exit_race_target;PEAK_MPI_ACTIVATION_POLICY=post-init;PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS=20;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "runtime activation did not complete within 20 ms.*mpi_activation_wait_timeout_ok"
+                FAIL_REGULAR_EXPRESSION "mpi_activation_exit_race_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
+                TIMEOUT 15)
+        add_test(NAME test_mpi_finalize_owner_wait_is_bounded
+            COMMAND $<TARGET_FILE:test_mpi_finalize_owner_timeout>)
+        set_tests_properties(
+            test_mpi_finalize_owner_wait_is_bounded
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=main;PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS=10;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "MPI finalizer owner did not complete within 10 ms.*mpi_finalize_owner_timeout_ok"
+                FAIL_REGULAR_EXPRESSION "mpi_finalize_owner_timeout_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
+                TIMEOUT 15)
         set(_PEAK_MPI_TEST_NPROCS 2)
         if(MPIEXEC_MAX_NUMPROCS AND MPIEXEC_MAX_NUMPROCS LESS _PEAK_MPI_TEST_NPROCS)
             set(_PEAK_MPI_TEST_NPROCS ${MPIEXEC_MAX_NUMPROCS})
@@ -3488,7 +3516,7 @@ if(BUILD_TESTING)
 
     # Add test of memory allocation intercepting
     add_subdirectory(memory)
-    foreach(memlog_case create sizing mapping overflow capacity stalled stress no-clobber allocation realloc tid-fork)
+    foreach(memlog_case create sizing mapping overflow capacity stalled stalled-timeout stress no-clobber allocation realloc tid-fork)
         add_test(NAME test_memlog_${memlog_case}
             COMMAND test_memlog_safety ${memlog_case})
         set_tests_properties(test_memlog_${memlog_case}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -910,7 +910,7 @@ if(BUILD_TESTING)
         set_tests_properties(test_pthread_start_publication_timeout
             PROPERTIES
                 ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS=10;PEAK_TEST_PTHREAD_START_TIMEOUT=1;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
-                PASS_REGULAR_EXPRESSION "pthread child metadata publication did not complete within 10 ms.*pthread_start_publication_timeout_ok"
+                PASS_REGULAR_EXPRESSION "pthread child metadata publication did not complete after [0-9.]+ ms [(]timeout=10 ms[)].*pthread_start_publication_timeout_ok"
                 FAIL_REGULAR_EXPRESSION "fatal|pthread start-timeout.*failed|published late|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)
 
@@ -2312,7 +2312,16 @@ if(BUILD_TESTING)
             test_mpi_activation_wait_is_bounded
             PROPERTIES
                 ENVIRONMENT "PEAK_TARGET=peak_mpi_activation_exit_race_target;PEAK_MPI_ACTIVATION_POLICY=post-init;PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS=20;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
-                PASS_REGULAR_EXPRESSION "runtime activation did not complete within 20 ms.*mpi_activation_wait_timeout_ok"
+                PASS_REGULAR_EXPRESSION "runtime activation did not complete after [0-9.]+ ms [(]timeout=20 ms; deadline expired[)].*mpi_activation_wait_timeout_ok"
+                FAIL_REGULAR_EXPRESSION "mpi_activation_exit_race_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
+                TIMEOUT 15)
+        add_test(NAME test_mpi_activation_wait_cancellation
+            COMMAND $<TARGET_FILE:test_mpi_activation_exit_race> cancel)
+        set_tests_properties(
+            test_mpi_activation_wait_cancellation
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=peak_mpi_activation_exit_race_target;PEAK_MPI_ACTIVATION_POLICY=post-init;PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS=5000;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "mpi_activation_wait_cancellation_ok"
                 FAIL_REGULAR_EXPRESSION "mpi_activation_exit_race_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
                 TIMEOUT 15)
         add_test(NAME test_mpi_finalize_owner_wait_is_bounded
@@ -2321,7 +2330,16 @@ if(BUILD_TESTING)
             test_mpi_finalize_owner_wait_is_bounded
             PROPERTIES
                 ENVIRONMENT "PEAK_TARGET=main;PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS=10;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
-                PASS_REGULAR_EXPRESSION "MPI finalizer owner did not complete within 10 ms.*mpi_finalize_owner_timeout_ok"
+                PASS_REGULAR_EXPRESSION "MPI finalizer owner did not complete after [0-9.]+ ms [(]timeout=10 ms; deadline expired[)].*mpi_finalize_owner_timeout_ok"
+                FAIL_REGULAR_EXPRESSION "mpi_finalize_owner_timeout_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
+                TIMEOUT 15)
+        add_test(NAME test_mpi_finalize_owner_wait_cancellation
+            COMMAND $<TARGET_FILE:test_mpi_finalize_owner_timeout> cancel)
+        set_tests_properties(
+            test_mpi_finalize_owner_wait_cancellation
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=main;PEAK_MPI_FINALIZE_OWNER_TIMEOUT_MS=5000;PEAK_VERBOSITY=warn;${HEARTBEAT_OFF_ENV};${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "mpi_finalize_owner_cancellation_ok"
                 FAIL_REGULAR_EXPRESSION "mpi_finalize_owner_timeout_error|Caught signal|Segmentation fault|SIGSEGV|signal 11"
                 TIMEOUT 15)
         set(_PEAK_MPI_TEST_NPROCS 2)

--- a/test/detach_runtime/CMakeLists.txt
+++ b/test/detach_runtime/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(test_pthread_slot_registry
   ${PROJECT_SOURCE_DIR}/src/pthread_slot_registry.c)
 target_include_directories(test_pthread_slot_registry PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(test_pthread_slot_registry PRIVATE Threads::Threads)
+target_compile_definitions(test_pthread_slot_registry PRIVATE PEAK_ENABLE_TEST_HOOKS=1)
 if(PEAK_ENABLE_TSAN_TESTS)
   target_compile_options(test_pthread_slot_registry PRIVATE
     -fsanitize=thread -fno-omit-frame-pointer -O1 -g)

--- a/test/detach_runtime/test_fastpath_thread_exit.c
+++ b/test/detach_runtime/test_fastpath_thread_exit.c
@@ -24,6 +24,9 @@ static atomic_int user_destructor_calls;
 static pthread_key_t user_destructor_key;
 static void (*clear_current_slot)(void);
 static int (*thread_is_tracked)(pthread_t);
+static int (*current_thread_has_slot)(void);
+static void (*release_start_publication)(void);
+static atomic_int start_timeout_child_untracked;
 static atomic_int destructor_tracking_failed;
 static atomic_int threshold_holder_ready;
 static atomic_int threshold_holder_release;
@@ -112,6 +115,49 @@ exit_worker(void* arg)
     (void)peak_fastpath_thread_exit_target(0);
     (void)peak_fastpath_thread_exit_target(1);
     return (void*)1;
+}
+
+static void*
+start_timeout_worker(void* arg)
+{
+    (void)arg;
+    if (current_thread_has_slot != NULL && !current_thread_has_slot()) {
+        atomic_store_explicit(&start_timeout_child_untracked, 1,
+                              memory_order_release);
+    }
+    (void)peak_fastpath_thread_exit_target(0);
+    if (release_start_publication != NULL) {
+        release_start_publication();
+    }
+    return NULL;
+}
+
+static int
+run_start_publication_timeout(void (*pause_enable)(void))
+{
+    pthread_t thread;
+
+    if (pause_enable == NULL || release_start_publication == NULL ||
+        current_thread_has_slot == NULL) {
+        fputs("missing pthread start-timeout hooks\n", stderr);
+        return 1;
+    }
+    atomic_store_explicit(&start_timeout_child_untracked, 0,
+                          memory_order_release);
+    pause_enable();
+    if (pthread_create(&thread, NULL, start_timeout_worker, NULL) != 0 ||
+        pthread_join(thread, NULL) != 0) {
+        fputs("pthread start-timeout worker failed\n", stderr);
+        return 1;
+    }
+    if (!atomic_load_explicit(&start_timeout_child_untracked,
+                              memory_order_acquire) ||
+        thread_is_tracked(thread)) {
+        fputs("pthread start-timeout child was published late\n", stderr);
+        return 1;
+    }
+    puts("pthread_start_publication_timeout_ok");
+    return 0;
 }
 
 static void*
@@ -494,6 +540,14 @@ main(void)
         RTLD_DEFAULT, "pthread_listener_test_clear_current_thread_slot");
     thread_is_tracked = (int (*)(pthread_t))dlsym(
         RTLD_DEFAULT, "pthread_listener_test_thread_is_tracked");
+    current_thread_has_slot = (int (*)(void))dlsym(
+        RTLD_DEFAULT, "pthread_listener_test_current_thread_has_slot");
+    void (*pause_start_publication)(void) = (void (*)(void))dlsym(
+        RTLD_DEFAULT,
+        "pthread_listener_test_pause_start_publication_enable");
+    release_start_publication = (void (*)(void))dlsym(
+        RTLD_DEFAULT,
+        "pthread_listener_test_release_start_publication");
     if (call_count == NULL || thread_count == NULL || dropped_calls == NULL ||
         dropped_threads == NULL || thread_is_tracked == NULL) {
         fputs("missing accounting test hooks\n", stderr);
@@ -512,6 +566,9 @@ main(void)
     }
     if (getenv("PEAK_TEST_RETIRED_ACTIVE_THRESHOLD") != NULL) {
         return run_retired_active_detach_threshold_regression();
+    }
+    if (getenv("PEAK_TEST_PTHREAD_START_TIMEOUT") != NULL) {
+        return run_start_publication_timeout(pause_start_publication);
     }
     (void)peak_fastpath_thread_exit_target(0);
     if (getenv("PEAK_TEST_RETIRED_DETACH_THRESHOLD") != NULL) {

--- a/test/detach_runtime/test_pthread_slot_registry.c
+++ b/test/detach_runtime/test_pthread_slot_registry.c
@@ -7,6 +7,7 @@
 
 #define WORKER_COUNT 8
 #define STRESS_ROUNDS 200
+#define HANDSHAKE_TIMEOUT_MS 5000U
 
 static PeakPthreadSlotRegistry registry;
 static _Atomic int ready[WORKER_COUNT];
@@ -31,6 +32,99 @@ typedef struct {
     _Atomic int release;
 } KeyHolder;
 
+typedef struct {
+    _Atomic int* state;
+    PeakPthreadStartHandshakeState result;
+} HandshakeWaiter;
+
+static _Atomic int cancellation_waiter_started;
+
+static void*
+handshake_waiter(void* data)
+{
+    HandshakeWaiter* waiter = data;
+
+    waiter->result = peak_pthread_slot_registry_wait_ready(
+        waiter->state, HANDSHAKE_TIMEOUT_MS);
+    return NULL;
+}
+
+static void*
+cancellation_waiter(void* data)
+{
+    _Atomic int* state = data;
+
+    atomic_store_explicit(&cancellation_waiter_started, 1,
+                          memory_order_release);
+    (void)peak_pthread_slot_registry_wait_ready(state,
+                                                HANDSHAKE_TIMEOUT_MS);
+    return NULL;
+}
+
+static int
+run_handshake_checks(void)
+{
+    _Atomic int state = PEAK_PTHREAD_START_PENDING;
+    HandshakeWaiter waiter = { .state = &state };
+    pthread_t thread;
+
+    CHECK(peak_pthread_slot_registry_publish_ready(&state));
+    CHECK(peak_pthread_slot_registry_wait_ready(
+              &state, HANDSHAKE_TIMEOUT_MS) == PEAK_PTHREAD_START_READY);
+
+    atomic_store_explicit(&state, PEAK_PTHREAD_START_PENDING,
+                          memory_order_release);
+    CHECK(peak_pthread_slot_registry_wait_ready(&state, 1) ==
+          PEAK_PTHREAD_START_ABANDONED);
+    CHECK(!peak_pthread_slot_registry_publish_ready(&state));
+
+    atomic_store_explicit(&state, PEAK_PTHREAD_START_PENDING,
+                          memory_order_release);
+    CHECK(pthread_create(&thread, NULL, handshake_waiter, &waiter) == 0);
+    CHECK(peak_pthread_slot_registry_publish_ready(&state));
+    CHECK(pthread_join(thread, NULL) == 0);
+    CHECK(waiter.result == PEAK_PTHREAD_START_READY);
+
+    atomic_store_explicit(&state, PEAK_PTHREAD_START_PENDING,
+                          memory_order_release);
+    waiter.result = PEAK_PTHREAD_START_ABANDONED;
+    CHECK(pthread_create(&thread, NULL, handshake_waiter, &waiter) == 0);
+    unsigned int waiter_count = 0;
+    for (unsigned int attempt = 0;
+         attempt < 10000 && waiter_count == 0; ++attempt) {
+        waiter_count = peak_pthread_slot_registry_test_wake_waiters();
+    }
+    CHECK(waiter_count == 1);
+    CHECK(atomic_load_explicit(&state, memory_order_acquire) ==
+          PEAK_PTHREAD_START_PENDING);
+    CHECK(peak_pthread_slot_registry_publish_ready(&state));
+    CHECK(pthread_join(thread, NULL) == 0);
+    CHECK(waiter.result == PEAK_PTHREAD_START_READY);
+
+    atomic_store_explicit(&state, PEAK_PTHREAD_START_PENDING,
+                          memory_order_release);
+    atomic_store_explicit(&cancellation_waiter_started, 0,
+                          memory_order_release);
+    CHECK(pthread_create(&thread, NULL, cancellation_waiter, &state) == 0);
+    while (atomic_load_explicit(&cancellation_waiter_started,
+                                memory_order_acquire) == 0) {
+    }
+    CHECK(pthread_cancel(thread) == 0);
+    void* canceled_result = NULL;
+    CHECK(pthread_join(thread, &canceled_result) == 0);
+    CHECK(canceled_result == PTHREAD_CANCELED);
+    CHECK(atomic_load_explicit(&state, memory_order_acquire) ==
+          PEAK_PTHREAD_START_ABANDONED);
+
+    /* Cancellation must release the shared wait mutex for later handshakes. */
+    atomic_store_explicit(&state, PEAK_PTHREAD_START_PENDING,
+                          memory_order_release);
+    CHECK(peak_pthread_slot_registry_publish_ready(&state));
+    CHECK(peak_pthread_slot_registry_wait_ready(
+              &state, HANDSHAKE_TIMEOUT_MS) == PEAK_PTHREAD_START_READY);
+    return 0;
+}
+
 static void*
 registry_worker(void* data)
 {
@@ -48,7 +142,13 @@ registry_worker(void* data)
         payload[worker_id] = ((uint64_t)(unsigned int)round << 32) |
                              (uint32_t)worker_id;
         peak_pthread_slot_registry_publish_ready(&ready[worker_id]);
-        peak_pthread_slot_registry_wait_ready(&release_worker[worker_id]);
+        if (peak_pthread_slot_registry_wait_ready(
+                &release_worker[worker_id], HANDSHAKE_TIMEOUT_MS) !=
+            PEAK_PTHREAD_START_READY) {
+            atomic_fetch_add_explicit(&worker_failures, 1,
+                                      memory_order_relaxed);
+            return NULL;
+        }
         if (!peak_pthread_slot_registry_compare_remove(&registry, pthread_self(),
                                                        token.generation, true)) {
             atomic_fetch_add_explicit(&worker_failures, 1, memory_order_relaxed);
@@ -67,7 +167,7 @@ key_holder(void* data)
 {
     KeyHolder* holder = data;
 
-    atomic_store_explicit(&holder->ready, 1, memory_order_release);
+    (void)peak_pthread_slot_registry_publish_ready(&holder->ready);
     while (atomic_load_explicit(&holder->release, memory_order_acquire) == 0) {
     }
     return NULL;
@@ -88,7 +188,9 @@ run_concurrent_stress(pthread_t worker_threads[WORKER_COUNT])
         for (int worker = 0; worker < WORKER_COUNT; worker++) {
             PeakPthreadSlotToken token;
 
-            peak_pthread_slot_registry_wait_ready(&ready[worker]);
+            CHECK(peak_pthread_slot_registry_wait_ready(
+                      &ready[worker], HANDSHAKE_TIMEOUT_MS) ==
+                  PEAK_PTHREAD_START_READY);
             CHECK(payload[worker] ==
                   (((uint64_t)(unsigned int)round << 32) | (uint32_t)worker));
             CHECK(peak_pthread_slot_registry_capture(&registry,
@@ -133,7 +235,9 @@ run_lifecycle_checks(void)
     for (int holder = 0; holder < 4; holder++) {
         CHECK(pthread_create(&holder_threads[holder], NULL, key_holder,
                              &holders[holder]) == 0);
-        peak_pthread_slot_registry_wait_ready(&holders[holder].ready);
+        CHECK(peak_pthread_slot_registry_wait_ready(
+                  &holders[holder].ready, HANDSHAKE_TIMEOUT_MS) ==
+              PEAK_PTHREAD_START_READY);
     }
 
     CHECK(peak_pthread_slot_registry_reserve_insert(&registry, holder_threads[0],
@@ -181,6 +285,7 @@ main(void)
 {
     pthread_t worker_threads[WORKER_COUNT];
 
+    CHECK(run_handshake_checks() == 0);
     CHECK(peak_pthread_slot_registry_init(&registry, WORKER_COUNT + 4));
     CHECK(run_concurrent_stress(worker_threads) == 0);
     peak_pthread_slot_registry_destroy(&registry);

--- a/test/dgemm_mpi/CMakeLists.txt
+++ b/test/dgemm_mpi/CMakeLists.txt
@@ -24,6 +24,10 @@ add_executable(test_mpi_activation_exit_race
     test_mpi_activation_exit_race.c)
 target_link_libraries(test_mpi_activation_exit_race
     PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+add_executable(test_mpi_finalize_owner_timeout
+    test_mpi_finalize_owner_timeout.c)
+target_link_libraries(test_mpi_finalize_owner_timeout
+    PRIVATE ${CMAKE_DL_LIBS})
 add_library(test_mpi_init_chain_wrapper MODULE
     mpi_init_chain_wrapper.c)
 target_link_libraries(test_mpi_init_chain_wrapper

--- a/test/dgemm_mpi/test_mpi_activation_exit_race.c
+++ b/test/dgemm_mpi/test_mpi_activation_exit_race.c
@@ -3,6 +3,8 @@
 #include <pthread.h>
 #include <sched.h>
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
 
 typedef void (*PeakVoidFunction)(void);
 typedef int (*PeakIntFunction)(void);
@@ -28,9 +30,21 @@ complete_mpi_init(void* opaque)
     return NULL;
 }
 
-int
-main(void)
+static double
+monotonic_milliseconds(void)
 {
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)now.tv_sec * 1000.0 + (double)now.tv_nsec / 1000000.0;
+}
+
+int
+main(int argc, char** argv)
+{
+    int timeout_mode = argc == 2 && strcmp(argv[1], "timeout") == 0;
     PeakVoidFunction pause_enable =
         (PeakVoidFunction)dlsym(
             RTLD_DEFAULT, "peak_test_activation_pause_enable");
@@ -40,6 +54,15 @@ main(void)
     PeakVoidFunction activation_release =
         (PeakVoidFunction)dlsym(
             RTLD_DEFAULT, "peak_test_activation_release");
+    PeakVoidFunction after_claim_enable =
+        (PeakVoidFunction)dlsym(
+            RTLD_DEFAULT, "peak_test_activation_pause_after_claim_enable");
+    PeakIntFunction after_claim_held =
+        (PeakIntFunction)dlsym(
+            RTLD_DEFAULT, "peak_test_activation_after_claim_is_held");
+    PeakVoidFunction after_claim_release =
+        (PeakVoidFunction)dlsym(
+            RTLD_DEFAULT, "peak_test_activation_after_claim_release");
     PeakVoidFunction fini =
         (PeakVoidFunction)dlsym(RTLD_DEFAULT, "peak_test_fini");
     PeakIntFunction runtime_active =
@@ -52,20 +75,48 @@ main(void)
     pthread_t completion_thread;
 
     if (pause_enable == NULL || activation_held == NULL ||
-        activation_release == NULL || fini == NULL ||
+        activation_release == NULL || after_claim_enable == NULL ||
+        after_claim_held == NULL || after_claim_release == NULL || fini == NULL ||
         runtime_active == NULL || completion.complete == NULL) {
         fputs("mpi_activation_exit_race_error missing hooks\n", stderr);
         return 2;
     }
 
-    pause_enable();
+    if (timeout_mode) {
+        after_claim_enable();
+    } else {
+        pause_enable();
+    }
     if (pthread_create(
             &completion_thread, NULL, complete_mpi_init, &completion) != 0) {
         fputs("mpi_activation_exit_race_error pthread_create\n", stderr);
         return 3;
     }
-    while (!activation_held()) {
+    while (!(timeout_mode ? after_claim_held() : activation_held())) {
         sched_yield();
+    }
+
+    if (timeout_mode) {
+        double started_ms = monotonic_milliseconds();
+
+        fini();
+        double elapsed_ms = monotonic_milliseconds() - started_ms;
+        if (elapsed_ms < 0.0 || elapsed_ms > 1000.0 ||
+            runtime_active() != 0) {
+            fputs("mpi_activation_exit_race_error unbounded activation wait\n",
+                  stderr);
+            return 5;
+        }
+        after_claim_release();
+        pthread_join(completion_thread, NULL);
+        if (runtime_active() == 0) {
+            fputs("mpi_activation_exit_race_error activation did not resume\n",
+                  stderr);
+            return 6;
+        }
+        fini();
+        puts("mpi_activation_wait_timeout_ok");
+        return 0;
     }
 
     /*

--- a/test/dgemm_mpi/test_mpi_activation_exit_race.c
+++ b/test/dgemm_mpi/test_mpi_activation_exit_race.c
@@ -8,11 +8,16 @@
 
 typedef void (*PeakVoidFunction)(void);
 typedef int (*PeakIntFunction)(void);
+typedef unsigned int (*PeakUnsignedFunction)(void);
 typedef void (*PeakMpiInitCompletedFunction)(int);
 
 typedef struct {
     PeakMpiInitCompletedFunction complete;
 } CompletionArgs;
+
+typedef struct {
+    PeakVoidFunction fini;
+} FiniArgs;
 
 __attribute__((visibility("default"), noinline))
 int
@@ -27,6 +32,15 @@ complete_mpi_init(void* opaque)
     CompletionArgs* args = (CompletionArgs*)opaque;
 
     args->complete(0);
+    return NULL;
+}
+
+static void*
+run_fini(void* opaque)
+{
+    FiniArgs* args = (FiniArgs*)opaque;
+
+    args->fini();
     return NULL;
 }
 
@@ -45,6 +59,7 @@ int
 main(int argc, char** argv)
 {
     int timeout_mode = argc == 2 && strcmp(argv[1], "timeout") == 0;
+    int cancel_mode = argc == 2 && strcmp(argv[1], "cancel") == 0;
     PeakVoidFunction pause_enable =
         (PeakVoidFunction)dlsym(
             RTLD_DEFAULT, "peak_test_activation_pause_enable");
@@ -65,6 +80,9 @@ main(int argc, char** argv)
             RTLD_DEFAULT, "peak_test_activation_after_claim_release");
     PeakVoidFunction fini =
         (PeakVoidFunction)dlsym(RTLD_DEFAULT, "peak_test_fini");
+    PeakUnsignedFunction activation_waiter_count =
+        (PeakUnsignedFunction)dlsym(
+            RTLD_DEFAULT, "peak_test_activation_waiter_count");
     PeakIntFunction runtime_active =
         (PeakIntFunction)dlsym(
             RTLD_DEFAULT, "peak_runtime_is_active_for_checkpoint");
@@ -77,12 +95,13 @@ main(int argc, char** argv)
     if (pause_enable == NULL || activation_held == NULL ||
         activation_release == NULL || after_claim_enable == NULL ||
         after_claim_held == NULL || after_claim_release == NULL || fini == NULL ||
-        runtime_active == NULL || completion.complete == NULL) {
+        activation_waiter_count == NULL || runtime_active == NULL ||
+        completion.complete == NULL) {
         fputs("mpi_activation_exit_race_error missing hooks\n", stderr);
         return 2;
     }
 
-    if (timeout_mode) {
+    if (timeout_mode || cancel_mode) {
         after_claim_enable();
     } else {
         pause_enable();
@@ -92,8 +111,39 @@ main(int argc, char** argv)
         fputs("mpi_activation_exit_race_error pthread_create\n", stderr);
         return 3;
     }
-    while (!(timeout_mode ? after_claim_held() : activation_held())) {
+    while (!((timeout_mode || cancel_mode) ? after_claim_held() :
+                                              activation_held())) {
         sched_yield();
+    }
+
+    if (cancel_mode) {
+        pthread_t waiter;
+        void* canceled_result = NULL;
+        FiniArgs fini_args = { .fini = fini };
+
+        if (pthread_create(&waiter, NULL, run_fini, &fini_args) != 0) {
+            fputs("mpi_activation_exit_race_error waiter create\n", stderr);
+            return 5;
+        }
+        while (activation_waiter_count() == 0) {
+            sched_yield();
+        }
+        if (pthread_cancel(waiter) != 0 ||
+            pthread_join(waiter, &canceled_result) != 0 ||
+            canceled_result != PTHREAD_CANCELED) {
+            fputs("mpi_activation_exit_race_error waiter cancel\n", stderr);
+            return 6;
+        }
+        after_claim_release();
+        pthread_join(completion_thread, NULL);
+        if (runtime_active() == 0) {
+            fputs("mpi_activation_exit_race_error owner publication blocked\n",
+                  stderr);
+            return 7;
+        }
+        fini();
+        puts("mpi_activation_wait_cancellation_ok");
+        return 0;
     }
 
     if (timeout_mode) {

--- a/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
+++ b/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
@@ -1,10 +1,28 @@
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <pthread.h>
+#include <sched.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 typedef void (*PeakVoidFunction)(void);
 typedef int (*PeakIntFunction)(void);
+typedef unsigned int (*PeakUnsignedFunction)(void);
+typedef void (*PeakPublishFunction)(int);
+
+typedef struct {
+    PeakIntFunction wait_for_owner;
+} WaiterArgs;
+
+static void*
+wait_for_finalize_owner(void* opaque)
+{
+    WaiterArgs* args = (WaiterArgs*)opaque;
+
+    (void)args->wait_for_owner();
+    return NULL;
+}
 
 static double
 monotonic_milliseconds(void)
@@ -18,8 +36,9 @@ monotonic_milliseconds(void)
 }
 
 int
-main(void)
+main(int argc, char** argv)
 {
+    int cancel_mode = argc == 2 && strcmp(argv[1], "cancel") == 0;
     PeakVoidFunction set_in_progress =
         (PeakVoidFunction)dlsym(
             RTLD_DEFAULT,
@@ -32,16 +51,68 @@ main(void)
         (PeakIntFunction)dlsym(
             RTLD_DEFAULT,
             "mpi_interceptor_test_collectives_failed_closed");
+    PeakUnsignedFunction waiter_count =
+        (PeakUnsignedFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_finalize_waiter_count");
+    PeakPublishFunction publish_result =
+        (PeakPublishFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_publish_finalize_result");
+    PeakVoidFunction prepare_finalize_stub =
+        (PeakVoidFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_prepare_original_finalize_stub");
+    PeakIntFunction call_original_finalize_once =
+        (PeakIntFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_call_original_finalize_once");
+    PeakUnsignedFunction original_finalize_call_count =
+        (PeakUnsignedFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_original_finalize_call_count");
     double started_ms;
     double elapsed_ms;
     int result;
 
     if (set_in_progress == NULL || wait_for_owner == NULL ||
-        failed_closed == NULL) {
+        failed_closed == NULL || waiter_count == NULL ||
+        publish_result == NULL || prepare_finalize_stub == NULL ||
+        call_original_finalize_once == NULL ||
+        original_finalize_call_count == NULL) {
         fputs("mpi_finalize_owner_timeout_error missing hooks\n", stderr);
         return 2;
     }
+    prepare_finalize_stub();
     set_in_progress();
+    if (cancel_mode) {
+        pthread_t waiter;
+        void* canceled_result = NULL;
+        WaiterArgs waiter_args = { .wait_for_owner = wait_for_owner };
+
+        if (pthread_create(&waiter, NULL, wait_for_finalize_owner,
+                           &waiter_args) != 0) {
+            fputs("mpi_finalize_owner_timeout_error waiter create\n", stderr);
+            return 3;
+        }
+        while (waiter_count() == 0) {
+            sched_yield();
+        }
+        if (pthread_cancel(waiter) != 0 ||
+            pthread_join(waiter, &canceled_result) != 0 ||
+            canceled_result != PTHREAD_CANCELED) {
+            fputs("mpi_finalize_owner_timeout_error waiter cancel\n", stderr);
+            return 4;
+        }
+        publish_result(0);
+        if (wait_for_owner() != 0 || failed_closed()) {
+            fputs("mpi_finalize_owner_timeout_error publication blocked\n",
+                  stderr);
+            return 5;
+        }
+        puts("mpi_finalize_owner_cancellation_ok");
+        return 0;
+    }
     started_ms = monotonic_milliseconds();
     result = wait_for_owner();
     elapsed_ms = monotonic_milliseconds() - started_ms;
@@ -50,6 +121,12 @@ main(void)
         fputs("mpi_finalize_owner_timeout_error wait was not bounded\n",
               stderr);
         return 3;
+    }
+    (void)call_original_finalize_once();
+    if (original_finalize_call_count() != 0) {
+        fputs("mpi_finalize_owner_timeout_error real MPI call after timeout\n",
+              stderr);
+        return 4;
     }
     puts("mpi_finalize_owner_timeout_ok");
     return 0;

--- a/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
+++ b/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
@@ -122,8 +122,8 @@ main(int argc, char** argv)
               stderr);
         return 3;
     }
-    (void)call_original_finalize_once();
-    if (original_finalize_call_count() != 0) {
+    result = call_original_finalize_once();
+    if (result == 0 || original_finalize_call_count() != 0) {
         fputs("mpi_finalize_owner_timeout_error real MPI call after timeout\n",
               stderr);
         return 4;

--- a/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
+++ b/test/dgemm_mpi/test_mpi_finalize_owner_timeout.c
@@ -1,0 +1,56 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <time.h>
+
+typedef void (*PeakVoidFunction)(void);
+typedef int (*PeakIntFunction)(void);
+
+static double
+monotonic_milliseconds(void)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)now.tv_sec * 1000.0 + (double)now.tv_nsec / 1000000.0;
+}
+
+int
+main(void)
+{
+    PeakVoidFunction set_in_progress =
+        (PeakVoidFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_set_finalize_in_progress");
+    PeakIntFunction wait_for_owner =
+        (PeakIntFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_wait_for_finalize_owner");
+    PeakIntFunction failed_closed =
+        (PeakIntFunction)dlsym(
+            RTLD_DEFAULT,
+            "mpi_interceptor_test_collectives_failed_closed");
+    double started_ms;
+    double elapsed_ms;
+    int result;
+
+    if (set_in_progress == NULL || wait_for_owner == NULL ||
+        failed_closed == NULL) {
+        fputs("mpi_finalize_owner_timeout_error missing hooks\n", stderr);
+        return 2;
+    }
+    set_in_progress();
+    started_ms = monotonic_milliseconds();
+    result = wait_for_owner();
+    elapsed_ms = monotonic_milliseconds() - started_ms;
+    if (result == 0 || !failed_closed() || elapsed_ms < 0.0 ||
+        elapsed_ms > 1000.0) {
+        fputs("mpi_finalize_owner_timeout_error wait was not bounded\n",
+              stderr);
+        return 3;
+    }
+    puts("mpi_finalize_owner_timeout_ok");
+    return 0;
+}

--- a/test/memory/test_memlog_safety.c
+++ b/test/memory/test_memlog_safety.c
@@ -126,6 +126,41 @@ static int run_stalled_writer(void)
                    "finalizer did not complete after writer publication");
 }
 
+static int run_stalled_writer_timeout(void)
+{
+    PeakMemLogTestSnapshot snapshot;
+    pthread_t writer;
+
+    if (setenv("PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS", "10", 1) != 0) {
+        return 1;
+    }
+    if (!expect(peak_memlog_test_open(4),
+                "timeout log did not open")) return 1;
+    peak_memlog_test_pause_before_commit(1);
+    if (pthread_create(&writer, NULL, write_one_event, NULL) != 0) return 1;
+    for (unsigned int i = 0;
+         i < 10000 && !peak_memlog_test_writer_is_paused(); ++i) {
+        usleep(100);
+    }
+    if (!expect(peak_memlog_test_writer_is_paused(),
+                "timeout writer did not stall")) return 1;
+
+    peak_memlog_test_finalize();
+    peak_memlog_test_snapshot(&snapshot);
+    if (!expect(snapshot.state == PEAK_MEMLOG_DISABLED &&
+                snapshot.mapping_live && snapshot.exported == 0,
+                "timeout did not retain live memory-log state")) return 1;
+
+    peak_memlog_test_pause_before_commit(0);
+    pthread_join(writer, NULL);
+    peak_memlog_test_finalize();
+    peak_memlog_test_snapshot(&snapshot);
+    unsetenv("PEAK_MEMORY_WRITER_DRAIN_TIMEOUT_MS");
+    return !expect(snapshot.state == PEAK_MEMLOG_FINALIZED &&
+                   !snapshot.mapping_live,
+                   "retained memory-log state did not finalize after drain");
+}
+
 static int run_multithread_stress(void)
 {
     const size_t event_count = STRESS_THREADS * STRESS_EVENTS_PER_THREAD;
@@ -248,6 +283,9 @@ int main(int argc, char** argv)
     if (strcmp(argv[1], "overflow") == 0) return run_overflow();
     if (strcmp(argv[1], "capacity") == 0) return run_capacity();
     if (strcmp(argv[1], "stalled") == 0) return run_stalled_writer();
+    if (strcmp(argv[1], "stalled-timeout") == 0) {
+        return run_stalled_writer_timeout();
+    }
     if (strcmp(argv[1], "stress") == 0) return run_multithread_stress();
     if (strcmp(argv[1], "no-clobber") == 0) return run_output_no_clobber();
     if (strcmp(argv[1], "tid-fork") == 0) return run_tid_fork();

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1023,9 +1023,12 @@ def check_peak_init_heartbeat_order(repo_root):
             "PEAK_RUNTIME_ACTIVATION_CANCELED" in activation_close and
             "atomic_compare_exchange_weak_explicit(" in activation_close,
             "inactive teardown must atomically claim READY -> CANCELED")
-    require("PEAK_RUNTIME_ACTIVATION_IN_PROGRESS" in activation_close and
-            "sched_yield();" in activation_close,
-            "teardown must wait if activation wins the READY transition")
+    require("peak_runtime_activation_wait_for_terminal();" in activation_close and
+            "sched_yield();" not in activation_close and
+            "pthread_cond_timedwait" in source and
+            "PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS" in source,
+            "teardown must use a bounded wakeup when activation wins the "
+            "READY transition")
     require("peak_runtime_close_activation_for_teardown();" in
             extract_function(source, "peak_fini"),
             "main-return finalization must close deferred activation")


### PR DESCRIPTION
## Summary

- replace four profiler-owned `sched_yield()` waits with subsystem-local condition waits using monotonic deadlines
- make pthread child publication a cancellation-safe `PENDING -> READY/ABANDONED` handshake with late-publication rollback
- retain memory-log state on writer-drain timeout and fail the MPI finalizer-owner path closed without a second MPI call
- document finite timeout controls and add deterministic timeout, cancellation, wake-before-wait, spurious-wakeup, retention, and fail-closed regressions

## Safety and performance

- no detach/reattach FSM changes
- no locks, waits, allocations, or timeout checks added to the CPU target callback hot path
- timeout paths retain state that may still be reachable instead of performing destructive cleanup
- the production callback matrix passed at 1/2/8/32/64 threads for 10/100/1000 ns targets

## Validation

- exact head: `473cdd80f77029da2ac267f7f5d3540a1ea1e736`
- GitHub CI: 16/16 checks passed (including duplicate push/PR-triggered GCC, Clang, macOS, MPICH, Open MPI, and Intel MPI jobs)
- GCC and Clang focused builds passed
- runtime activation, pthread publication, memory writer retention, and MPI finalizer-owner regressions passed
- cancellation regressions prove canceled runtime/MPI waiters release the reacquired condition mutex and do not strand owner publication
- the MPI failed-closed regression proves later entries return an error and the original-finalizer stub remains uncalled
- timeout diagnostics report both monotonic elapsed time and the configured deadline
- pthread handshake passed standalone TSan and ASan/UBSan runs
- `check_general_listener_hotpath.py` passed
- `check_detach_lifecycle_invariants.py` passed
- callback hot-path benchmark matrix passed all unchanged gates
- local Clang suite: 510/519 passed in one `-j4` run; the remaining nine long MILC-like performance tests contended when run concurrently, and an affected auto-stress case passed when rerun in isolation

## Independent review

- a strict independent review found and blocked cancellation cleanup and MPI failed-closed return-semantics gaps
- both findings were fixed and covered by deterministic regressions
- the complete exact-head re-review returned `ACCEPT` with no blocking correctness, concurrency, lifecycle, portability, performance, or scope findings

Closes #91
