### PR TITLE
Reclaim detached-thread profiling slots safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,14 @@ in detail.
 | `PEAK_TEXT_OUTPUT` | Force or suppress the human-readable stderr report. |
 | `PEAK_VERBOSITY` | `silent`, `report`/`quiet`, `warn`, `info`, or `debug`; numeric levels `0` through `4` are also accepted. |
 | `PEAK_NAME_TRUNCATE` | Truncate long function and kernel names in text output. |
-| `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. |
+| `PEAK_MAX_NUM_THREADS` | Tracked-thread capacity. Default: twice the online CPU count; `0` uses one slot and values above `4096` clamp. A successful `pthread_join()` immediately releases a completed slot. On Linux, detached slots are reclaimed by a bounded controller slow path only after PEAK's final TLS-destructor pass and proof that the generation's kernel TID is absent from `/proc/self/task`; ambiguous cases remain quarantined. |
 | `PEAK_RUNTIME_ACTIVATION_WAIT_TIMEOUT_MS` | Maximum wait for another thread to finish deferred runtime activation. On timeout, dependent teardown/report work is skipped. Default: `5000`. |
 | `PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS` | Maximum wait for a `pthread_create()` caller to publish child slot metadata. On timeout, the child runs untracked and late metadata is discarded safely. Default: `5000`. |
+
+At `info` verbosity, detached-thread cleanup reports its scan count, examined
+entries, reclaimed/deferred totals, pending high-water mark, fixed 64-entry
+budget, and 100 ms minimum scan interval. These scans run only on the controller
+slow path; target callbacks do not perform registry searches or `/proc` access.
 
 Every text and stats CSV report includes a capability manifest for CPU targets,
 strict mutation, CUDA, memory tracking, JIT input, dynamic DSO discovery, and

--- a/include/internal/pthread_slot_registry.h
+++ b/include/internal/pthread_slot_registry.h
@@ -6,6 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include <sys/types.h>
 
 #define PEAK_PTHREAD_SLOT_REGISTRY_MAX_CAPACITY 4096U
 
@@ -13,6 +14,11 @@ typedef struct {
     size_t slot;
     uint64_t generation;
 } PeakPthreadSlotToken;
+
+typedef struct {
+    PeakPthreadSlotToken token;
+    pid_t kernel_tid;
+} PeakPthreadDetachedCandidate;
 
 typedef enum {
     PEAK_PTHREAD_START_PENDING = 0,
@@ -23,7 +29,12 @@ typedef enum {
 typedef struct {
     pthread_t tid;
     PeakPthreadSlotToken token;
+    pid_t kernel_tid;
     bool occupied;
+    bool detached;
+    bool final_destructor_pass;
+    bool exit_pending;
+    bool retiring;
 } PeakPthreadSlotRegistryEntry;
 
 /* The registry is deliberately allocation-free. It is used only from the
@@ -37,6 +48,9 @@ typedef struct {
     size_t reusable_count;
     size_t next_slot;
     size_t capacity;
+    size_t reclaim_cursor;
+    size_t exit_pending_count;
+    size_t max_exit_pending_count;
     uint64_t next_generation;
     bool initialized;
 } PeakPthreadSlotRegistry;
@@ -53,6 +67,41 @@ bool peak_pthread_slot_registry_compare_remove(PeakPthreadSlotRegistry* registry
                                                pthread_t tid,
                                                uint64_t generation,
                                                bool reusable);
+bool peak_pthread_slot_registry_compare_remove_token(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool reusable);
+bool peak_pthread_slot_registry_begin_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token);
+bool peak_pthread_slot_registry_complete_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool reusable);
+bool peak_pthread_slot_registry_defer_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token);
+bool peak_pthread_slot_registry_mark_kernel_tid(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    pid_t kernel_tid);
+bool peak_pthread_slot_registry_mark_detached(
+    PeakPthreadSlotRegistry* registry,
+    pthread_t tid,
+    uint64_t generation,
+    bool* became_exit_pending);
+bool peak_pthread_slot_registry_mark_final_destructor(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool* became_exit_pending);
+size_t peak_pthread_slot_registry_snapshot_exit_pending(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadDetachedCandidate* candidates,
+    size_t budget,
+    size_t* entries_examined);
+size_t peak_pthread_slot_registry_exit_pending_count(
+    PeakPthreadSlotRegistry* registry,
+    size_t* max_count);
 bool peak_pthread_slot_registry_quarantine(PeakPthreadSlotRegistry* registry,
                                            pthread_t tid);
 bool peak_pthread_slot_registry_contains(PeakPthreadSlotRegistry* registry,

--- a/include/pthread_listener.h
+++ b/include/pthread_listener.h
@@ -134,6 +134,12 @@ PEAK_PTHREAD_LISTENER_API int
 pthread_listener_test_current_thread_has_slot(void);
 PEAK_PTHREAD_LISTENER_API int
 pthread_listener_test_mark_current_thread_final_destructor(void);
+PEAK_PTHREAD_LISTENER_API void
+pthread_listener_test_join_detach_race_enable(void);
+PEAK_PTHREAD_LISTENER_API unsigned int
+pthread_listener_test_join_detach_race_paused(void);
+PEAK_PTHREAD_LISTENER_API void
+pthread_listener_test_join_detach_race_release(void);
 #endif
 
 /**

--- a/include/pthread_listener.h
+++ b/include/pthread_listener.h
@@ -9,6 +9,8 @@
 #include "frida-gum.h"
 
 #include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <unistd.h>
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -34,11 +36,26 @@ struct _PthreadListener {
  */
 typedef struct _PthreadState PthreadState;
 
+typedef struct {
+    uint64_t scans;
+    uint64_t entries_examined;
+    uint64_t candidates_checked;
+    uint64_t reclaimed;
+    uint64_t deferred_alive;
+    uint64_t ambiguous_checks;
+    uint64_t retire_failures;
+    size_t pending;
+    size_t max_pending;
+    unsigned int scan_budget;
+    unsigned int scan_interval_ms;
+} PeakPthreadReclamationDiagnostics;
+
 /**
  * Tracks the child ID argument and wrapper context until pthread_create
- * returns.  Only successful joins release slots for reuse; detached or
- * otherwise unjoined threads retain quarantined slots because POSIX does not
- * provide a post-destructor notification with a safe ordering guarantee.
+ * returns. Successful joins release slots immediately. On Linux, detached
+ * slots become reusable only after PEAK's final TLS-destructor pass and a
+ * slow-path proof that the original kernel TID is absent from /proc/self/task.
+ * Ambiguous or unsupported cases remain quarantined.
  */
 struct _PthreadState {
     pthread_t* child_tid;
@@ -50,9 +67,11 @@ struct _PthreadState {
  * @brief Attaches pthread creation/join hooks and starts thread-ID tracking.
  *
  * The function initializes the thread-ID map, registers the main thread, and
- * installs Gum hooks for pthread_create and pthread_join. Created threads
+ * installs Gum hooks for pthread_create, pthread_join, and pthread_detach.
+ * Created threads
  * receive compact PEAK IDs when their wrapped start routine begins; IDs are
- * reused only after a successful join. The hooks are removed by
+ * are reused after a successful join or conservative Linux detached-thread
+ * exit proof. The hooks are removed by
  * pthread_listener_dettach(), but the mapping remains available because
  * wrapped start routines may finish after interception has stopped.
  */
@@ -92,6 +111,13 @@ PEAK_PTHREAD_LISTENER_API void pthread_listener_mark_next_created_thread_helper(
 /** Returns TRUE for a PEAK helper thread that must silently bypass accounting. */
 gboolean pthread_listener_current_thread_excluded(void);
 
+/** Runs one bounded Linux detached-thread reclamation pass on a slow path. */
+gboolean pthread_listener_reclaim_detached_slots(void);
+
+/** Copies detached-thread reclamation counters and configured scan bounds. */
+PEAK_PTHREAD_LISTENER_API void pthread_listener_get_reclamation_diagnostics(
+    PeakPthreadReclamationDiagnostics* diagnostics);
+
 #ifdef PEAK_ENABLE_TEST_HOOKS
 void pthread_listener_test_fail_slot_publish(unsigned int count);
 void pthread_listener_test_clear_current_thread_slot(void);
@@ -106,6 +132,8 @@ PEAK_PTHREAD_LISTENER_API void
 pthread_listener_test_release_start_publication(void);
 PEAK_PTHREAD_LISTENER_API int
 pthread_listener_test_current_thread_has_slot(void);
+PEAK_PTHREAD_LISTENER_API int
+pthread_listener_test_mark_current_thread_final_destructor(void);
 #endif
 
 /**

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -4452,6 +4452,7 @@ peak_general_listener_controller_drain(unsigned int timeout_ms)
     for (;;) {
         gboolean pending;
 
+        (void)pthread_listener_reclaim_detached_slots();
         pthread_mutex_lock(&lock);
         (void)peak_general_controller_process_pending_unlocked(controller_tid,
                                                                tid_keys,
@@ -4527,6 +4528,7 @@ peak_general_controller_thread_main(void* arg)
             atomic_load_explicit(&general_controller_wake_sequence,
                                  memory_order_acquire);
 
+        (void)pthread_listener_reclaim_detached_slots();
         pthread_mutex_lock(&lock);
         (void)peak_general_controller_process_pending_unlocked(controller_tid,
                                                                tid_keys,

--- a/src/pthread_listener.c
+++ b/src/pthread_listener.c
@@ -78,6 +78,9 @@ static gboolean pthread_slot_key_created = FALSE;
 static _Atomic unsigned int pthread_test_fail_slot_publish = 0;
 static _Atomic int pthread_test_pause_start_publication;
 static _Atomic int pthread_test_release_start_publication;
+static _Atomic int pthread_test_join_detach_race_enabled;
+static _Atomic unsigned int pthread_test_join_detach_race_paused;
+static _Atomic int pthread_test_join_detach_race_release;
 #endif
 
 static void peak_pthread_slot_destructor(void* data);
@@ -488,6 +491,25 @@ pthread_listener_init(PthreadListener* self)
 static int (*original_pthread_join)(pthread_t thread, void **retval);
 static int (*original_pthread_detach)(pthread_t thread);
 
+static void
+pthread_listener_test_pause_join_detach_after_capture(gboolean captured)
+{
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (captured &&
+        atomic_load_explicit(&pthread_test_join_detach_race_enabled,
+                             memory_order_acquire) != 0) {
+        atomic_fetch_add_explicit(&pthread_test_join_detach_race_paused, 1,
+                                  memory_order_acq_rel);
+        while (atomic_load_explicit(&pthread_test_join_detach_race_release,
+                                    memory_order_acquire) == 0) {
+            sched_yield();
+        }
+    }
+#else
+    (void)captured;
+#endif
+}
+
 static gboolean
 pthread_listener_capture_thread_token(pthread_t thread,
                                       size_t* slot_out,
@@ -524,6 +546,7 @@ peak_pthread_join(pthread_t thread, void **retval)
     uint64_t generation = 0;
     gboolean captured =
         pthread_listener_capture_thread_token(thread, &slot, &generation);
+    pthread_listener_test_pause_join_detach_after_capture(captured);
     int ret = original_pthread_join(thread, retval);
     if (ret == 0 && captured) {
         PeakPthreadSlotToken token = {
@@ -554,6 +577,7 @@ peak_pthread_detach(pthread_t thread)
         peak_pthread_slot_registry_capture(&pthread_slot_registry,
                                             thread,
                                             &token);
+    pthread_listener_test_pause_join_detach_after_capture(captured);
     int ret = original_pthread_detach(thread);
 
     if (ret == 0 && captured) {
@@ -1007,6 +1031,33 @@ pthread_listener_test_mark_current_thread_final_destructor(void)
         &pthread_slot_registry, token, &became_exit_pending);
     pthread_listener_wake_reclaimer_if_pending(became_exit_pending);
     return marked;
+}
+
+void
+pthread_listener_test_join_detach_race_enable(void)
+{
+    atomic_store_explicit(&pthread_test_join_detach_race_paused, 0,
+                          memory_order_release);
+    atomic_store_explicit(&pthread_test_join_detach_race_release, 0,
+                          memory_order_release);
+    atomic_store_explicit(&pthread_test_join_detach_race_enabled, 1,
+                          memory_order_release);
+}
+
+unsigned int
+pthread_listener_test_join_detach_race_paused(void)
+{
+    return atomic_load_explicit(&pthread_test_join_detach_race_paused,
+                                memory_order_acquire);
+}
+
+void
+pthread_listener_test_join_detach_race_release(void)
+{
+    atomic_store_explicit(&pthread_test_join_detach_race_enabled, 0,
+                          memory_order_release);
+    atomic_store_explicit(&pthread_test_join_detach_race_release, 1,
+                          memory_order_release);
 }
 #endif
 

--- a/src/pthread_listener.c
+++ b/src/pthread_listener.c
@@ -7,13 +7,22 @@
 #include "internal/signal_policy_internal.h"
 #include "utils/env_parser.h"
 
+#include <errno.h>
 #include <limits.h>
 #include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#if defined(__linux__)
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#endif
 #include <time.h>
 
 #define PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_ENV \
     "PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS"
 #define PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_DEFAULT 5000U
+#define PEAK_PTHREAD_RECLAIM_SCAN_BUDGET 64U
+#define PEAK_PTHREAD_RECLAIM_SCAN_INTERVAL_MS 100U
 
 #undef g_printerr
 #define g_printerr(...) peak_log_warn(__VA_ARGS__)
@@ -28,12 +37,18 @@ static gboolean tid_mapping_initialized = FALSE;
 static PeakPthreadSlotRegistry pthread_slot_registry;
 static gpointer pthread_create_hook_address;
 static gpointer pthread_join_hook_address;
+static gpointer pthread_detach_hook_address;
 extern pthread_t heartbeat_thread;
 extern gulong peak_max_num_threads;
 static unsigned int pthread_start_handshake_timeout_ms =
     PEAK_PTHREAD_START_HANDSHAKE_TIMEOUT_MS_DEFAULT;
 static PeakEnvWarningState pthread_start_timeout_config_warning;
 static _Atomic int pthread_start_timeout_warning_emitted;
+static int pthread_task_directory_fd = -1;
+static pthread_mutex_t pthread_reclaim_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct timespec pthread_reclaim_last_scan;
+static gboolean pthread_reclaim_last_scan_valid;
+static PeakPthreadReclamationDiagnostics pthread_reclaim_diagnostics;
 
 static void pthread_listener_iface_init(gpointer g_iface, gpointer iface_data);
 static gboolean pthread_listener_insert_thread_unlocked(pthread_t tid);
@@ -111,11 +126,30 @@ typedef struct {
     void* start_arg;
     gboolean skip_tracking;
     gboolean tracked;
+    gboolean detached;
     size_t slot;
     uint64_t generation;
     _Atomic int handshake_state;
     _Atomic unsigned int references;
 } PeakPthreadStartContext;
+
+static pid_t
+pthread_listener_current_kernel_tid(void)
+{
+#if defined(__linux__) && defined(SYS_gettid)
+    return (pid_t)syscall(SYS_gettid);
+#else
+    return 0;
+#endif
+}
+
+static void
+pthread_listener_wake_reclaimer_if_pending(gboolean became_exit_pending)
+{
+    if (became_exit_pending) {
+        peak_general_listener_controller_wake();
+    }
+}
 
 static void
 peak_pthread_start_context_release(PeakPthreadStartContext* context)
@@ -177,8 +211,8 @@ peak_pthread_slot_destructor(void* data)
      * POSIX does not order key destructors.  Re-publish through all available
      * iterations so application destructors keep their slot.  Crucially, this
      * destructor never clears, retires, or reuses the slot: an implementation
-     * may run PEAK before an application key in its final iteration.  Only a
-     * successful pthread_join below proves all destructors have completed.
+     * may run PEAK before an application key in its final iteration. A join
+     * handoff or later Linux kernel-TID absence proof is still required.
      */
     identity->destructor_passes++;
 #ifdef PTHREAD_DESTRUCTOR_ITERATIONS
@@ -192,8 +226,20 @@ peak_pthread_slot_destructor(void* data)
 
     /* Do not remove or mark this map entry dead here.  POSIX may run an
      * application destructor after PEAK in this final iteration, and that
-     * destructor may still enter a target.  Successful pthread_join is the
-     * only proof that every destructor has finished. */
+     * destructor may still enter a target.  A detached slot becomes pending,
+     * but cannot be retired until the controller proves that its kernel TID
+     * has left /proc/self/task. */
+    if (tid_mapping_initialized) {
+        PeakPthreadSlotToken token = {
+            .slot = identity->slot,
+            .generation = identity->generation,
+        };
+        bool became_exit_pending = false;
+
+        (void)peak_pthread_slot_registry_mark_final_destructor(
+            &pthread_slot_registry, token, &became_exit_pending);
+        pthread_listener_wake_reclaimer_if_pending(became_exit_pending);
+    }
 }
 
 static void
@@ -233,6 +279,15 @@ peak_pthread_start(void* data)
                  * identity invalid so callbacks are explicitly counted as
                  * dropped rather than silently excluded. */
                 pthread_thread_excluded = FALSE;
+            } else if (tid_mapping_initialized) {
+                PeakPthreadSlotToken token = {
+                    .slot = context->slot,
+                    .generation = context->generation,
+                };
+                (void)peak_pthread_slot_registry_mark_kernel_tid(
+                    &pthread_slot_registry,
+                    token,
+                    pthread_listener_current_kernel_tid());
             }
         }
     } else {
@@ -317,6 +372,13 @@ pthread_listener_on_enter(GumInvocationListener* listener,
     start_context->start_arg = gum_invocation_context_get_nth_argument(ic, 3);
     start_context->skip_tracking =
         (tid == &heartbeat_thread) || pthread_next_create_is_helper;
+    const pthread_attr_t* attr =
+        gum_invocation_context_get_nth_argument(ic, 1);
+    int detach_state = PTHREAD_CREATE_JOINABLE;
+    start_context->detached =
+        attr != NULL &&
+        pthread_attr_getdetachstate(attr, &detach_state) == 0 &&
+        detach_state == PTHREAD_CREATE_DETACHED;
     atomic_init(&start_context->handshake_state,
                 PEAK_PTHREAD_START_PENDING);
     atomic_init(&start_context->references, 2);
@@ -358,13 +420,21 @@ pthread_listener_on_leave(GumInvocationListener* listener,
                     context->slot = token.slot;
                     context->generation = token.generation;
                     context->tracked = TRUE;
+                    if (context->detached) {
+                        (void)peak_pthread_slot_registry_mark_detached(
+                            &pthread_slot_registry,
+                            *thread_state->child_tid,
+                            context->generation,
+                            NULL);
+                    }
                 } else {
                     /* A detached/unjoined thread may have exited and its
                      * pthread_t can already be reused by this untracked
                      * child.  Delete the stale identity to ensure a later
                      * pthread_join cannot retire or recycle that old slot.
-                     * Deliberately do not queue its slot: without its join
-                     * handoff it remains permanently quarantined. */
+                     * Deliberately do not queue its slot: the stale identity
+                     * prevents a generation-safe kernel-TID proof, so the old
+                     * slot remains quarantined. */
                     (void)pthread_listener_quarantine_ambiguous_tid_unlocked(
                         *thread_state->child_tid);
                 }
@@ -416,6 +486,7 @@ pthread_listener_init(PthreadListener* self)
 }
 
 static int (*original_pthread_join)(pthread_t thread, void **retval);
+static int (*original_pthread_detach)(pthread_t thread);
 
 static gboolean
 pthread_listener_capture_thread_token(pthread_t thread,
@@ -446,15 +517,6 @@ pthread_listener_remove_thread_if_token_unlocked(pthread_t thread,
     }
 }
 
-static void
-pthread_listener_remove_thread_if_token(pthread_t thread,
-                                        uint64_t generation,
-                                        gboolean reusable)
-{
-    pthread_listener_remove_thread_if_token_unlocked(thread, generation,
-                                                      reusable);
-}
-
 static int
 peak_pthread_join(pthread_t thread, void **retval)
 {
@@ -464,12 +526,171 @@ peak_pthread_join(pthread_t thread, void **retval)
         pthread_listener_capture_thread_token(thread, &slot, &generation);
     int ret = original_pthread_join(thread, retval);
     if (ret == 0 && captured) {
-            /* pthread_join returning is the post-termination handoff: the
-             * joined thread and every TLS destructor are now complete. */
-        gboolean reusable = peak_general_listener_retire_current_thread_slot(slot);
-        pthread_listener_remove_thread_if_token(thread, generation, reusable);
+        PeakPthreadSlotToken token = {
+            .slot = slot,
+            .generation = generation,
+        };
+
+        /* pthread_join returning is the post-termination handoff: the joined
+         * thread and every TLS destructor are complete. Claim the generation
+         * before touching its physical slot so a detach/join race cannot
+         * release and reuse that slot underneath retirement. */
+        if (peak_pthread_slot_registry_begin_retire(&pthread_slot_registry,
+                                                    token)) {
+            gboolean reusable =
+                peak_general_listener_retire_current_thread_slot(slot);
+            (void)peak_pthread_slot_registry_complete_retire(
+                &pthread_slot_registry, token, reusable);
+        }
     }
     return ret;
+}
+
+static int
+peak_pthread_detach(pthread_t thread)
+{
+    PeakPthreadSlotToken token;
+    gboolean captured = tid_mapping_initialized &&
+        peak_pthread_slot_registry_capture(&pthread_slot_registry,
+                                            thread,
+                                            &token);
+    int ret = original_pthread_detach(thread);
+
+    if (ret == 0 && captured) {
+        bool became_exit_pending = false;
+
+        (void)peak_pthread_slot_registry_mark_detached(
+            &pthread_slot_registry,
+            thread,
+            token.generation,
+            &became_exit_pending);
+        pthread_listener_wake_reclaimer_if_pending(became_exit_pending);
+    }
+    return ret;
+}
+
+static gboolean
+pthread_listener_reclaim_interval_elapsed(const struct timespec* now)
+{
+    if (!pthread_reclaim_last_scan_valid) {
+        return TRUE;
+    }
+
+    int64_t elapsed_ns =
+        (int64_t)(now->tv_sec - pthread_reclaim_last_scan.tv_sec) *
+            1000000000LL +
+        (int64_t)(now->tv_nsec - pthread_reclaim_last_scan.tv_nsec);
+    return elapsed_ns >=
+        (int64_t)PEAK_PTHREAD_RECLAIM_SCAN_INTERVAL_MS * 1000000LL;
+}
+
+gboolean
+pthread_listener_reclaim_detached_slots(void)
+{
+#if defined(__linux__)
+    PeakPthreadDetachedCandidate
+        candidates[PEAK_PTHREAD_RECLAIM_SCAN_BUDGET];
+    struct timespec now;
+    size_t entries_examined = 0;
+    size_t candidate_count;
+    gboolean did_work = FALSE;
+
+    if (!tid_mapping_initialized || pthread_task_directory_fd < 0 ||
+        peak_pthread_slot_registry_exit_pending_count(
+            &pthread_slot_registry, NULL) == 0 ||
+        clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return FALSE;
+    }
+
+    (void)pthread_mutex_lock(&pthread_reclaim_mutex);
+    if (!pthread_listener_reclaim_interval_elapsed(&now)) {
+        (void)pthread_mutex_unlock(&pthread_reclaim_mutex);
+        return FALSE;
+    }
+    pthread_reclaim_last_scan = now;
+    pthread_reclaim_last_scan_valid = TRUE;
+    candidate_count = peak_pthread_slot_registry_snapshot_exit_pending(
+        &pthread_slot_registry,
+        candidates,
+        PEAK_PTHREAD_RECLAIM_SCAN_BUDGET,
+        &entries_examined);
+    pthread_reclaim_diagnostics.scans++;
+    pthread_reclaim_diagnostics.entries_examined += entries_examined;
+    pthread_reclaim_diagnostics.candidates_checked += candidate_count;
+
+    for (size_t index = 0; index < candidate_count; index++) {
+        char tid_name[32];
+        struct stat task_stat;
+        int written = snprintf(tid_name, sizeof(tid_name), "%ld",
+                               (long)candidates[index].kernel_tid);
+
+        if (written <= 0 || (size_t)written >= sizeof(tid_name)) {
+            pthread_reclaim_diagnostics.ambiguous_checks++;
+            continue;
+        }
+        errno = 0;
+        if (fstatat(pthread_task_directory_fd, tid_name, &task_stat,
+                    AT_SYMLINK_NOFOLLOW) == 0) {
+            pthread_reclaim_diagnostics.deferred_alive++;
+            continue;
+        }
+        if (errno != ENOENT) {
+            pthread_reclaim_diagnostics.ambiguous_checks++;
+            continue;
+        }
+
+        if (!peak_pthread_slot_registry_begin_retire(
+                &pthread_slot_registry, candidates[index].token)) {
+            pthread_reclaim_diagnostics.ambiguous_checks++;
+            continue;
+        }
+        gboolean reusable = peak_general_listener_retire_current_thread_slot(
+            candidates[index].token.slot);
+        if (!reusable) {
+            pthread_reclaim_diagnostics.retire_failures++;
+            (void)peak_pthread_slot_registry_defer_retire(
+                &pthread_slot_registry, candidates[index].token);
+            continue;
+        }
+        if (peak_pthread_slot_registry_complete_retire(
+                &pthread_slot_registry, candidates[index].token, true)) {
+            pthread_reclaim_diagnostics.reclaimed++;
+            did_work = TRUE;
+        } else {
+            pthread_reclaim_diagnostics.ambiguous_checks++;
+        }
+    }
+
+    pthread_reclaim_diagnostics.pending =
+        peak_pthread_slot_registry_exit_pending_count(
+            &pthread_slot_registry,
+            &pthread_reclaim_diagnostics.max_pending);
+    (void)pthread_mutex_unlock(&pthread_reclaim_mutex);
+    return did_work;
+#else
+    return FALSE;
+#endif
+}
+
+void
+pthread_listener_get_reclamation_diagnostics(
+    PeakPthreadReclamationDiagnostics* diagnostics)
+{
+    if (diagnostics == NULL) {
+        return;
+    }
+
+    (void)pthread_mutex_lock(&pthread_reclaim_mutex);
+    pthread_reclaim_diagnostics.pending =
+        peak_pthread_slot_registry_exit_pending_count(
+            &pthread_slot_registry,
+            &pthread_reclaim_diagnostics.max_pending);
+    pthread_reclaim_diagnostics.scan_budget =
+        PEAK_PTHREAD_RECLAIM_SCAN_BUDGET;
+    pthread_reclaim_diagnostics.scan_interval_ms =
+        PEAK_PTHREAD_RECLAIM_SCAN_INTERVAL_MS;
+    *diagnostics = pthread_reclaim_diagnostics;
+    (void)pthread_mutex_unlock(&pthread_reclaim_mutex);
 }
 
 void pthread_listener_attach()
@@ -518,7 +739,23 @@ void pthread_listener_attach()
                                     (gpointer*)(&original_pthread_join),
                                     NULL);
     }
+    pthread_detach_hook_address =
+        peak_general_listener_find_function("pthread_detach");
+    if (pthread_detach_hook_address) {
+        gum_interceptor_replace_fast(pthread_create_interceptor,
+                                    pthread_detach_hook_address,
+                                    &peak_pthread_detach,
+                                    (gpointer*)(&original_pthread_detach),
+                                    NULL);
+    }
     gum_interceptor_end_transaction(pthread_create_interceptor);
+
+#if defined(__linux__)
+    if (pthread_task_directory_fd < 0) {
+        pthread_task_directory_fd = open("/proc/self/task",
+                                         O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    }
+#endif
 }
 
 static gboolean
@@ -540,11 +777,40 @@ pthread_listener_flush_teardown(void)
     return gum_interceptor_flush(pthread_create_interceptor);
 }
 
+static void
+pthread_listener_log_reclamation_diagnostics(void)
+{
+    PeakPthreadReclamationDiagnostics diagnostics;
+
+    pthread_listener_get_reclamation_diagnostics(&diagnostics);
+    if (diagnostics.scans == 0 && diagnostics.pending == 0) {
+        return;
+    }
+    peak_log_info(
+        "[peak] detached thread slot reclamation: scans=%llu "
+        "entries_examined=%llu candidates=%llu reclaimed=%llu "
+        "deferred_alive=%llu ambiguous=%llu retire_failures=%llu "
+        "pending=%lu max_pending=%lu budget=%u interval_ms=%u\n",
+        (unsigned long long)diagnostics.scans,
+        (unsigned long long)diagnostics.entries_examined,
+        (unsigned long long)diagnostics.candidates_checked,
+        (unsigned long long)diagnostics.reclaimed,
+        (unsigned long long)diagnostics.deferred_alive,
+        (unsigned long long)diagnostics.ambiguous_checks,
+        (unsigned long long)diagnostics.retire_failures,
+        (unsigned long)diagnostics.pending,
+        (unsigned long)diagnostics.max_pending,
+        diagnostics.scan_budget,
+        diagnostics.scan_interval_ms);
+}
+
 gboolean pthread_listener_dettach()
 {
     if (pthread_create_interceptor == NULL) {
         return TRUE;
     }
+
+    pthread_listener_log_reclamation_diagnostics();
 
     gum_interceptor_begin_transaction(pthread_create_interceptor);
     if (pthread_create_listener != NULL) {
@@ -552,6 +818,10 @@ gboolean pthread_listener_dettach()
     }
     if (pthread_join_hook_address != NULL) {
         gum_interceptor_revert(pthread_create_interceptor, pthread_join_hook_address);
+    }
+    if (pthread_detach_hook_address != NULL) {
+        gum_interceptor_revert(pthread_create_interceptor,
+                               pthread_detach_hook_address);
     }
     gum_interceptor_end_transaction(pthread_create_interceptor);
 
@@ -576,6 +846,7 @@ gboolean pthread_listener_dettach()
     pthread_create_interceptor = NULL;
     pthread_create_hook_address = NULL;
     pthread_join_hook_address = NULL;
+    pthread_detach_hook_address = NULL;
 
     return TRUE;
 }
@@ -718,6 +989,24 @@ int
 pthread_listener_test_current_thread_has_slot(void)
 {
     return pthread_slot_identity.valid ? 1 : 0;
+}
+
+PEAK_API int
+pthread_listener_test_mark_current_thread_final_destructor(void)
+{
+    bool became_exit_pending = false;
+
+    if (!tid_mapping_initialized || !pthread_slot_identity.valid) {
+        return 0;
+    }
+    PeakPthreadSlotToken token = {
+        .slot = pthread_slot_identity.slot,
+        .generation = pthread_slot_identity.generation,
+    };
+    int marked = peak_pthread_slot_registry_mark_final_destructor(
+        &pthread_slot_registry, token, &became_exit_pending);
+    pthread_listener_wake_reclaimer_if_pending(became_exit_pending);
+    return marked;
 }
 #endif
 

--- a/src/pthread_listener.c
+++ b/src/pthread_listener.c
@@ -491,10 +491,10 @@ pthread_listener_init(PthreadListener* self)
 static int (*original_pthread_join)(pthread_t thread, void **retval);
 static int (*original_pthread_detach)(pthread_t thread);
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
 static void
 pthread_listener_test_pause_join_detach_after_capture(gboolean captured)
 {
-#ifdef PEAK_ENABLE_TEST_HOOKS
     if (captured &&
         atomic_load_explicit(&pthread_test_join_detach_race_enabled,
                              memory_order_acquire) != 0) {
@@ -505,10 +505,8 @@ pthread_listener_test_pause_join_detach_after_capture(gboolean captured)
             sched_yield();
         }
     }
-#else
-    (void)captured;
-#endif
 }
+#endif
 
 static gboolean
 pthread_listener_capture_thread_token(pthread_t thread,
@@ -546,7 +544,9 @@ peak_pthread_join(pthread_t thread, void **retval)
     uint64_t generation = 0;
     gboolean captured =
         pthread_listener_capture_thread_token(thread, &slot, &generation);
+#ifdef PEAK_ENABLE_TEST_HOOKS
     pthread_listener_test_pause_join_detach_after_capture(captured);
+#endif
     int ret = original_pthread_join(thread, retval);
     if (ret == 0 && captured) {
         PeakPthreadSlotToken token = {
@@ -577,7 +577,9 @@ peak_pthread_detach(pthread_t thread)
         peak_pthread_slot_registry_capture(&pthread_slot_registry,
                                             thread,
                                             &token);
+#ifdef PEAK_ENABLE_TEST_HOOKS
     pthread_listener_test_pause_join_detach_after_capture(captured);
+#endif
     int ret = original_pthread_detach(thread);
 
     if (ret == 0 && captured) {

--- a/src/pthread_slot_registry.c
+++ b/src/pthread_slot_registry.c
@@ -139,6 +139,68 @@ peak_pthread_slot_registry_find_unlocked(PeakPthreadSlotRegistry* registry,
     return NULL;
 }
 
+static PeakPthreadSlotRegistryEntry*
+peak_pthread_slot_registry_find_token_unlocked(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token)
+{
+    if (token.slot >= registry->capacity) {
+        return NULL;
+    }
+
+    PeakPthreadSlotRegistryEntry* entry = &registry->entries[token.slot];
+    if (!entry->occupied || entry->token.generation != token.generation) {
+        return NULL;
+    }
+    return entry;
+}
+
+static void
+peak_pthread_slot_registry_discard_unlocked(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotRegistryEntry* entry)
+{
+    if (entry->exit_pending && registry->exit_pending_count != 0) {
+        registry->exit_pending_count--;
+    }
+    entry->occupied = false;
+    entry->detached = false;
+    entry->final_destructor_pass = false;
+    entry->exit_pending = false;
+    entry->retiring = false;
+    entry->kernel_tid = 0;
+}
+
+static bool
+peak_pthread_slot_registry_update_exit_pending_unlocked(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotRegistryEntry* entry)
+{
+    if (entry->exit_pending || entry->retiring || !entry->detached ||
+        !entry->final_destructor_pass || entry->kernel_tid <= 0) {
+        return false;
+    }
+
+    entry->exit_pending = true;
+    registry->exit_pending_count++;
+    if (registry->exit_pending_count > registry->max_exit_pending_count) {
+        registry->max_exit_pending_count = registry->exit_pending_count;
+    }
+    return true;
+}
+
+static void
+peak_pthread_slot_registry_enqueue_reusable_unlocked(
+    PeakPthreadSlotRegistry* registry,
+    size_t slot)
+{
+    size_t reusable_tail =
+        (registry->reusable_head + registry->reusable_count) %
+        registry->capacity;
+    registry->reusable[reusable_tail] = slot;
+    registry->reusable_count++;
+}
+
 bool
 peak_pthread_slot_registry_init(PeakPthreadSlotRegistry* registry,
                                 size_t capacity)
@@ -192,16 +254,17 @@ peak_pthread_slot_registry_reserve_insert(PeakPthreadSlotRegistry* registry,
         /* A newly created thread can receive a pthread_t held by an unjoined
          * predecessor. Drop that ambiguous mapping, but never recycle it. */
         if (old_entry != NULL) {
-            old_entry->occupied = false;
+            peak_pthread_slot_registry_discard_unlocked(registry, old_entry);
         }
         (void)pthread_mutex_unlock(&registry->mutex);
         return false;
     }
 
     if (old_entry != NULL) {
-        old_entry->occupied = false;
+        peak_pthread_slot_registry_discard_unlocked(registry, old_entry);
     }
     PeakPthreadSlotRegistryEntry* entry = &registry->entries[slot];
+    memset(entry, 0, sizeof(*entry));
     entry->tid = tid;
     entry->token.slot = slot;
     entry->token.generation = ++registry->next_generation;
@@ -227,8 +290,10 @@ peak_pthread_slot_registry_capture(PeakPthreadSlotRegistry* registry,
 
     (void)pthread_mutex_lock(&registry->mutex);
     entry = peak_pthread_slot_registry_find_unlocked(registry, tid);
-    if (entry != NULL) {
+    if (entry != NULL && !entry->retiring) {
         *token = entry->token;
+    } else {
+        entry = NULL;
     }
     (void)pthread_mutex_unlock(&registry->mutex);
     return entry != NULL;
@@ -248,19 +313,271 @@ peak_pthread_slot_registry_compare_remove(PeakPthreadSlotRegistry* registry,
 
     (void)pthread_mutex_lock(&registry->mutex);
     entry = peak_pthread_slot_registry_find_unlocked(registry, tid);
-    if (entry == NULL || entry->token.generation != generation) {
+    if (entry == NULL || entry->retiring ||
+        entry->token.generation != generation) {
         (void)pthread_mutex_unlock(&registry->mutex);
         return false;
     }
     if (reusable) {
-        size_t reusable_tail =
-            (registry->reusable_head + registry->reusable_count) % registry->capacity;
-        registry->reusable[reusable_tail] = entry->token.slot;
-        registry->reusable_count++;
+        peak_pthread_slot_registry_enqueue_reusable_unlocked(
+            registry, entry->token.slot);
     }
-    entry->occupied = false;
+    peak_pthread_slot_registry_discard_unlocked(registry, entry);
     (void)pthread_mutex_unlock(&registry->mutex);
     return true;
+}
+
+bool
+peak_pthread_slot_registry_compare_remove_token(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool reusable)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry == NULL || entry->retiring) {
+        (void)pthread_mutex_unlock(&registry->mutex);
+        return false;
+    }
+    if (reusable) {
+        peak_pthread_slot_registry_enqueue_reusable_unlocked(
+            registry, entry->token.slot);
+    }
+    peak_pthread_slot_registry_discard_unlocked(registry, entry);
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return true;
+}
+
+bool
+peak_pthread_slot_registry_begin_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry == NULL || entry->retiring) {
+        (void)pthread_mutex_unlock(&registry->mutex);
+        return false;
+    }
+    entry->retiring = true;
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return true;
+}
+
+bool
+peak_pthread_slot_registry_complete_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool reusable)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry == NULL || !entry->retiring) {
+        (void)pthread_mutex_unlock(&registry->mutex);
+        return false;
+    }
+    if (reusable) {
+        peak_pthread_slot_registry_enqueue_reusable_unlocked(
+            registry, entry->token.slot);
+    }
+    peak_pthread_slot_registry_discard_unlocked(registry, entry);
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return true;
+}
+
+bool
+peak_pthread_slot_registry_defer_retire(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry == NULL || !entry->retiring) {
+        (void)pthread_mutex_unlock(&registry->mutex);
+        return false;
+    }
+    entry->retiring = false;
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return true;
+}
+
+bool
+peak_pthread_slot_registry_mark_kernel_tid(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    pid_t kernel_tid)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+    bool became_exit_pending = false;
+
+    if (registry == NULL || !registry->initialized || kernel_tid <= 0) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry != NULL) {
+        entry->kernel_tid = kernel_tid;
+        became_exit_pending =
+            peak_pthread_slot_registry_update_exit_pending_unlocked(
+                registry, entry);
+    }
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return entry != NULL || became_exit_pending;
+}
+
+bool
+peak_pthread_slot_registry_mark_detached(
+    PeakPthreadSlotRegistry* registry,
+    pthread_t tid,
+    uint64_t generation,
+    bool* became_exit_pending)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+    bool became_pending = false;
+
+    if (became_exit_pending != NULL) {
+        *became_exit_pending = false;
+    }
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_unlocked(registry, tid);
+    if (entry != NULL && entry->token.generation == generation) {
+        entry->detached = true;
+        became_pending =
+            peak_pthread_slot_registry_update_exit_pending_unlocked(
+                registry, entry);
+    } else {
+        entry = NULL;
+    }
+    (void)pthread_mutex_unlock(&registry->mutex);
+    if (became_exit_pending != NULL) {
+        *became_exit_pending = became_pending;
+    }
+    return entry != NULL;
+}
+
+bool
+peak_pthread_slot_registry_mark_final_destructor(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadSlotToken token,
+    bool* became_exit_pending)
+{
+    PeakPthreadSlotRegistryEntry* entry;
+    bool became_pending = false;
+
+    if (became_exit_pending != NULL) {
+        *became_exit_pending = false;
+    }
+    if (registry == NULL || !registry->initialized) {
+        return false;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    entry = peak_pthread_slot_registry_find_token_unlocked(registry, token);
+    if (entry != NULL) {
+        entry->final_destructor_pass = true;
+        became_pending =
+            peak_pthread_slot_registry_update_exit_pending_unlocked(
+                registry, entry);
+    }
+    (void)pthread_mutex_unlock(&registry->mutex);
+    if (became_exit_pending != NULL) {
+        *became_exit_pending = became_pending;
+    }
+    return entry != NULL;
+}
+
+size_t
+peak_pthread_slot_registry_snapshot_exit_pending(
+    PeakPthreadSlotRegistry* registry,
+    PeakPthreadDetachedCandidate* candidates,
+    size_t budget,
+    size_t* entries_examined)
+{
+    size_t count = 0;
+    size_t examined = 0;
+
+    if (entries_examined != NULL) {
+        *entries_examined = 0;
+    }
+    if (registry == NULL || !registry->initialized || candidates == NULL ||
+        budget == 0 || registry->capacity == 0) {
+        return 0;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    size_t limit = budget < registry->capacity ? budget : registry->capacity;
+    while (examined < limit) {
+        size_t index = (registry->reclaim_cursor + examined) %
+                       registry->capacity;
+        PeakPthreadSlotRegistryEntry* entry = &registry->entries[index];
+
+        if (entry->occupied && entry->exit_pending && !entry->retiring) {
+            candidates[count].token = entry->token;
+            candidates[count].kernel_tid = entry->kernel_tid;
+            count++;
+        }
+        examined++;
+    }
+    registry->reclaim_cursor =
+        (registry->reclaim_cursor + examined) % registry->capacity;
+    (void)pthread_mutex_unlock(&registry->mutex);
+
+    if (entries_examined != NULL) {
+        *entries_examined = examined;
+    }
+    return count;
+}
+
+size_t
+peak_pthread_slot_registry_exit_pending_count(
+    PeakPthreadSlotRegistry* registry,
+    size_t* max_count)
+{
+    size_t count = 0;
+
+    if (max_count != NULL) {
+        *max_count = 0;
+    }
+    if (registry == NULL || !registry->initialized) {
+        return 0;
+    }
+
+    (void)pthread_mutex_lock(&registry->mutex);
+    count = registry->exit_pending_count;
+    if (max_count != NULL) {
+        *max_count = registry->max_exit_pending_count;
+    }
+    (void)pthread_mutex_unlock(&registry->mutex);
+    return count;
 }
 
 bool
@@ -276,7 +593,7 @@ peak_pthread_slot_registry_quarantine(PeakPthreadSlotRegistry* registry,
     (void)pthread_mutex_lock(&registry->mutex);
     entry = peak_pthread_slot_registry_find_unlocked(registry, tid);
     if (entry != NULL) {
-        entry->occupied = false;
+        peak_pthread_slot_registry_discard_unlocked(registry, entry);
     }
     (void)pthread_mutex_unlock(&registry->mutex);
     return entry != NULL;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -923,13 +923,13 @@ if(BUILD_TESTING)
                 FAIL_REGULAR_EXPRESSION "fatal|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)
 
-        add_test(NAME test_fastpath_thread_exit_detached_slot_quarantine
+        add_test(NAME test_fastpath_thread_exit_detached_slot_reclamation
             COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
-        set_tests_properties(test_fastpath_thread_exit_detached_slot_quarantine
+        set_tests_properties(test_fastpath_thread_exit_detached_slot_reclamation
             PROPERTIES
-                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_TEST_DETACHED_QUARANTINE=1;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
+                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=2;PEAK_TEST_DETACHED_RECLAMATION=1;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
                 PASS_REGULAR_EXPRESSION "fastpath_thread_exit_ok"
-                FAIL_REGULAR_EXPRESSION "fatal|detached thread slot was reused|Gum [^\\r\\n]* failed"
+                FAIL_REGULAR_EXPRESSION "fatal|detached .* failed|detached .* mismatch|slot was not reclaimed|fast path regressed|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)
 
         add_test(NAME test_fastpath_thread_exit_helper_silent

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -932,6 +932,15 @@ if(BUILD_TESTING)
                 FAIL_REGULAR_EXPRESSION "fatal|detached .* failed|detached .* mismatch|slot was not reclaimed|fast path regressed|Gum [^\\r\\n]* failed"
                 TIMEOUT 30)
 
+        add_test(NAME test_pthread_join_detach_slot_race
+            COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
+        set_tests_properties(test_pthread_join_detach_slot_race
+            PROPERTIES
+                ENVIRONMENT "PEAK_TARGET=peak_fastpath_thread_exit_target;PEAK_MAX_NUM_THREADS=4;PEAK_TEST_PTHREAD_JOIN_DETACH_RACE=1;PEAK_COST=0;PEAK_HEARTBEAT_INTERVAL=0;${PRELOAD_VAR}"
+                PASS_REGULAR_EXPRESSION "fastpath_thread_exit_ok"
+                FAIL_REGULAR_EXPRESSION "fatal|join/detach race .* failed|join/detach race .* mismatch|no native winner|did not capture|not reclaimed|retirement state pending|Gum [^\\r\\n]* failed"
+                TIMEOUT 30)
+
         add_test(NAME test_fastpath_thread_exit_helper_silent
             COMMAND ${PROJECT_BINARY_DIR}/test/detach_runtime/test_fastpath_thread_exit)
         set_tests_properties(test_fastpath_thread_exit_helper_silent

--- a/test/detach_runtime/CMakeLists.txt
+++ b/test/detach_runtime/CMakeLists.txt
@@ -53,6 +53,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 add_executable(test_fastpath_thread_exit test_fastpath_thread_exit.c)
+target_include_directories(test_fastpath_thread_exit
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${FRIDA_GUM_INCLUDE_DIRS}
+)
 target_link_libraries(test_fastpath_thread_exit
     PRIVATE Threads::Threads ${DL_LIBRARY})
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/test/detach_runtime/test_fastpath_thread_exit.c
+++ b/test/detach_runtime/test_fastpath_thread_exit.c
@@ -1,5 +1,7 @@
 #define _GNU_SOURCE
 
+#include "pthread_listener.h"
+
 #include <pthread.h>
 #include <dirent.h>
 #include <dlfcn.h>
@@ -33,10 +35,16 @@ static atomic_int threshold_holder_release;
 static atomic_int retired_active_ready;
 static atomic_int retired_active_release;
 static atomic_int detached_worker_done;
+static atomic_int detached_worker_release;
+static atomic_int detached_pending_ready;
+static int (*mark_current_thread_final_destructor)(void);
 static atomic_int aba_worker_ready;
 static atomic_int aba_worker_release;
 typedef unsigned long (*CountFunction)(size_t);
 typedef uint64_t (*DroppedFunction)(void);
+
+typedef void (*ReclamationDiagnosticsFunction)(
+    PeakPthreadReclamationDiagnostics*);
 
 static int
 checkpoint_name_matches(const char* name, long pid)
@@ -60,7 +68,6 @@ checkpoint_name_matches(const char* name, long pid)
 }
 typedef void (*MarkNextHelperFunction)(void);
 typedef int (*StaleGenerationRemoveFunction)(pthread_t);
-typedef int (*RemoveAmbiguousMappingFunction)(pthread_t);
 
 __attribute__((noinline, used, externally_visible, visibility("default")))
 PEAK_TEST_TARGET_NOIPA
@@ -238,9 +245,25 @@ reused_active_five_worker(void* arg)
 static void*
 detached_worker(void* arg)
 {
-    (void)arg;
+    intptr_t mode = (intptr_t)arg;
+
+    (void)pthread_setspecific(user_destructor_key, (void*)1);
     (void)peak_fastpath_thread_exit_target(0);
     atomic_store_explicit(&detached_worker_done, 1, memory_order_release);
+    if (mode == 2) {
+        if (mark_current_thread_final_destructor == NULL ||
+            !mark_current_thread_final_destructor()) {
+            atomic_store_explicit(&destructor_tracking_failed, 1,
+                                  memory_order_release);
+        }
+        atomic_store_explicit(&detached_pending_ready, 1,
+                              memory_order_release);
+    }
+    while (mode != 0 &&
+           !atomic_load_explicit(&detached_worker_release,
+                                 memory_order_acquire)) {
+        sched_yield();
+    }
     return NULL;
 }
 
@@ -253,39 +276,245 @@ one_call_worker(void* arg)
 }
 
 static int
-run_detached_quarantine_regression(CountFunction call_count,
-                                   DroppedFunction dropped_calls,
-                                   DroppedFunction dropped_threads,
-                                   RemoveAmbiguousMappingFunction remove_ambiguous)
+wait_for_detached_reclamation(ReclamationDiagnosticsFunction get_diagnostics,
+                              uint64_t expected_reclaimed)
 {
-    pthread_t detached;
-    pthread_t later;
+    for (unsigned int attempt = 0; attempt < 500; attempt++) {
+        PeakPthreadReclamationDiagnostics diagnostics;
 
-    atomic_store_explicit(&detached_worker_done, 0, memory_order_relaxed);
-    if (pthread_create(&detached, NULL, detached_worker, NULL) != 0 ||
-        pthread_detach(detached) != 0) {
-        fputs("detached worker setup failed\n", stderr);
+        get_diagnostics(&diagnostics);
+        if (diagnostics.reclaimed >= expected_reclaimed) {
+            return 0;
+        }
+        usleep(10000);
+    }
+    return 1;
+}
+
+static int
+wait_for_alive_detached_deferral(
+    ReclamationDiagnosticsFunction get_diagnostics,
+    uint64_t initial_deferred_alive,
+    uint64_t expected_reclaimed)
+{
+    for (unsigned int attempt = 0; attempt < 500; attempt++) {
+        PeakPthreadReclamationDiagnostics diagnostics;
+
+        get_diagnostics(&diagnostics);
+        if (diagnostics.deferred_alive > initial_deferred_alive) {
+            if (diagnostics.reclaimed == expected_reclaimed &&
+                diagnostics.pending == 1) {
+                return 0;
+            }
+            fprintf(stderr,
+                    "live deferral mismatch: deferred=%llu reclaimed=%llu "
+                    "pending=%lu\n",
+                    (unsigned long long)diagnostics.deferred_alive,
+                    (unsigned long long)diagnostics.reclaimed,
+                    (unsigned long)diagnostics.pending);
+            return 1;
+        }
+        usleep(10000);
+    }
+    PeakPthreadReclamationDiagnostics diagnostics;
+    get_diagnostics(&diagnostics);
+    fprintf(stderr,
+            "live deferral timeout: scans=%llu candidates=%llu deferred=%llu "
+            "reclaimed=%llu pending=%lu\n",
+            (unsigned long long)diagnostics.scans,
+            (unsigned long long)diagnostics.candidates_checked,
+            (unsigned long long)diagnostics.deferred_alive,
+            (unsigned long long)diagnostics.reclaimed,
+            (unsigned long)diagnostics.pending);
+    return 1;
+}
+
+static int
+run_detached_reclamation_regression(
+    CountFunction call_count,
+    DroppedFunction dropped_calls,
+    DroppedFunction dropped_threads,
+    ReclamationDiagnosticsFunction get_diagnostics)
+{
+#if defined(__linux__)
+    enum { DETACHED_ITERATIONS = 12 };
+    uint64_t expected_reclaimed = 0;
+    PeakPthreadReclamationDiagnostics initial_diagnostics;
+
+    if (get_diagnostics == NULL ||
+        mark_current_thread_final_destructor == NULL) {
+        fputs("missing detached reclamation test hooks\n", stderr);
         return 1;
     }
-    while (!atomic_load_explicit(&detached_worker_done, memory_order_acquire)) {
+    get_diagnostics(&initial_diagnostics);
+
+    for (int iteration = 0; iteration < DETACHED_ITERATIONS; iteration++) {
+        pthread_t detached;
+        pthread_attr_t attr;
+        pthread_attr_t* attr_pointer = NULL;
+        int destructor_count_before = atomic_load_explicit(
+            &user_destructor_calls, memory_order_relaxed);
+
+        atomic_store_explicit(&detached_worker_done, 0, memory_order_relaxed);
+        atomic_store_explicit(&detached_worker_release, 0,
+                              memory_order_relaxed);
+        atomic_store_explicit(&detached_pending_ready, 0,
+                              memory_order_relaxed);
+        if (iteration % 3 == 0) {
+            if (pthread_attr_init(&attr) != 0 ||
+                pthread_attr_setdetachstate(&attr,
+                                            PTHREAD_CREATE_DETACHED) != 0) {
+                fputs("detached worker attribute setup failed\n", stderr);
+                return 1;
+            }
+            attr_pointer = &attr;
+        }
+        void* worker_argument = iteration == 0 ? (void*)2 :
+                                iteration == 1 ? (void*)1 : NULL;
+        if (pthread_create(&detached, attr_pointer, detached_worker,
+                           worker_argument) != 0) {
+            if (attr_pointer != NULL) {
+                (void)pthread_attr_destroy(&attr);
+            }
+            fputs("detached worker create failed\n", stderr);
+            return 1;
+        }
+        if (attr_pointer != NULL) {
+            (void)pthread_attr_destroy(&attr);
+        } else if (iteration % 3 == 1) {
+            if (iteration == 1) {
+                while (!atomic_load_explicit(&detached_worker_done,
+                                             memory_order_acquire)) {
+                    sched_yield();
+                }
+            }
+            if (pthread_detach(detached) != 0) {
+                fputs("running worker detach failed\n", stderr);
+                return 1;
+            }
+            if (iteration == 1) {
+                void* unexpected_result = NULL;
+                if (pthread_join(detached, &unexpected_result) == 0) {
+                    fputs("detached worker unexpectedly joined\n", stderr);
+                    return 1;
+                }
+                if (pthread_detach(detached) == 0) {
+                    fputs("failed detach changed detached state\n", stderr);
+                    return 1;
+                }
+            }
+            atomic_store_explicit(&detached_worker_release, 1,
+                                  memory_order_release);
+        }
+        while (!atomic_load_explicit(&detached_worker_done,
+                                     memory_order_acquire)) {
+            sched_yield();
+        }
+        if (iteration == 0) {
+            while (!atomic_load_explicit(&detached_pending_ready,
+                                         memory_order_acquire)) {
+                sched_yield();
+            }
+            if (wait_for_alive_detached_deferral(
+                    get_diagnostics, initial_diagnostics.deferred_alive,
+                    expected_reclaimed) != 0) {
+                fputs("live detached destructor slot was reclaimed\n", stderr);
+                return 1;
+            }
+            atomic_store_explicit(&detached_worker_release, 1,
+                                  memory_order_release);
+        }
+        if (iteration % 3 == 2) {
+            /* Exercise a successful detach after all four adversarial
+             * application TLS destructor passes have completed. */
+            while (atomic_load_explicit(&user_destructor_calls,
+                                        memory_order_acquire) <
+                   destructor_count_before + 4) {
+                sched_yield();
+            }
+            if (pthread_detach(detached) != 0) {
+                fputs("late detached worker detach failed\n", stderr);
+                return 1;
+            }
+        }
+        expected_reclaimed++;
+        if (wait_for_detached_reclamation(get_diagnostics,
+                                          expected_reclaimed) != 0) {
+            fputs("detached worker slot was not reclaimed\n", stderr);
+            return 1;
+        }
+    }
+
+    /* Cancellation runs all PEAK cleanup/destructor paths but has no join
+     * handoff once detach succeeds. It must reach the same conservative path. */
+    atomic_store_explicit(&cancel_target_entered, 0, memory_order_relaxed);
+    pthread_t canceled;
+    if (pthread_create(&canceled, NULL, cancel_worker, NULL) != 0) {
+        fputs("detached cancel worker create failed\n", stderr);
+        return 1;
+    }
+    while (!atomic_load_explicit(&cancel_target_entered,
+                                 memory_order_acquire)) {
         sched_yield();
     }
-    /* A detached thread has no join handoff. Its completed slot must remain
-     * quarantined, so the later user thread is explicitly dropped rather than
-     * reusing potentially live TLS-destructor state. */
-    if (!thread_is_tracked(detached) || remove_ambiguous == NULL ||
-        !remove_ambiguous(detached) || thread_is_tracked(detached)) {
-        fputs("untracked create did not clear ambiguous detached identity\n", stderr);
+    if (pthread_detach(canceled) != 0 || pthread_cancel(canceled) != 0) {
+        fputs("detached cancel worker setup failed\n", stderr);
         return 1;
     }
-    if (pthread_create(&later, NULL, one_call_worker, NULL) != 0 ||
-        pthread_join(later, NULL) != 0 || thread_is_tracked(later) ||
-        call_count(0) != 2 || dropped_calls() != 1 || dropped_threads() != 1) {
-        fputs("detached thread slot was reused or silently excluded\n", stderr);
+    expected_reclaimed++;
+    if (wait_for_detached_reclamation(get_diagnostics,
+                                      expected_reclaimed) != 0) {
+        fputs("canceled detached worker slot was not reclaimed\n", stderr);
+        return 1;
+    }
+
+    /* The successful-join fast path remains available after repeated reuse of
+     * the single non-main profiling slot. */
+    pthread_t joined;
+    if (pthread_create(&joined, NULL, one_call_worker, NULL) != 0 ||
+        pthread_join(joined, NULL) != 0 || thread_is_tracked(joined)) {
+        fputs("joined worker fast path regressed after detached reuse\n",
+              stderr);
+        return 1;
+    }
+
+    PeakPthreadReclamationDiagnostics diagnostics;
+    get_diagnostics(&diagnostics);
+    if (diagnostics.reclaimed != expected_reclaimed ||
+        diagnostics.pending != 0 || diagnostics.max_pending > 1 ||
+        diagnostics.scan_budget != 64 ||
+        diagnostics.scan_interval_ms != 100 ||
+        diagnostics.entries_examined >
+            diagnostics.scans * diagnostics.scan_budget ||
+        diagnostics.retire_failures != 0 || dropped_calls() != 0 ||
+        dropped_threads() != 0 ||
+        atomic_load_explicit(&destructor_tracking_failed,
+                             memory_order_acquire) != 0 ||
+        call_count(0) < 1 + DETACHED_ITERATIONS * 5 + 1) {
+        fprintf(stderr,
+                "detached reclamation mismatch: calls=%lu dropped=%llu/%llu "
+                "scans=%llu examined=%llu reclaimed=%llu pending=%lu "
+                "max_pending=%lu failures=%llu\n",
+                call_count(0), (unsigned long long)dropped_calls(),
+                (unsigned long long)dropped_threads(),
+                (unsigned long long)diagnostics.scans,
+                (unsigned long long)diagnostics.entries_examined,
+                (unsigned long long)diagnostics.reclaimed,
+                (unsigned long)diagnostics.pending,
+                (unsigned long)diagnostics.max_pending,
+                (unsigned long long)diagnostics.retire_failures);
         return 1;
     }
     puts("fastpath_thread_exit_ok");
     return 0;
+#else
+    (void)call_count;
+    (void)dropped_calls;
+    (void)dropped_threads;
+    (void)get_diagnostics;
+    puts("fastpath_thread_exit_ok");
+    return 0;
+#endif
 }
 
 static int
@@ -529,10 +758,10 @@ main(void)
         (StaleGenerationRemoveFunction)dlsym(
             RTLD_DEFAULT,
             "pthread_listener_test_stale_generation_remove_preserves_mapping");
-    RemoveAmbiguousMappingFunction remove_ambiguous =
-        (RemoveAmbiguousMappingFunction)dlsym(
+    ReclamationDiagnosticsFunction get_reclamation_diagnostics =
+        (ReclamationDiagnosticsFunction)dlsym(
             RTLD_DEFAULT,
-            "pthread_listener_test_untracked_create_removes_ambiguous_mapping");
+            "pthread_listener_get_reclamation_diagnostics");
     typedef void (*FailPublishFunction)(unsigned int);
     FailPublishFunction fail_slot_publish = (FailPublishFunction)dlsym(
         RTLD_DEFAULT, "pthread_listener_test_fail_slot_publish");
@@ -548,6 +777,9 @@ main(void)
     release_start_publication = (void (*)(void))dlsym(
         RTLD_DEFAULT,
         "pthread_listener_test_release_start_publication");
+    mark_current_thread_final_destructor = (int (*)(void))dlsym(
+        RTLD_DEFAULT,
+        "pthread_listener_test_mark_current_thread_final_destructor");
     if (call_count == NULL || thread_count == NULL || dropped_calls == NULL ||
         dropped_threads == NULL || thread_is_tracked == NULL) {
         fputs("missing accounting test hooks\n", stderr);
@@ -574,10 +806,10 @@ main(void)
     if (getenv("PEAK_TEST_RETIRED_DETACH_THRESHOLD") != NULL) {
         return run_retired_detach_threshold_regression();
     }
-    if (getenv("PEAK_TEST_DETACHED_QUARANTINE") != NULL) {
-        return run_detached_quarantine_regression(call_count, dropped_calls,
-                                                  dropped_threads,
-                                                  remove_ambiguous);
+    if (getenv("PEAK_TEST_DETACHED_RECLAMATION") != NULL) {
+        return run_detached_reclamation_regression(
+            call_count, dropped_calls, dropped_threads,
+            get_reclamation_diagnostics);
     }
     if (getenv("PEAK_TEST_HELPER_SILENT") != NULL) {
         return run_helper_silent_regression(call_count, dropped_calls,

--- a/test/detach_runtime/test_fastpath_thread_exit.c
+++ b/test/detach_runtime/test_fastpath_thread_exit.c
@@ -38,6 +38,9 @@ static atomic_int detached_worker_done;
 static atomic_int detached_worker_release;
 static atomic_int detached_pending_ready;
 static int (*mark_current_thread_final_destructor)(void);
+static void (*join_detach_race_enable)(void);
+static unsigned int (*join_detach_race_paused)(void);
+static void (*join_detach_race_release)(void);
 static atomic_int aba_worker_ready;
 static atomic_int aba_worker_release;
 typedef unsigned long (*CountFunction)(size_t);
@@ -45,6 +48,14 @@ typedef uint64_t (*DroppedFunction)(void);
 
 typedef void (*ReclamationDiagnosticsFunction)(
     PeakPthreadReclamationDiagnostics*);
+
+typedef struct {
+    pthread_t target;
+    atomic_int target_ready;
+    atomic_int target_release;
+    int join_status;
+    int detach_status;
+} JoinDetachRace;
 
 static int
 checkpoint_name_matches(const char* name, long pid)
@@ -275,6 +286,39 @@ one_call_worker(void* arg)
     return NULL;
 }
 
+static void*
+join_detach_race_target(void* data)
+{
+    JoinDetachRace* race = data;
+
+    (void)pthread_setspecific(user_destructor_key, (void*)1);
+    (void)peak_fastpath_thread_exit_target(0);
+    atomic_store_explicit(&race->target_ready, 1, memory_order_release);
+    while (!atomic_load_explicit(&race->target_release,
+                                 memory_order_acquire)) {
+        sched_yield();
+    }
+    return NULL;
+}
+
+static void*
+join_detach_race_joiner(void* data)
+{
+    JoinDetachRace* race = data;
+
+    race->join_status = pthread_join(race->target, NULL);
+    return NULL;
+}
+
+static void*
+join_detach_race_detacher(void* data)
+{
+    JoinDetachRace* race = data;
+
+    race->detach_status = pthread_detach(race->target);
+    return NULL;
+}
+
 static int
 wait_for_detached_reclamation(ReclamationDiagnosticsFunction get_diagnostics,
                               uint64_t expected_reclaimed)
@@ -327,6 +371,130 @@ wait_for_alive_detached_deferral(
             (unsigned long long)diagnostics.reclaimed,
             (unsigned long)diagnostics.pending);
     return 1;
+}
+
+static int
+run_join_detach_race_regression(
+    CountFunction call_count,
+    DroppedFunction dropped_calls,
+    DroppedFunction dropped_threads,
+    ReclamationDiagnosticsFunction get_diagnostics)
+{
+#if defined(__linux__)
+    enum { RACE_ROUNDS = 16 };
+    PeakPthreadReclamationDiagnostics diagnostics;
+
+    if (join_detach_race_enable == NULL || join_detach_race_paused == NULL ||
+        join_detach_race_release == NULL || get_diagnostics == NULL) {
+        fputs("missing join/detach race test hooks\n", stderr);
+        return 1;
+    }
+    get_diagnostics(&diagnostics);
+    uint64_t expected_reclaimed = diagnostics.reclaimed;
+
+    for (int round = 0; round < RACE_ROUNDS; round++) {
+        JoinDetachRace race = {
+            .join_status = -1,
+            .detach_status = -1,
+        };
+        pthread_t joiner;
+        pthread_t detacher;
+
+        atomic_init(&race.target_ready, 0);
+        atomic_init(&race.target_release, 0);
+        if (pthread_create(&race.target, NULL, join_detach_race_target,
+                           &race) != 0) {
+            fputs("join/detach race target create failed\n", stderr);
+            return 1;
+        }
+        while (!atomic_load_explicit(&race.target_ready,
+                                     memory_order_acquire)) {
+            sched_yield();
+        }
+
+        join_detach_race_enable();
+        if (pthread_create(&joiner, NULL, join_detach_race_joiner, &race) !=
+                0 ||
+            pthread_create(&detacher, NULL, join_detach_race_detacher, &race) !=
+                0) {
+            atomic_store_explicit(&race.target_release, 1,
+                                  memory_order_release);
+            join_detach_race_release();
+            fputs("join/detach race caller create failed\n", stderr);
+            return 1;
+        }
+        for (unsigned int attempt = 0;
+             attempt < 500 && join_detach_race_paused() != 2; attempt++) {
+            usleep(10000);
+        }
+        if (join_detach_race_paused() != 2) {
+            atomic_store_explicit(&race.target_release, 1,
+                                  memory_order_release);
+            join_detach_race_release();
+            (void)pthread_join(joiner, NULL);
+            (void)pthread_join(detacher, NULL);
+            fputs("join/detach callers did not capture one generation\n",
+                  stderr);
+            return 1;
+        }
+
+        atomic_store_explicit(&race.target_release, 1, memory_order_release);
+        join_detach_race_release();
+        if (pthread_join(joiner, NULL) != 0 ||
+            pthread_join(detacher, NULL) != 0) {
+            fputs("join/detach race caller cleanup failed\n", stderr);
+            return 1;
+        }
+        if (race.join_status != 0 && race.detach_status != 0) {
+            fprintf(stderr,
+                    "join/detach race had no native winner: join=%d detach=%d\n",
+                    race.join_status, race.detach_status);
+            return 1;
+        }
+        if (race.join_status != 0) {
+            expected_reclaimed++;
+            if (wait_for_detached_reclamation(get_diagnostics,
+                                              expected_reclaimed) != 0) {
+                fputs("join/detach race detached winner was not reclaimed\n",
+                      stderr);
+                return 1;
+            }
+        }
+
+        unsigned long expected_calls = 1UL + (unsigned long)(round + 1) * 5UL;
+        int expected_destructors = (round + 1) * 4;
+        if (call_count(0) != expected_calls || dropped_calls() != 0 ||
+            dropped_threads() != 0 ||
+            atomic_load_explicit(&user_destructor_calls,
+                                 memory_order_relaxed) !=
+                expected_destructors) {
+            fprintf(stderr,
+                    "join/detach race accounting mismatch at round %d: "
+                    "calls=%lu expected=%lu dropped=%llu/%llu destructors=%d\n",
+                    round, call_count(0), expected_calls,
+                    (unsigned long long)dropped_calls(),
+                    (unsigned long long)dropped_threads(),
+                    atomic_load_explicit(&user_destructor_calls,
+                                         memory_order_relaxed));
+            return 1;
+        }
+    }
+
+    get_diagnostics(&diagnostics);
+    if (diagnostics.pending != 0 || diagnostics.retire_failures != 0) {
+        fputs("join/detach race left retirement state pending\n", stderr);
+        return 1;
+    }
+    puts("fastpath_thread_exit_ok");
+    return 0;
+#else
+    (void)call_count;
+    (void)dropped_calls;
+    (void)dropped_threads;
+    (void)get_diagnostics;
+    puts("fastpath_thread_exit_ok");
+    return 0;
+#endif
 }
 
 static int
@@ -444,6 +612,21 @@ run_detached_reclamation_regression(
             return 1;
         }
     }
+    unsigned long expected_detached_calls =
+        1UL + DETACHED_ITERATIONS * 5UL;
+    if (call_count(0) != expected_detached_calls ||
+        atomic_load_explicit(&user_destructor_calls,
+                             memory_order_relaxed) !=
+            DETACHED_ITERATIONS * 4) {
+        fprintf(stderr,
+                "detached exact-once mismatch: calls=%lu expected=%lu "
+                "destructors=%d expected_destructors=%d\n",
+                call_count(0), expected_detached_calls,
+                atomic_load_explicit(&user_destructor_calls,
+                                     memory_order_relaxed),
+                DETACHED_ITERATIONS * 4);
+        return 1;
+    }
 
     /* Cancellation runs all PEAK cleanup/destructor paths but has no join
      * handoff once detach succeeds. It must reach the same conservative path. */
@@ -467,6 +650,7 @@ run_detached_reclamation_regression(
         fputs("canceled detached worker slot was not reclaimed\n", stderr);
         return 1;
     }
+    unsigned long calls_after_cancellation = call_count(0);
 
     /* The successful-join fast path remains available after repeated reuse of
      * the single non-main profiling slot. */
@@ -490,7 +674,7 @@ run_detached_reclamation_regression(
         dropped_threads() != 0 ||
         atomic_load_explicit(&destructor_tracking_failed,
                              memory_order_acquire) != 0 ||
-        call_count(0) < 1 + DETACHED_ITERATIONS * 5 + 1) {
+        call_count(0) != calls_after_cancellation + 1) {
         fprintf(stderr,
                 "detached reclamation mismatch: calls=%lu dropped=%llu/%llu "
                 "scans=%llu examined=%llu reclaimed=%llu pending=%lu "
@@ -780,6 +964,12 @@ main(void)
     mark_current_thread_final_destructor = (int (*)(void))dlsym(
         RTLD_DEFAULT,
         "pthread_listener_test_mark_current_thread_final_destructor");
+    join_detach_race_enable = (void (*)(void))dlsym(
+        RTLD_DEFAULT, "pthread_listener_test_join_detach_race_enable");
+    join_detach_race_paused = (unsigned int (*)(void))dlsym(
+        RTLD_DEFAULT, "pthread_listener_test_join_detach_race_paused");
+    join_detach_race_release = (void (*)(void))dlsym(
+        RTLD_DEFAULT, "pthread_listener_test_join_detach_race_release");
     if (call_count == NULL || thread_count == NULL || dropped_calls == NULL ||
         dropped_threads == NULL || thread_is_tracked == NULL) {
         fputs("missing accounting test hooks\n", stderr);
@@ -808,6 +998,11 @@ main(void)
     }
     if (getenv("PEAK_TEST_DETACHED_RECLAMATION") != NULL) {
         return run_detached_reclamation_regression(
+            call_count, dropped_calls, dropped_threads,
+            get_reclamation_diagnostics);
+    }
+    if (getenv("PEAK_TEST_PTHREAD_JOIN_DETACH_RACE") != NULL) {
+        return run_join_detach_race_regression(
             call_count, dropped_calls, dropped_threads,
             get_reclamation_diagnostics);
     }

--- a/test/detach_runtime/test_pthread_slot_registry.c
+++ b/test/detach_runtime/test_pthread_slot_registry.c
@@ -280,6 +280,140 @@ run_lifecycle_checks(void)
     return 0;
 }
 
+static int
+run_detached_reclamation_checks(void)
+{
+    PeakPthreadSlotToken late_detach_token;
+    PeakPthreadSlotToken detached_at_create_token;
+    PeakPthreadSlotToken reused_token;
+    PeakPthreadDetachedCandidate candidate;
+    pthread_t holder_threads[3];
+    KeyHolder holders[3] = {0};
+    bool became_exit_pending = false;
+    size_t entries_examined = 0;
+    size_t max_pending = 0;
+
+    for (int holder = 0; holder < 3; holder++) {
+        CHECK(pthread_create(&holder_threads[holder], NULL, key_holder,
+                             &holders[holder]) == 0);
+        CHECK(peak_pthread_slot_registry_wait_ready(
+                  &holders[holder].ready, HANDSHAKE_TIMEOUT_MS) ==
+              PEAK_PTHREAD_START_READY);
+    }
+
+    /* A thread that exits before pthread_detach remains quarantined until the
+     * successful late detach publishes the missing half of EXIT_PENDING. */
+    CHECK(peak_pthread_slot_registry_reserve_insert(
+        &registry, holder_threads[0], &late_detach_token));
+    CHECK(peak_pthread_slot_registry_mark_kernel_tid(
+        &registry, late_detach_token, 1001));
+    CHECK(peak_pthread_slot_registry_mark_final_destructor(
+        &registry, late_detach_token, &became_exit_pending));
+    CHECK(!became_exit_pending);
+    CHECK(peak_pthread_slot_registry_exit_pending_count(
+              &registry, &max_pending) == 0);
+    CHECK(!peak_pthread_slot_registry_mark_detached(
+        &registry, holder_threads[0], late_detach_token.generation + 1,
+        &became_exit_pending));
+    CHECK(!became_exit_pending);
+    CHECK(peak_pthread_slot_registry_mark_detached(
+        &registry, holder_threads[0], late_detach_token.generation,
+        &became_exit_pending));
+    CHECK(became_exit_pending);
+    CHECK(peak_pthread_slot_registry_exit_pending_count(
+              &registry, &max_pending) == 1);
+    CHECK(max_pending == 1);
+    CHECK(peak_pthread_slot_registry_snapshot_exit_pending(
+              &registry, &candidate, 1, &entries_examined) == 1);
+    CHECK(entries_examined == 1);
+    CHECK(candidate.token.slot == late_detach_token.slot);
+    CHECK(candidate.token.generation == late_detach_token.generation);
+    CHECK(candidate.kernel_tid == 1001);
+    PeakPthreadDetachedCandidate stale_candidate = candidate;
+
+    /* Retirement owns one generation before its physical slot is cleared.
+     * Capture/snapshot cannot hand the same generation to a competing join or
+     * controller pass, and a failed retire can restore pending eligibility. */
+    CHECK(peak_pthread_slot_registry_begin_retire(
+        &registry, late_detach_token));
+    CHECK(!peak_pthread_slot_registry_capture(
+        &registry, holder_threads[0], &reused_token));
+    CHECK(!peak_pthread_slot_registry_begin_retire(
+        &registry, late_detach_token));
+    CHECK(peak_pthread_slot_registry_snapshot_exit_pending(
+              &registry, &candidate, 4, &entries_examined) == 0);
+    CHECK(entries_examined == 4);
+    CHECK(peak_pthread_slot_registry_defer_retire(
+        &registry, late_detach_token));
+    CHECK(peak_pthread_slot_registry_capture(
+        &registry, holder_threads[0], &reused_token));
+    CHECK(reused_token.generation == late_detach_token.generation);
+    CHECK(peak_pthread_slot_registry_begin_retire(
+        &registry, late_detach_token));
+
+    /* A stale /proc candidate must not remove a replacement generation even
+     * when the physical slot and pthread_t are reused. */
+    CHECK(peak_pthread_slot_registry_complete_retire(
+        &registry, late_detach_token, true));
+    CHECK(peak_pthread_slot_registry_exit_pending_count(
+              &registry, NULL) == 0);
+    CHECK(peak_pthread_slot_registry_reserve_insert(
+        &registry, holder_threads[1], &reused_token));
+    CHECK(reused_token.slot == late_detach_token.slot);
+    CHECK(reused_token.generation != late_detach_token.generation);
+    CHECK(!peak_pthread_slot_registry_compare_remove_token(
+        &registry, stale_candidate.token, true));
+    CHECK(peak_pthread_slot_registry_contains(&registry, holder_threads[1]));
+    CHECK(peak_pthread_slot_registry_compare_remove_token(
+        &registry, reused_token, true));
+
+    /* Create-time detached state is recorded before the child's kernel TID
+     * and final destructor pass arrive. Only the complete triple is eligible. */
+    CHECK(peak_pthread_slot_registry_reserve_insert(
+        &registry, holder_threads[2], &detached_at_create_token));
+    CHECK(peak_pthread_slot_registry_mark_detached(
+        &registry, holder_threads[2], detached_at_create_token.generation,
+        &became_exit_pending));
+    CHECK(!became_exit_pending);
+    CHECK(peak_pthread_slot_registry_mark_kernel_tid(
+        &registry, detached_at_create_token, 1002));
+    CHECK(peak_pthread_slot_registry_exit_pending_count(
+              &registry, NULL) == 0);
+    CHECK(peak_pthread_slot_registry_mark_final_destructor(
+        &registry, detached_at_create_token, &became_exit_pending));
+    CHECK(became_exit_pending);
+
+    /* Every snapshot is bounded by its caller-supplied scan budget and the
+     * round-robin cursor eventually reaches the pending entry. */
+    bool found = false;
+    for (size_t scan = 0; scan < 4; scan++) {
+        size_t count = peak_pthread_slot_registry_snapshot_exit_pending(
+            &registry, &candidate, 1, &entries_examined);
+        CHECK(entries_examined == 1);
+        CHECK(count <= 1);
+        if (count == 1) {
+            CHECK(candidate.token.slot == detached_at_create_token.slot);
+            CHECK(candidate.token.generation ==
+                  detached_at_create_token.generation);
+            CHECK(candidate.kernel_tid == 1002);
+            found = true;
+            break;
+        }
+    }
+    CHECK(found);
+    CHECK(peak_pthread_slot_registry_compare_remove_token(
+        &registry, detached_at_create_token, false));
+    CHECK(peak_pthread_slot_registry_exit_pending_count(
+              &registry, NULL) == 0);
+
+    for (int holder = 0; holder < 3; holder++) {
+        atomic_store_explicit(&holders[holder].release, 1,
+                              memory_order_release);
+        CHECK(pthread_join(holder_threads[holder], NULL) == 0);
+    }
+    return 0;
+}
+
 int
 main(void)
 {
@@ -291,6 +425,9 @@ main(void)
     peak_pthread_slot_registry_destroy(&registry);
     CHECK(peak_pthread_slot_registry_init(&registry, 4));
     CHECK(run_lifecycle_checks() == 0);
+    peak_pthread_slot_registry_destroy(&registry);
+    CHECK(peak_pthread_slot_registry_init(&registry, 4));
+    CHECK(run_detached_reclamation_checks() == 0);
     peak_pthread_slot_registry_destroy(&registry);
     puts("pthread_slot_registry_ok");
     return 0;

--- a/test/static_checks/check_gum_mutation_allowlist.py
+++ b/test/static_checks/check_gum_mutation_allowlist.py
@@ -62,14 +62,14 @@ EXPECTED = {
         "attach": 1,
         "begin_transaction": 1,
         "end_transaction": 1,
-        "replace_fast": 1,
+        "replace_fast": 2,
     },
     ("support-shutdown-debt", "src/pthread_listener.c"): {
         "begin_transaction": 1,
         "detach": 1,
         "end_transaction": 1,
         "flush": 2,
-        "revert": 1,
+        "revert": 2,
     },
     ("support-init", "src/cuda_interceptor.cpp"): {
         "begin_transaction": 1,


### PR DESCRIPTION
Closes #92.

## Summary

- track create-time detach state, successful `pthread_detach()` transitions, and each reserved slot's Linux kernel TID
- preserve the multi-pass PEAK TLS destructor contract and mark detached generations `EXIT_PENDING` without retiring them there
- reclaim only from the existing controller slow path after `/proc/self/task/<tid>` is absent, with a fixed 64-entry scan budget and 100 ms minimum interval
- claim `slot + generation` before statistics retirement so join/detach races cannot clear a replacement generation
- keep ambiguous checks, TID reuse, unsupported platforms, and failed retirement safely quarantined or pending
- expose bounded-scan diagnostics and document the Linux policy

## Safety and performance

- target enter/leave callbacks are unchanged
- no callback-path lock, allocation, system call, registry traversal, or new state-machine transition was added
- `src/detach_controller.c`, attach policy, Gum mutation support, and detach/reattach FSM transition logic are unchanged
- `src/general_listener.c` only invokes one bounded reclamation pass from the controller loop and controller drain, before taking the controller lock
- successful joins still retire immediately; their generation is now claimed before the physical slot is cleared to prevent reuse races
- non-Linux builds retain conservative quarantine behavior

## Coverage

The regression suite covers:

- `PTHREAD_CREATE_DETACHED`
- detach while running and detach after all application TLS destructor passes
- a real same-generation `pthread_join()` / `pthread_detach()` race, with both callers paused after generation capture and released together
- failed detach and failed join of a detached live thread
- cancellation/nonlocal thread exit
- application TLS destructor target attribution through all destructor iterations
- live kernel-TID deferral before slot reuse
- repeated reuse with `PEAK_MAX_NUM_THREADS=2` and zero dropped calls
- exact per-generation call and destructor counts, so duplicate physical retirement cannot pass as a lower-bound success
- stale generation/TID candidate rejection and two-phase retirement ownership
- bounded round-robin scans and diagnostics
- unchanged joined-thread reclamation

## Validation

- GCC: focused lifecycle, hot-path, controller, handoff, unwind, registry, detached reclamation, and concurrent join/detach race tests passed
- Clang: detached reclamation, concurrent join/detach race, generation ABA, and registry tests passed (4/4)
- detached reclamation and concurrent join/detach race tests each passed 20 consecutive runs
- ASan/UBSan registry test passed
- `check_detach_lifecycle_invariants.py`: passed
- `check_gum_mutation_allowlist.py`: passed with the added pthread detach replacement and teardown revert explicitly classified
- `check_general_listener_hotpath.py`: passed
- `check_general_listener_layout.py`: passed

The local aggregate build also encountered a host-toolchain linker failure for an unrelated target because `/usr/lib64/libubsan.so.1.0.0` is absent. All targets touched by this PR built and passed under GCC and Clang; repository CI provides the complete matrix, including TSan.
