### PR TITLE
Bound JIT retry state and track provider generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ See [Physical detach controller](docs/physical-detach-controller.md) and
 | `PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS` | Retry lifetime for matching code that is not executable yet. Default: `1000`. |
 | `PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS` | Maximum age of a controller attach retry before it is dropped. Default: `1000`. |
 | `PEAK_JIT_PENDING_CAPACITY` | Maximum pending non-executable and attach-retry records. Default: `4096`; maximum: `65536`. |
-| `PEAK_JIT_DRAIN_RECORD_BUDGET` | Maximum records handled by one controller drain pass. Default: `1024`. |
+| `PEAK_JIT_DRAIN_RECORD_BUDGET` | Maximum records handled by one controller drain pass. Default: `1024`; a budget of one alternates metadata and pending retry work while both exist. |
 
 See [JIT profiling](docs/jit-profiling.md) for provider guarantees and code
 lifetime requirements.

--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ See [Physical detach controller](docs/physical-detach-controller.md) and
 | `PEAK_JIT_MAP_PATH` | Override the Linux `/tmp/perf-<pid>.map` path. |
 | `PEAK_JIT_TRACE_PATH` | Optional CSV path for provider events and JIT records. |
 | `PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS` | Retry lifetime for matching code that is not executable yet. Default: `1000`. |
+| `PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS` | Maximum age of a controller attach retry before it is dropped. Default: `1000`. |
+| `PEAK_JIT_PENDING_CAPACITY` | Maximum pending non-executable and attach-retry records. Default: `4096`; maximum: `65536`. |
 | `PEAK_JIT_DRAIN_RECORD_BUDGET` | Maximum records handled by one controller drain pass. Default: `1024`. |
 
 See [JIT profiling](docs/jit-profiling.md) for provider guarantees and code

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -64,9 +64,11 @@ PEAK_JIT_TRACE_PATH=/path/to/jit-trace.csv
 
 Trace rows show provider enablement and each processed perf-map record with an
 `attached`, `not-matched`, `not-executable`, `not-executable-retry`,
-`not-executable-timeout`, `partial-record`, `attach-retry`, or `attach-failed`
-result. Complete lines that exceed PEAK's bounded read buffer are skipped with
-`overlong-record`; true EOF partial rows are retained as `partial-record`.
+`not-executable-timeout`, `partial-record`, `attach-retry`, `attach-failed`,
+`generation-refreshed`, `already-pending`, `pending-queue-full`, or
+`pending-allocation-failure` result. Complete lines that exceed PEAK's bounded
+read buffer are skipped with `overlong-record`; true EOF partial rows are
+retained as `partial-record`.
 String fields are emitted as CSV fields, so names containing commas or quotes
 remain parseable. The final field is the provider generation that owned the
 event.
@@ -90,7 +92,9 @@ the corresponding retry expire on its next drain.
 Final text and CSV reports publish queue-full, non-executable-timeout,
 attach-retry-timeout, and allocation-failure counts together with the current
 generation, pending count, and pending high-water mark. MPI and socket reports
-aggregate the counters, so a fail-open drop on any rank remains visible.
+sum event counters and final pending counts, while pending high-water and
+provider generation are rank maxima. MPI skips JIT diagnostic collectives when
+no rank requested JIT; a JIT report uses one vector maximum and one vector sum.
 
 The provider also bounds each controller-thread drain pass. The default budget
 is 1024 perf-map or pending records per pass and can be adjusted with:
@@ -100,10 +104,11 @@ PEAK_JIT_DRAIN_RECORD_BUDGET=4096
 ```
 
 When pending retries and unread metadata coexist, at least half of each
-multi-record pass is reserved for unread metadata. A one-record pass always
-consumes metadata first. Once the source reaches EOF or is temporarily
-unavailable, the remaining budget services pending retries. This keeps queue
-saturation from starving later valid rows while still aging pending records.
+multi-record pass is reserved for unread metadata. A one-record pass alternates
+metadata and one pending retry while both exist. Once the source reaches EOF or
+is temporarily unavailable, the remaining budget services pending retries.
+This keeps queue saturation from starving later valid rows while preserving a
+finite retry lifetime under a sustained metadata backlog.
 Pending retries use a rotating cursor, so a persistent head record cannot
 starve later pending entries under a small budget.
 
@@ -118,8 +123,9 @@ general listener controller thread and publishes a matching symbol through a
 private controller-only attach bridge. That bridge:
 
 1. requires the current thread to be the general listener controller;
-2. matches a `PEAK_TARGET` slot and ignores same-generation duplicate rows for
-   an already attached code address;
+2. matches a `PEAK_TARGET` slot, ignores same-generation duplicate rows, and
+   reports a same-address source-generation update as metadata refresh rather
+   than a second Gum attachment;
 3. prepares the attach through the existing strict detach controller;
 4. attaches Gum to the JIT entry address;
 5. publishes `hook_address`, listener state, and demangled display name only

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -68,14 +68,29 @@ Trace rows show provider enablement and each processed perf-map record with an
 result. Complete lines that exceed PEAK's bounded read buffer are skipped with
 `overlong-record`; true EOF partial rows are retained as `partial-record`.
 String fields are emitted as CSV fields, so names containing commas or quotes
-remain parseable.
+remain parseable. The final field is the provider generation that owned the
+event.
 
 `partial-record` is the only normal result that leaves the reader offset at the
 current record, because it means the runtime is still appending that line.
 `not-executable-retry` and `attach-retry` are stored as pending retry records
-keyed by address, size, and name while the reader continues scanning later
-metadata. This prevents a stale or temporarily refused target row from hiding a
-later executable generation of the same JIT function.
+keyed by provider generation, address, size, and name while the reader continues
+scanning later metadata. This prevents a stale or temporarily refused target row
+from hiding a later executable generation of the same JIT function.
+
+Pending state is a fixed-capacity array allocated outside the attach mutation
+path. `PEAK_JIT_PENDING_CAPACITY` selects the capacity (default `4096`, hard
+maximum `65536`). Once full, PEAK drops the newest pending record but continues
+consuming the perf map, so a later executable record can still attach without
+entering the queue. `PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS` bounds controller attach
+retries (default `1000`). `PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS` independently
+bounds records whose ranges are not executable yet (default `1000`). Zero makes
+the corresponding retry expire on its next drain.
+
+Final text and CSV reports publish queue-full, non-executable-timeout,
+attach-retry-timeout, and allocation-failure counts together with the current
+generation, pending count, and pending high-water mark. MPI and socket reports
+aggregate the counters, so a fail-open drop on any rank remains visible.
 
 The provider also bounds each controller-thread drain pass. The default budget
 is 1024 perf-map or pending records per pass and can be adjusted with:
@@ -83,6 +98,12 @@ is 1024 perf-map or pending records per pass and can be adjusted with:
 ```bash
 PEAK_JIT_DRAIN_RECORD_BUDGET=4096
 ```
+
+When pending retries and unread metadata coexist, at least half of each
+multi-record pass is reserved for unread metadata. A one-record pass always
+consumes metadata first. Once the source reaches EOF or is temporarily
+unavailable, the remaining budget services pending retries. This keeps queue
+saturation from starving later valid rows while still aging pending records.
 
 When the budget is exhausted, the provider reports pending work and lets the
 controller loop process detach/reattach requests before resuming JIT metadata
@@ -95,8 +116,8 @@ general listener controller thread and publishes a matching symbol through a
 private controller-only attach bridge. That bridge:
 
 1. requires the current thread to be the general listener controller;
-2. matches a `PEAK_TARGET` slot and ignores duplicate rows for an already
-   attached code address;
+2. matches a `PEAK_TARGET` slot and ignores same-generation duplicate rows for
+   an already attached code address;
 3. prepares the attach through the existing strict detach controller;
 4. attaches Gum to the JIT entry address;
 5. publishes `hook_address`, listener state, and demangled display name only
@@ -135,8 +156,9 @@ provider failure.
 
 ## Lifetime Boundary
 
-Perf-map metadata is load-only. It does not provide a reliable unload, move, or
-generation record. PEAK therefore treats perf-map JIT attach as valid only while
+Perf-map metadata is load-only. An unload-aware perf-map backend is not
+available: the format does not provide a reliable unload or move record. PEAK
+therefore treats perf-map JIT attach as valid only while
 the JIT code mapping remains executable and alive through PEAK teardown. A row
 whose range is not executable at drain time is ignored unless it matches a
 configured target; matching non-executable rows are retried because many JITs
@@ -148,13 +170,15 @@ interface is required before PEAK can safely support long-running code-cache GC,
 unload, or move events with reattach.
 
 The provider processes the perf-map file as append-only metadata and remembers
-the last drained offset. If the file is truncated, the offset resets and PEAK
-drains from the start; if the path is replaced by a different inode, PEAK also
-resets its offset and pending retry records. During shutdown, the controller
+the last drained offset. When it observes truncation or replacement by a
+different inode, it increments the provider generation, resets the offset and
+pending retries, and treats a repeated address/name as a new metadata lifetime.
+This generation models the metadata source lifetime only; it does not claim that
+perf-map can identify individual code unloads. During shutdown, the controller
 drains until no retry is pending or the shutdown drain deadline expires so
 records emitted shortly before process exit are not missed after one transient
-retry. At the shutdown deadline, PEAK performs one final drain that treats
-matching non-executable pending rows as timed out.
+retry. At the shutdown deadline, PEAK performs one final drain that expires both
+non-executable and attach-retry pending rows.
 
 Duplicate rows for the same logical target and code address are treated as
 metadata repeats and do not create another listener. If a JIT unmaps a code
@@ -199,6 +223,11 @@ The default test suite includes:
   is skipped instead of being mistaken for an append-in-progress partial row;
 - retry coverage proving transient attach refusals do not consume perf-map
   records;
+- bounded-queue coverage proving saturation is reported without blocking a later
+  executable row, plus a full-queue shutdown bound;
+- finite attach-retry timeout and allocation-failure fail-open coverage;
+- truncation and inode-replacement coverage proving the same address/name is
+  processed under a new provider generation;
 - V8 optimized-name alias coverage for both `JS:*name` and
   `LazyCompile:*name`;
 - CSV trace coverage for V8-style names containing commas and quotes;

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -232,8 +232,9 @@ The default test suite includes:
 - bounded-queue coverage proving saturation is reported without blocking a later
   executable row, plus a full-queue shutdown bound;
 - finite attach-retry timeout and allocation-failure fail-open coverage;
-- observed truncation and inode-replacement coverage proving the same
-  address/name is processed under a new provider generation;
+- observed truncation before and during a drain, plus inode-replacement
+  coverage proving the same address/name is processed under a new provider
+  generation;
 - V8 optimized-name alias coverage for both `JS:*name` and
   `LazyCompile:*name`;
 - CSV trace coverage for V8-style names containing commas and quotes;

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -172,11 +172,13 @@ interface is required before PEAK can safely support long-running code-cache GC,
 unload, or move events with reattach.
 
 The provider processes the perf-map file as append-only metadata and remembers
-the last drained offset. It detects source reset through size regression,
-same-size metadata timestamp changes, and bounded head/tail signatures of the
-committed prefix; inode replacement is detected separately. An observed reset
+the last drained offset. An observed size regression or inode replacement
 increments the provider generation, resets the offset and pending retries, and
-treats a repeated address/name as a new metadata lifetime.
+treats a repeated address/name as a new metadata lifetime. A same-inode
+truncate-and-rewrite that completes between observations without exposing a
+smaller size is indistinguishable from an append without rescanning unbounded
+history, so it is outside this bounded perf-map contract. Runtimes requiring an
+explicit reset or unload transition need an unload-aware provider.
 This generation models the metadata source lifetime only; it does not claim that
 perf-map can identify individual code unloads. During shutdown, the controller
 drains until no retry is pending or the shutdown drain deadline expires so
@@ -230,9 +232,8 @@ The default test suite includes:
 - bounded-queue coverage proving saturation is reported without blocking a later
   executable row, plus a full-queue shutdown bound;
 - finite attach-retry timeout and allocation-failure fail-open coverage;
-- immediate same-size truncation, larger prefix replacement, and inode
-  replacement coverage proving the same address/name is processed under a new
-  provider generation;
+- observed truncation and inode-replacement coverage proving the same
+  address/name is processed under a new provider generation;
 - V8 optimized-name alias coverage for both `JS:*name` and
   `LazyCompile:*name`;
 - CSV trace coverage for V8-style names containing commas and quotes;

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -104,6 +104,8 @@ multi-record pass is reserved for unread metadata. A one-record pass always
 consumes metadata first. Once the source reaches EOF or is temporarily
 unavailable, the remaining budget services pending retries. This keeps queue
 saturation from starving later valid rows while still aging pending records.
+Pending retries use a rotating cursor, so a persistent head record cannot
+starve later pending entries under a small budget.
 
 When the budget is exhausted, the provider reports pending work and lets the
 controller loop process detach/reattach requests before resuming JIT metadata
@@ -170,9 +172,11 @@ interface is required before PEAK can safely support long-running code-cache GC,
 unload, or move events with reattach.
 
 The provider processes the perf-map file as append-only metadata and remembers
-the last drained offset. When it observes truncation or replacement by a
-different inode, it increments the provider generation, resets the offset and
-pending retries, and treats a repeated address/name as a new metadata lifetime.
+the last drained offset. It detects source reset through size regression,
+same-size metadata timestamp changes, and bounded head/tail signatures of the
+committed prefix; inode replacement is detected separately. An observed reset
+increments the provider generation, resets the offset and pending retries, and
+treats a repeated address/name as a new metadata lifetime.
 This generation models the metadata source lifetime only; it does not claim that
 perf-map can identify individual code unloads. During shutdown, the controller
 drains until no retry is pending or the shutdown drain deadline expires so
@@ -226,8 +230,9 @@ The default test suite includes:
 - bounded-queue coverage proving saturation is reported without blocking a later
   executable row, plus a full-queue shutdown bound;
 - finite attach-retry timeout and allocation-failure fail-open coverage;
-- truncation and inode-replacement coverage proving the same address/name is
-  processed under a new provider generation;
+- immediate same-size truncation, larger prefix replacement, and inode
+  replacement coverage proving the same address/name is processed under a new
+  provider generation;
 - V8 optimized-name alias coverage for both `JS:*name` and
   `LazyCompile:*name`;
 - CSV trace coverage for V8-style names containing commas and quotes;

--- a/docs/jit-profiling.md
+++ b/docs/jit-profiling.md
@@ -180,7 +180,10 @@ unload, or move events with reattach.
 The provider processes the perf-map file as append-only metadata and remembers
 the last drained offset. An observed size regression or inode replacement
 increments the provider generation, resets the offset and pending retries, and
-treats a repeated address/name as a new metadata lifetime. A same-inode
+treats a repeated address/name as a new metadata lifetime. The source check is
+repeated against the current pathname before post-read retries;
+an observed reset schedules another drain so rewritten metadata is not lost at
+shutdown. A same-inode
 truncate-and-rewrite that completes between observations without exposing a
 smaller size is indistinguishable from an append without rescanning unbounded
 history, so it is outside this bounded perf-map contract. Runtimes requiring an

--- a/include/internal/general_listener/report_snapshot.h
+++ b/include/internal/general_listener/report_snapshot.h
@@ -7,6 +7,7 @@
  */
 
 #include "internal/general_listener/report_model.h"
+#include "internal/jit_provider_diagnostics.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -150,6 +151,7 @@ typedef struct {
     /** Non-critical profiler facilities disabled without mutating user code. */
     uint32_t degraded_mask;
     PeakProfilerCapabilityManifest capabilities;
+    PeakJitProviderDiagnostics jit;
     double overhead_per_call;
     int rank_count;
     PeakReportOverhead overhead;

--- a/include/internal/general_listener_internal.h
+++ b/include/internal/general_listener_internal.h
@@ -12,7 +12,8 @@ typedef enum {
     PEAK_DYNAMIC_ATTACH_ATTACHED = 0,
     PEAK_DYNAMIC_ATTACH_NO_MATCH,
     PEAK_DYNAMIC_ATTACH_RETRY,
-    PEAK_DYNAMIC_ATTACH_FAILED
+    PEAK_DYNAMIC_ATTACH_FAILED,
+    PEAK_DYNAMIC_ATTACH_GENERATION_REFRESHED
 } PeakDynamicAttachResult;
 
 PeakDynamicAttachResult peak_general_listener_dynamic_attach_symbol(

--- a/include/internal/general_listener_internal.h
+++ b/include/internal/general_listener_internal.h
@@ -19,7 +19,8 @@ PeakDynamicAttachResult peak_general_listener_dynamic_attach_symbol(
     const char* symbol_name,
     gpointer symbol_address,
     gsize symbol_size,
-    const char* provider_name);
+    const char* provider_name,
+    uint64_t provider_generation);
 
 gboolean peak_general_listener_dynamic_symbol_matches_any_target(
     const char* symbol_name,

--- a/include/internal/jit_provider.h
+++ b/include/internal/jit_provider.h
@@ -23,6 +23,7 @@
  */
 
 #include "frida-gum.h"
+#include "internal/jit_provider_diagnostics.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,6 +51,9 @@ gboolean peak_jit_provider_requested(void);
 /** Returns whether a supported JIT provider is currently active. */
 gboolean peak_jit_provider_is_active(void);
 
+/** Copies the process-local bounded-state and drop diagnostics. */
+void peak_jit_provider_get_diagnostics(PeakJitProviderDiagnostics* diagnostics);
+
 /**
  * @brief Stops ingestion and releases module-owned provider state.
  *
@@ -71,8 +75,8 @@ void peak_jit_provider_disable(void);
  * share the limit from `PEAK_JIT_DRAIN_RECORD_BUDGET` (default 1024 records;
  * zero also selects the default).  Incomplete lines remain uncommitted for a
  * later drain.  Non-executable matching symbols remain pending until their
- * millisecond timeout, while retryable attach results remain pending without
- * that timeout.
+ * configured millisecond timeout; retryable attach results have an independent
+ * configured age limit.
  *
  * @retval TRUE More work remains because of a retry, an incomplete record, or
  *              budget exhaustion.
@@ -81,12 +85,11 @@ void peak_jit_provider_disable(void);
 gboolean peak_jit_provider_drain_pending(void);
 
 /**
- * @brief Drains while immediately expiring non-executable pending symbols.
+ * @brief Drains after immediately expiring all existing pending symbols.
  *
- * This mode drops matching symbols whose ranges are still non-executable
- * instead of waiting for `PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS`.  It may still
- * return true for retryable attach results, incomplete input, or budget
- * exhaustion.
+ * This shutdown mode drops existing non-executable and attach-retry records
+ * instead of waiting for their normal age limits. It may still return true for
+ * incomplete input or budget exhaustion.
  *
  * @retval TRUE Work remains for a reason not eliminated by forced timeout.
  * @retval FALSE The provider is disabled or no known work remains.

--- a/include/internal/jit_provider_diagnostics.h
+++ b/include/internal/jit_provider_diagnostics.h
@@ -1,0 +1,16 @@
+#ifndef PEAK_JIT_PROVIDER_DIAGNOSTICS_H
+#define PEAK_JIT_PROVIDER_DIAGNOSTICS_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint64_t pending_queue_full;
+    uint64_t non_executable_timeout;
+    uint64_t attach_retry_timeout;
+    uint64_t allocation_failure;
+    uint64_t provider_generation;
+    uint64_t pending_count;
+    uint64_t pending_high_water;
+} PeakJitProviderDiagnostics;
+
+#endif /* PEAK_JIT_PROVIDER_DIAGNOSTICS_H */

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -3079,7 +3079,7 @@ peak_general_listener_dynamic_attach_symbol(const char* symbol_name,
             peak_hook_provider_generation != NULL &&
             peak_hook_provider_generation[i] != provider_generation) {
             peak_hook_provider_generation[i] = provider_generation;
-            result = PEAK_DYNAMIC_ATTACH_ATTACHED;
+            result = PEAK_DYNAMIC_ATTACH_GENERATION_REFRESHED;
             duplicate_address = TRUE;
             break;
         }

--- a/src/general_listener.c
+++ b/src/general_listener.c
@@ -170,6 +170,7 @@ extern gboolean* peak_detached;
 extern gdouble* heartbeat_overhead;
 extern unsigned int check_interval;
 PEAK_API gpointer* hook_address = NULL;
+static uint64_t* peak_hook_provider_generation = NULL;
 static double peak_general_overhead;
 extern size_t peak_hook_address_count;
 extern char** peak_hook_strings;
@@ -2971,6 +2972,8 @@ peak_general_listener_expand_dynamic_hook_tables_unlocked(
     peak_hook_last_retry_status =
         g_renew(PeakDetachStatus, peak_hook_last_retry_status, new_count);
     hook_address = g_renew(gpointer, hook_address, new_count);
+    peak_hook_provider_generation =
+        g_renew(uint64_t, peak_hook_provider_generation, new_count);
     peak_demangled_strings = g_renew(char*, peak_demangled_strings, new_count);
     peak_need_detach = g_renew(gboolean, peak_need_detach, new_count);
     peak_detached = g_renew(gboolean, peak_detached, new_count);
@@ -3005,6 +3008,7 @@ peak_general_listener_expand_dynamic_hook_tables_unlocked(
     peak_hook_retry_count[old_count] = 0;
     peak_hook_last_retry_status[old_count] = PEAK_DETACH_STATUS_SAFE;
     hook_address[old_count] = NULL;
+    peak_hook_provider_generation[old_count] = 0;
     peak_demangled_strings[old_count] = NULL;
     peak_need_detach[old_count] = FALSE;
     peak_detached[old_count] = FALSE;
@@ -3023,7 +3027,8 @@ PeakDynamicAttachResult
 peak_general_listener_dynamic_attach_symbol(const char* symbol_name,
                                             gpointer symbol_address,
                                             gsize symbol_size,
-                                            const char* provider_name)
+                                            const char* provider_name,
+                                            uint64_t provider_generation)
 {
     (void)symbol_size;
 
@@ -3067,6 +3072,16 @@ peak_general_listener_dynamic_attach_symbol(const char* symbol_name,
         matched_target = TRUE;
         if (target_for_new_generation == NULL) {
             target_for_new_generation = peak_hook_strings[i];
+        }
+
+        if (hook_address[i] == symbol_address &&
+            peak_general_listener_provider_is_perfmap(provider_name) &&
+            peak_hook_provider_generation != NULL &&
+            peak_hook_provider_generation[i] != provider_generation) {
+            peak_hook_provider_generation[i] = provider_generation;
+            result = PEAK_DYNAMIC_ATTACH_ATTACHED;
+            duplicate_address = TRUE;
+            break;
         }
 
         if (hook_address[i] == symbol_address) {
@@ -3175,6 +3190,9 @@ peak_general_listener_dynamic_attach_symbol(const char* symbol_name,
 
         if (attach_status == GUM_ATTACH_OK) {
             hook_address[i] = symbol_address;
+            if (peak_hook_provider_generation != NULL) {
+                peak_hook_provider_generation[i] = provider_generation;
+            }
             g_free(peak_demangled_strings[i]);
             peak_demangled_strings[i] = g_strdup(peak_hook_strings[i]);
             array_listener[i] = new_listener;
@@ -7180,6 +7198,8 @@ peak_general_listener_attach()
     peak_hook_last_retry_status = g_new0(PeakDetachStatus, peak_hook_address_count);
 
     hook_address = g_new0(gpointer, peak_hook_address_count);
+    peak_hook_provider_generation =
+        g_new0(uint64_t, peak_hook_address_count);
     peak_demangled_strings = g_new0(char*, peak_hook_address_count);
     /*
      * Freeze the threshold before any target hook becomes executable.  The
@@ -8042,6 +8062,7 @@ peak_general_listener_build_report_snapshot(
         &peak_general_listener_dropped_calls, memory_order_relaxed);
     snapshot->dropped_threads = atomic_load_explicit(
         &peak_general_listener_dropped_threads, memory_order_relaxed);
+    peak_jit_provider_get_diagnostics(&snapshot->jit);
     snapshot->rank_count = rank_count;
     if (report_overhead != NULL) {
         snapshot->overhead = *report_overhead;
@@ -8970,6 +8991,7 @@ gboolean peak_general_listener_dettach()
     }
     g_object_unref(interceptor);
     g_free(hook_address);
+    g_free(peak_hook_provider_generation);
     g_free(array_listener_detached);
     g_free(array_listener_reattached);
     g_free(array_listener_revisited);
@@ -8997,6 +9019,7 @@ gboolean peak_general_listener_dettach()
 
     interceptor = NULL;
     hook_address = NULL;
+    peak_hook_provider_generation = NULL;
     array_listener_detached = NULL;
     array_listener_reattached = NULL;
     array_listener_revisited = NULL;

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -1028,6 +1028,10 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     uint64_t mpi_dropped_threads = 0;
     uint64_t mpi_max_dropped_calls = 0;
     uint64_t mpi_max_dropped_threads = 0;
+    uint64_t local_jit_sum[6];
+    uint64_t mpi_jit_sum[6] = {0};
+    uint64_t mpi_jit_sum_max[6] = {0};
+    uint64_t mpi_jit_generation = 0;
     int local_elapsed_valid;
     int all_elapsed_valid = 0;
     int local_accounting_valid;
@@ -1114,6 +1118,12 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
         peak_mpi_report_positive_finite(local_elapsed_seconds) ? 1 : 0;
     local_accounting_valid = local->overhead.accounting_valid ? 1 : 0;
     local_hook_count = (unsigned long)local->hook_count;
+    local_jit_sum[0] = local->jit.pending_queue_full;
+    local_jit_sum[1] = local->jit.non_executable_timeout;
+    local_jit_sum[2] = local->jit.attach_retry_timeout;
+    local_jit_sum[3] = local->jit.allocation_failure;
+    local_jit_sum[4] = local->jit.pending_count;
+    local_jit_sum[5] = local->jit.pending_high_water;
 
     if (!peak_mpi_allreduce_checked(&local_elapsed_valid,
                                     &all_elapsed_valid,
@@ -1148,6 +1158,35 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
                                     MPI_MAX,
                                     "hook-count-max")) {
         return peak_mpi_report_transport_collective_failure();
+    }
+    if (!peak_mpi_allreduce_checked(local_jit_sum,
+                                    mpi_jit_sum_max,
+                                    6,
+                                    PEAK_MPI_UINT64_DATATYPE,
+                                    MPI_MAX,
+                                    "jit-diagnostics-max") ||
+        !peak_mpi_allreduce_checked(&local->jit.provider_generation,
+                                    &mpi_jit_generation,
+                                    1,
+                                    PEAK_MPI_UINT64_DATATYPE,
+                                    MPI_MAX,
+                                    "jit-generation-max")) {
+        return peak_mpi_report_transport_collective_failure();
+    }
+    for (size_t i = 0; i < 6; i++) {
+        if (mpi_jit_sum_max[i] >
+            (UINT64_MAX - 1) / (uint64_t)size) {
+            mpi_jit_sum[i] = UINT64_MAX - 1;
+        } else if (!peak_mpi_reduce_checked(&local_jit_sum[i],
+                                            &mpi_jit_sum[i],
+                                            1,
+                                            PEAK_MPI_UINT64_DATATYPE,
+                                            MPI_SUM,
+                                            0,
+                                            rank == 0,
+                                            "jit-diagnostic-sum")) {
+            return peak_mpi_report_transport_collective_failure();
+        }
     }
 
     local_duplicate_names =
@@ -1446,6 +1485,13 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     aggregate->rank_count = size;
     aggregate->dropped_calls = mpi_dropped_calls;
     aggregate->dropped_threads = mpi_dropped_threads;
+    aggregate->jit.pending_queue_full = mpi_jit_sum[0];
+    aggregate->jit.non_executable_timeout = mpi_jit_sum[1];
+    aggregate->jit.attach_retry_timeout = mpi_jit_sum[2];
+    aggregate->jit.allocation_failure = mpi_jit_sum[3];
+    aggregate->jit.pending_count = mpi_jit_sum[4];
+    aggregate->jit.pending_high_water = mpi_jit_sum[5];
+    aggregate->jit.provider_generation = mpi_jit_generation;
     aggregate->degraded_mask = aggregate_degraded_mask;
     aggregate->capabilities.requested = aggregate_capability_any[0];
     aggregate->capabilities.compiled = aggregate_capability_all[0];

--- a/src/general_listener/mpi_report_transport.c
+++ b/src/general_listener/mpi_report_transport.c
@@ -1028,10 +1028,10 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     uint64_t mpi_dropped_threads = 0;
     uint64_t mpi_max_dropped_calls = 0;
     uint64_t mpi_max_dropped_threads = 0;
-    uint64_t local_jit_sum[6];
-    uint64_t mpi_jit_sum[6] = {0};
-    uint64_t mpi_jit_sum_max[6] = {0};
-    uint64_t mpi_jit_generation = 0;
+    uint64_t local_jit_values[7];
+    uint64_t local_jit_sum[5];
+    uint64_t mpi_jit_sum[5] = {0};
+    uint64_t mpi_jit_max[7] = {0};
     int local_elapsed_valid;
     int all_elapsed_valid = 0;
     int local_accounting_valid;
@@ -1118,12 +1118,13 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
         peak_mpi_report_positive_finite(local_elapsed_seconds) ? 1 : 0;
     local_accounting_valid = local->overhead.accounting_valid ? 1 : 0;
     local_hook_count = (unsigned long)local->hook_count;
-    local_jit_sum[0] = local->jit.pending_queue_full;
-    local_jit_sum[1] = local->jit.non_executable_timeout;
-    local_jit_sum[2] = local->jit.attach_retry_timeout;
-    local_jit_sum[3] = local->jit.allocation_failure;
-    local_jit_sum[4] = local->jit.pending_count;
-    local_jit_sum[5] = local->jit.pending_high_water;
+    local_jit_values[0] = local->jit.pending_queue_full;
+    local_jit_values[1] = local->jit.non_executable_timeout;
+    local_jit_values[2] = local->jit.attach_retry_timeout;
+    local_jit_values[3] = local->jit.allocation_failure;
+    local_jit_values[4] = local->jit.pending_count;
+    local_jit_values[5] = local->jit.pending_high_water;
+    local_jit_values[6] = local->jit.provider_generation;
 
     if (!peak_mpi_allreduce_checked(&local_elapsed_valid,
                                     &all_elapsed_valid,
@@ -1159,33 +1160,38 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
                                     "hook-count-max")) {
         return peak_mpi_report_transport_collective_failure();
     }
-    if (!peak_mpi_allreduce_checked(local_jit_sum,
-                                    mpi_jit_sum_max,
-                                    6,
-                                    PEAK_MPI_UINT64_DATATYPE,
-                                    MPI_MAX,
-                                    "jit-diagnostics-max") ||
-        !peak_mpi_allreduce_checked(&local->jit.provider_generation,
-                                    &mpi_jit_generation,
-                                    1,
-                                    PEAK_MPI_UINT64_DATATYPE,
-                                    MPI_MAX,
-                                    "jit-generation-max")) {
-        return peak_mpi_report_transport_collective_failure();
-    }
-    for (size_t i = 0; i < 6; i++) {
-        if (mpi_jit_sum_max[i] >
-            (UINT64_MAX - 1) / (uint64_t)size) {
-            mpi_jit_sum[i] = UINT64_MAX - 1;
-        } else if (!peak_mpi_reduce_checked(&local_jit_sum[i],
-                                            &mpi_jit_sum[i],
-                                            1,
-                                            PEAK_MPI_UINT64_DATATYPE,
-                                            MPI_SUM,
-                                            0,
-                                            rank == 0,
-                                            "jit-diagnostic-sum")) {
+    if ((aggregate_capability_any[0] & PEAK_CAPABILITY_JIT) != 0) {
+        if (!peak_mpi_allreduce_checked(local_jit_values,
+                                        mpi_jit_max,
+                                        7,
+                                        PEAK_MPI_UINT64_DATATYPE,
+                                        MPI_MAX,
+                                        "jit-diagnostics-max")) {
             return peak_mpi_report_transport_collective_failure();
+        }
+        for (size_t i = 0; i < 5; i++) {
+            local_jit_sum[i] =
+                mpi_jit_max[i] > (UINT64_MAX - 1) / (uint64_t)size
+                    ? 0
+                    : local_jit_values[i];
+        }
+        if (!peak_mpi_reduce_checked(local_jit_sum,
+                                     mpi_jit_sum,
+                                     5,
+                                     PEAK_MPI_UINT64_DATATYPE,
+                                     MPI_SUM,
+                                     0,
+                                     rank == 0,
+                                     "jit-diagnostics-sum")) {
+            return peak_mpi_report_transport_collective_failure();
+        }
+        if (rank == 0) {
+            for (size_t i = 0; i < 5; i++) {
+                if (mpi_jit_max[i] >
+                    (UINT64_MAX - 1) / (uint64_t)size) {
+                    mpi_jit_sum[i] = UINT64_MAX - 1;
+                }
+            }
         }
     }
 
@@ -1490,8 +1496,8 @@ peak_mpi_report_transport_reduce(PeakReportSnapshot* local,
     aggregate->jit.attach_retry_timeout = mpi_jit_sum[2];
     aggregate->jit.allocation_failure = mpi_jit_sum[3];
     aggregate->jit.pending_count = mpi_jit_sum[4];
-    aggregate->jit.pending_high_water = mpi_jit_sum[5];
-    aggregate->jit.provider_generation = mpi_jit_generation;
+    aggregate->jit.pending_high_water = mpi_jit_max[5];
+    aggregate->jit.provider_generation = mpi_jit_max[6];
     aggregate->degraded_mask = aggregate_degraded_mask;
     aggregate->capabilities.requested = aggregate_capability_any[0];
     aggregate->capabilities.compiled = aggregate_capability_all[0];

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -778,13 +778,13 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         "count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
         "dropped_calls,dropped_threads,"
-        "jit_pending_queue_full,jit_non_executable_timeout,"
-        "jit_attach_retry_timeout,jit_allocation_failure,"
-        "jit_provider_generation,jit_pending_count,jit_pending_high_water,"
         "capability_requested,capability_compiled,capability_active,"
         "capability_partial,capability_retained,capability_failed,"
         "cuda_compiled_apis,cuda_found_apis,cuda_installed_apis,"
-        "cuda_failed_apis,degraded_mask\n";
+        "cuda_failed_apis,degraded_mask,"
+        "jit_pending_queue_full,jit_non_executable_timeout,"
+        "jit_attach_retry_timeout,jit_allocation_failure,"
+        "jit_provider_generation,jit_pending_count,jit_pending_high_water\n";
     char* temp_csv;
     PeakReportCsvDestination destination = {.dirfd = -1};
     FILE* csv;
@@ -896,8 +896,9 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
                       csv, "PEAK_JIT_DIAGNOSTICS") &&
                   fprintf(
                       csv,
-                      ",0,0,0,0,0,0,0,0,0,0,0,0,%llu,%llu,%llu,%llu,%llu,%llu,%llu,"
-                      "0,0,0,0,0,0,0,0,0,0,0\n",
+                      ",0,0,0,0,0,0,0,0,0,0,0,0,"
+                      "0,0,0,0,0,0,0,0,0,0,0,"
+                      "%llu,%llu,%llu,%llu,%llu,%llu,%llu\n",
                       (unsigned long long)snapshot->jit.pending_queue_full,
                       (unsigned long long)snapshot->jit.non_executable_timeout,
                       (unsigned long long)snapshot->jit.attach_retry_timeout,
@@ -922,8 +923,8 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(csv, row_name) &&
                   fprintf(
                       csv,
-                      ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,%d,%d,%d,%d,%d,%d,"
-                      "0,0,0,0,0\n",
+                      ",0,0,0,0,0,0,0,0,0,0,0,0,%d,%d,%d,%d,%d,%d,"
+                      "0,0,0,0,0,0,0,0,0,0,0,0\n",
                       (snapshot->capabilities.requested & mask) != 0,
                       (snapshot->capabilities.compiled & mask) != 0,
                       (snapshot->capabilities.active & mask) != 0,
@@ -935,8 +936,8 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(
                       csv, "PEAK_CUDA_API_COVERAGE") &&
                   fprintf(csv,
-                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-                          "%u,%u,%u,%u,0\n",
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          "%u,%u,%u,%u,0,0,0,0,0,0,0,0\n",
                           snapshot->capabilities.cuda_compiled_apis,
                           snapshot->capabilities.cuda_found_apis,
                           snapshot->capabilities.cuda_installed_apis,
@@ -946,8 +947,8 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(
                       csv, "PEAK_DEGRADED_CAPABILITIES") &&
                   fprintf(csv,
-                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-                          "0,0,0,0,%u\n",
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          "0,0,0,0,%u,0,0,0,0,0,0,0\n",
                           snapshot->degraded_mask) >= 0;
     }
     if (!success || ferror(csv)) {

--- a/src/general_listener/report_formatter.c
+++ b/src/general_listener/report_formatter.c
@@ -778,6 +778,9 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         "count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
         "dropped_calls,dropped_threads,"
+        "jit_pending_queue_full,jit_non_executable_timeout,"
+        "jit_attach_retry_timeout,jit_allocation_failure,"
+        "jit_provider_generation,jit_pending_count,jit_pending_high_water,"
         "capability_requested,capability_compiled,capability_active,"
         "capability_partial,capability_retained,capability_failed,"
         "cuda_compiled_apis,cuda_found_apis,cuda_installed_apis,"
@@ -854,7 +857,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
                   fprintf(
                       csv,
                       ",%lu,%lu,%.12Lg,%.9e,%.9e,%.9e,%.9e,%.9e,%.9e,%.9e,"
-                      "%llu,%llu,0,0,0,0,0,0,0,0,0,0,0\n",
+                      "%llu,%llu,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n",
                       snapshot->num_calls[i],
                       peak_report_calls_per_active_thread(
                           snapshot->num_calls[i], snapshot->thread_count[i]),
@@ -876,9 +879,32 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
                       csv, "PEAK_ACCOUNTING_DIAGNOSTICS") &&
                   fprintf(csv,
                           ",0,0,0,0,0,0,0,0,0,0,%llu,%llu,"
-                          "0,0,0,0,0,0,0,0,0,0,0\n",
+                          "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n",
                           (unsigned long long)snapshot->dropped_calls,
                           (unsigned long long)snapshot->dropped_threads) >= 0;
+    }
+    if (success &&
+        ((snapshot->capabilities.requested & PEAK_CAPABILITY_JIT) != 0 ||
+         snapshot->jit.provider_generation != 0 ||
+         snapshot->jit.pending_queue_full != 0 ||
+         snapshot->jit.non_executable_timeout != 0 ||
+         snapshot->jit.attach_retry_timeout != 0 ||
+         snapshot->jit.allocation_failure != 0 ||
+         snapshot->jit.pending_count != 0 ||
+         snapshot->jit.pending_high_water != 0)) {
+        success = peak_report_formatter_write_csv_name(
+                      csv, "PEAK_JIT_DIAGNOSTICS") &&
+                  fprintf(
+                      csv,
+                      ",0,0,0,0,0,0,0,0,0,0,0,0,%llu,%llu,%llu,%llu,%llu,%llu,%llu,"
+                      "0,0,0,0,0,0,0,0,0,0,0\n",
+                      (unsigned long long)snapshot->jit.pending_queue_full,
+                      (unsigned long long)snapshot->jit.non_executable_timeout,
+                      (unsigned long long)snapshot->jit.attach_retry_timeout,
+                      (unsigned long long)snapshot->jit.allocation_failure,
+                      (unsigned long long)snapshot->jit.provider_generation,
+                      (unsigned long long)snapshot->jit.pending_count,
+                      (unsigned long long)snapshot->jit.pending_high_water) >= 0;
     }
     for (size_t capability = 0;
          success && capability < sizeof(peak_report_capability_names) /
@@ -896,7 +922,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(csv, row_name) &&
                   fprintf(
                       csv,
-                      ",0,0,0,0,0,0,0,0,0,0,0,0,%d,%d,%d,%d,%d,%d,"
+                      ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,%d,%d,%d,%d,%d,%d,"
                       "0,0,0,0,0\n",
                       (snapshot->capabilities.requested & mask) != 0,
                       (snapshot->capabilities.compiled & mask) != 0,
@@ -909,7 +935,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(
                       csv, "PEAK_CUDA_API_COVERAGE") &&
                   fprintf(csv,
-                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
                           "%u,%u,%u,%u,0\n",
                           snapshot->capabilities.cuda_compiled_apis,
                           snapshot->capabilities.cuda_found_apis,
@@ -920,7 +946,7 @@ peak_report_formatter_write_csv_scoped(const PeakReportSnapshot* snapshot,
         success = peak_report_formatter_write_csv_name(
                       csv, "PEAK_DEGRADED_CAPABILITIES") &&
                   fprintf(csv,
-                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+                          ",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
                           "0,0,0,0,%u\n",
                           snapshot->degraded_mask) >= 0;
     }
@@ -1124,6 +1150,18 @@ peak_report_formatter_write_text(
             snapshot->capabilities.cuda_found_apis,
             snapshot->capabilities.cuda_installed_apis,
             snapshot->capabilities.cuda_failed_apis);
+        if ((snapshot->capabilities.requested & PEAK_CAPABILITY_JIT) != 0 ||
+            snapshot->jit.provider_generation != 0) {
+            peak_log_report(
+                "Profiler JIT diagnostics: generation=%llu pending=%llu high_water=%llu queue_full=%llu non_executable_timeout=%llu attach_retry_timeout=%llu allocation_failure=%llu\n",
+                (unsigned long long)snapshot->jit.provider_generation,
+                (unsigned long long)snapshot->jit.pending_count,
+                (unsigned long long)snapshot->jit.pending_high_water,
+                (unsigned long long)snapshot->jit.pending_queue_full,
+                (unsigned long long)snapshot->jit.non_executable_timeout,
+                (unsigned long long)snapshot->jit.attach_retry_timeout,
+                (unsigned long long)snapshot->jit.allocation_failure);
+        }
     }
     if (snapshot->dropped_calls != 0 || snapshot->dropped_threads != 0) {
         peak_log_report("Accounting diagnostics: dropped_calls=%llu dropped_threads=%llu "

--- a/src/general_listener/report_snapshot.c
+++ b/src/general_listener/report_snapshot.c
@@ -490,6 +490,7 @@ peak_report_snapshot_clone(
     copy->dropped_threads = source->dropped_threads;
     copy->degraded_mask = source->degraded_mask;
     copy->capabilities = source->capabilities;
+    copy->jit = source->jit;
     copy->rank_count = source->rank_count;
     copy->overhead = source->overhead;
     return copy;

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -2400,9 +2400,11 @@ peak_socket_gather_prepare_receipt(
     aggregate->jit->pending_count = peak_socket_add_uint64_saturated(
         aggregate->jit->pending_count,
         connection->header.jit_pending_count);
-    aggregate->jit->pending_high_water = peak_socket_add_uint64_saturated(
-        aggregate->jit->pending_high_water,
-        connection->header.jit_pending_high_water);
+    if (connection->header.jit_pending_high_water >
+        aggregate->jit->pending_high_water) {
+        aggregate->jit->pending_high_water =
+            connection->header.jit_pending_high_water;
+    }
     if (connection->header.jit_provider_generation >
         aggregate->jit->provider_generation) {
         aggregate->jit->provider_generation =

--- a/src/general_listener/socket_report_transport.c
+++ b/src/general_listener/socket_report_transport.c
@@ -78,7 +78,7 @@
     "PEAK_TEST_OUTPUT_AGGREGATION_SESSION_ALLOC_FAIL"
 
 #define PEAK_SOCKET_REDUCE_MAGIC 0x5045414b52454431ULL
-#define PEAK_SOCKET_REDUCE_VERSION 14U
+#define PEAK_SOCKET_REDUCE_VERSION 15U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT 0x41U
 #define PEAK_SOCKET_REDUCE_GATHER_RECEIPT_CONFIRM 0x42U
 #define PEAK_SOCKET_REDUCE_GATHER_REGISTERED 0x01U
@@ -137,6 +137,13 @@ typedef struct {
     uint32_t cuda_found_apis;
     uint32_t cuda_installed_apis;
     uint32_t cuda_failed_apis;
+    uint64_t jit_pending_queue_full;
+    uint64_t jit_non_executable_timeout;
+    uint64_t jit_attach_retry_timeout;
+    uint64_t jit_allocation_failure;
+    uint64_t jit_provider_generation;
+    uint64_t jit_pending_count;
+    uint64_t jit_pending_high_water;
 } PeakSocketReduceHeader;
 
 typedef struct {
@@ -166,19 +173,19 @@ typedef struct {
 } PeakSocketReduceRecord;
 
 /*
- * Wire-v14 intentionally targets a homogeneous job: every rank must use the
+ * Wire-v15 intentionally targets a homogeneous job: every rank must use the
  * same byte order, floating-point representation, and 64-bit Linux C ABI.
  * Lock the layouts so an accidental field or packing change cannot silently
  * corrupt a report without another wire-version bump.
  */
-_Static_assert(sizeof(PeakSocketReduceHeader) == 216,
-               "wire-v14 header layout changed");
+_Static_assert(sizeof(PeakSocketReduceHeader) == 272,
+               "wire-v15 header layout changed");
 _Static_assert(sizeof(PeakSocketReduceReleaseFrame) == 40,
-               "wire-v14 control-frame layout changed");
+               "wire-v15 control-frame layout changed");
 _Static_assert(sizeof(PeakSocketReduceRecord) == 80,
-               "wire-v14 record layout changed");
+               "wire-v15 record layout changed");
 _Static_assert(sizeof(unsigned long) == sizeof(uint64_t),
-               "wire-v14 requires a 64-bit unsigned long");
+               "wire-v15 requires a 64-bit unsigned long");
 
 struct PeakSocketReportSession {
     bool* release_targets;
@@ -2315,6 +2322,7 @@ typedef struct {
     bool* accounting_valid;
     uint32_t* degraded_mask;
     PeakProfilerCapabilityManifest* capabilities;
+    PeakJitProviderDiagnostics* jit;
 } PeakSocketGatherAggregate;
 
 static bool
@@ -2348,6 +2356,7 @@ peak_socket_gather_prepare_receipt(
     if (connection == NULL || aggregate == NULL ||
         aggregate->degraded_mask == NULL ||
         aggregate->capabilities == NULL ||
+        aggregate->jit == NULL ||
         connection->record_index != aggregate->hook_count ||
         connection->record_bytes != 0 ||
         !peak_report_maxima_consider(aggregate->maxima,
@@ -2376,6 +2385,29 @@ peak_socket_gather_prepare_receipt(
         *aggregate->dropped_calls, connection->header.dropped_calls);
     *aggregate->dropped_threads = peak_socket_add_uint64_saturated(
         *aggregate->dropped_threads, connection->header.dropped_threads);
+    aggregate->jit->pending_queue_full = peak_socket_add_uint64_saturated(
+        aggregate->jit->pending_queue_full,
+        connection->header.jit_pending_queue_full);
+    aggregate->jit->non_executable_timeout = peak_socket_add_uint64_saturated(
+        aggregate->jit->non_executable_timeout,
+        connection->header.jit_non_executable_timeout);
+    aggregate->jit->attach_retry_timeout = peak_socket_add_uint64_saturated(
+        aggregate->jit->attach_retry_timeout,
+        connection->header.jit_attach_retry_timeout);
+    aggregate->jit->allocation_failure = peak_socket_add_uint64_saturated(
+        aggregate->jit->allocation_failure,
+        connection->header.jit_allocation_failure);
+    aggregate->jit->pending_count = peak_socket_add_uint64_saturated(
+        aggregate->jit->pending_count,
+        connection->header.jit_pending_count);
+    aggregate->jit->pending_high_water = peak_socket_add_uint64_saturated(
+        aggregate->jit->pending_high_water,
+        connection->header.jit_pending_high_water);
+    if (connection->header.jit_provider_generation >
+        aggregate->jit->provider_generation) {
+        aggregate->jit->provider_generation =
+            connection->header.jit_provider_generation;
+    }
     *aggregate->accounting_valid =
         *aggregate->accounting_valid && tuple->accounting_valid;
     *aggregate->degraded_mask |= connection->header.degraded_mask;
@@ -3444,6 +3476,13 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     header.cuda_found_apis = local->capabilities.cuda_found_apis;
     header.cuda_installed_apis = local->capabilities.cuda_installed_apis;
     header.cuda_failed_apis = local->capabilities.cuda_failed_apis;
+    header.jit_pending_queue_full = local->jit.pending_queue_full;
+    header.jit_non_executable_timeout = local->jit.non_executable_timeout;
+    header.jit_attach_retry_timeout = local->jit.attach_retry_timeout;
+    header.jit_allocation_failure = local->jit.allocation_failure;
+    header.jit_provider_generation = local->jit.provider_generation;
+    header.jit_pending_count = local->jit.pending_count;
+    header.jit_pending_high_water = local->jit.pending_high_water;
     peak_socket_reduce_header_set_report_tuple(&header, &local_report_tuple);
 
     if (rank != 0) {
@@ -3500,6 +3539,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     uint32_t socket_degraded_mask = local->degraded_mask;
     PeakProfilerCapabilityManifest socket_capabilities =
         local->capabilities;
+    PeakJitProviderDiagnostics socket_jit = local->jit;
     unsigned int received = 0;
     bool failed;
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -3549,6 +3589,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     gather_aggregate.accounting_valid = &socket_accounting_valid;
     gather_aggregate.degraded_mask = &socket_degraded_mask;
     gather_aggregate.capabilities = &socket_capabilities;
+    gather_aggregate.jit = &socket_jit;
 #ifdef PEAK_ENABLE_TEST_HOOKS
     {
         int listener_ready = peak_socket_test_listener_ready_signal_root();
@@ -3629,6 +3670,7 @@ peak_socket_report_transport_begin(const PeakReportSnapshot* local,
     aggregate->dropped_threads = socket_dropped_threads;
     aggregate->degraded_mask = socket_degraded_mask;
     aggregate->capabilities = socket_capabilities;
+    aggregate->jit = socket_jit;
     aggregate->rank_count = size;
     peak_socket_report_set_aggregate_overhead(
         aggregate,

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -30,7 +30,6 @@
 #define PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET 1024UL
 #define PEAK_JIT_DEFAULT_PENDING_CAPACITY 4096UL
 #define PEAK_JIT_MAX_PENDING_CAPACITY 65536UL
-#define PEAK_JIT_PREFIX_PROBE_BYTES 512U
 #ifdef PEAK_ENABLE_TEST_HOOKS
 #define PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV "PEAK_JIT_TEST_ATTACH_SEQUENCE"
 #define PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION_ENV \
@@ -62,13 +61,6 @@ static gboolean peak_jit_perfmap_identity_known = FALSE;
 static dev_t peak_jit_perfmap_dev = 0;
 static ino_t peak_jit_perfmap_ino = 0;
 static off_t peak_jit_perfmap_last_size = 0;
-static time_t peak_jit_perfmap_mtime_seconds = 0;
-static long peak_jit_perfmap_mtime_nanoseconds = 0;
-static time_t peak_jit_perfmap_ctime_seconds = 0;
-static long peak_jit_perfmap_ctime_nanoseconds = 0;
-static gboolean peak_jit_perfmap_prefix_signature_known = FALSE;
-static off_t peak_jit_perfmap_prefix_signature_length = 0;
-static uint64_t peak_jit_perfmap_prefix_signature = 0;
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static unsigned int peak_jit_test_attach_sequence_index = 0;
 static char* configured_jit_test_attach_sequence = NULL;
@@ -469,142 +461,9 @@ peak_jit_pending_records_clear(void)
 }
 
 static void
-peak_jit_stat_timestamps(const struct stat* st,
-                         time_t* mtime_seconds,
-                         long* mtime_nanoseconds,
-                         time_t* ctime_seconds,
-                         long* ctime_nanoseconds)
-{
-#if defined(__APPLE__)
-    *mtime_seconds = st->st_mtimespec.tv_sec;
-    *mtime_nanoseconds = st->st_mtimespec.tv_nsec;
-    *ctime_seconds = st->st_ctimespec.tv_sec;
-    *ctime_nanoseconds = st->st_ctimespec.tv_nsec;
-#else
-    *mtime_seconds = st->st_mtim.tv_sec;
-    *mtime_nanoseconds = st->st_mtim.tv_nsec;
-    *ctime_seconds = st->st_ctim.tv_sec;
-    *ctime_nanoseconds = st->st_ctim.tv_nsec;
-#endif
-}
-
-static gboolean
-peak_jit_perfmap_timestamps_changed(const struct stat* st)
-{
-    time_t mtime_seconds;
-    long mtime_nanoseconds;
-    time_t ctime_seconds;
-    long ctime_nanoseconds;
-
-    peak_jit_stat_timestamps(st,
-                             &mtime_seconds,
-                             &mtime_nanoseconds,
-                             &ctime_seconds,
-                             &ctime_nanoseconds);
-    return mtime_seconds != peak_jit_perfmap_mtime_seconds ||
-           mtime_nanoseconds != peak_jit_perfmap_mtime_nanoseconds ||
-           ctime_seconds != peak_jit_perfmap_ctime_seconds ||
-           ctime_nanoseconds != peak_jit_perfmap_ctime_nanoseconds;
-}
-
-static void
-peak_jit_perfmap_remember_stat(const struct stat* st)
-{
-    peak_jit_perfmap_last_size = st->st_size;
-    peak_jit_stat_timestamps(st,
-                             &peak_jit_perfmap_mtime_seconds,
-                             &peak_jit_perfmap_mtime_nanoseconds,
-                             &peak_jit_perfmap_ctime_seconds,
-                             &peak_jit_perfmap_ctime_nanoseconds);
-}
-
-static gboolean
-peak_jit_hash_file_range(int fd,
-                         off_t offset,
-                         size_t size,
-                         uint64_t* hash)
-{
-    unsigned char buffer[PEAK_JIT_PREFIX_PROBE_BYTES];
-    size_t consumed = 0;
-
-    while (consumed < size) {
-        ssize_t count = pread(fd,
-                              buffer + consumed,
-                              size - consumed,
-                              offset + (off_t)consumed);
-        if (count < 0 && errno == EINTR) {
-            continue;
-        }
-        if (count <= 0) {
-            return FALSE;
-        }
-        consumed += (size_t)count;
-    }
-    for (size_t i = 0; i < size; i++) {
-        *hash ^= buffer[i];
-        *hash *= UINT64_C(1099511628211);
-    }
-    return TRUE;
-}
-
-static gboolean
-peak_jit_perfmap_compute_prefix_signature(int fd,
-                                          off_t length,
-                                          uint64_t* signature)
-{
-    uint64_t hash = UINT64_C(1469598103934665603);
-    size_t first_size;
-    size_t last_size;
-
-    if (length < 0 || signature == NULL) {
-        return FALSE;
-    }
-    first_size = (size_t)(length < (off_t)PEAK_JIT_PREFIX_PROBE_BYTES
-                              ? length
-                              : (off_t)PEAK_JIT_PREFIX_PROBE_BYTES);
-    last_size = length > (off_t)first_size
-                    ? (size_t)((length - (off_t)first_size) <
-                                       (off_t)PEAK_JIT_PREFIX_PROBE_BYTES
-                                   ? length - (off_t)first_size
-                                   : (off_t)PEAK_JIT_PREFIX_PROBE_BYTES)
-                    : 0;
-    hash ^= (uint64_t)length;
-    hash *= UINT64_C(1099511628211);
-    if (!peak_jit_hash_file_range(fd, 0, first_size, &hash) ||
-        (last_size != 0 &&
-         !peak_jit_hash_file_range(fd,
-                                   length - (off_t)last_size,
-                                   last_size,
-                                   &hash))) {
-        return FALSE;
-    }
-    *signature = hash;
-    return TRUE;
-}
-
-static void
-peak_jit_perfmap_remember_prefix(int fd, off_t length)
-{
-    uint64_t signature;
-
-    if (peak_jit_perfmap_compute_prefix_signature(fd, length, &signature)) {
-        peak_jit_perfmap_prefix_signature = signature;
-        peak_jit_perfmap_prefix_signature_length = length;
-        peak_jit_perfmap_prefix_signature_known = TRUE;
-    } else {
-        peak_jit_perfmap_prefix_signature_known = FALSE;
-        peak_jit_perfmap_prefix_signature_length = 0;
-        peak_jit_perfmap_prefix_signature = 0;
-    }
-}
-
-static void
 peak_jit_provider_advance_generation(const char* reason)
 {
     peak_jit_pending_records_clear();
-    peak_jit_perfmap_prefix_signature_known = FALSE;
-    peak_jit_perfmap_prefix_signature_length = 0;
-    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_provider_generation++;
     if (peak_jit_provider_generation == 0) {
         peak_jit_provider_generation = 1;
@@ -1122,42 +981,17 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
             peak_jit_perfmap_identity_known && !source_replaced &&
             (peak_jit_perfmap_offset > st.st_size ||
              st.st_size < peak_jit_perfmap_last_size);
-        gboolean source_reset = FALSE;
-
-        if (peak_jit_perfmap_identity_known && !source_replaced &&
-            !source_truncated && peak_jit_perfmap_offset > 0 &&
-            st.st_size >= peak_jit_perfmap_offset &&
-            peak_jit_perfmap_prefix_signature_known &&
-            peak_jit_perfmap_prefix_signature_length ==
-                peak_jit_perfmap_offset) {
-            uint64_t signature;
-            source_reset =
-                !peak_jit_perfmap_compute_prefix_signature(fileno(fp),
-                                                            peak_jit_perfmap_offset,
-                                                            &signature) ||
-                signature != peak_jit_perfmap_prefix_signature;
-        }
-        if (peak_jit_perfmap_identity_known && !source_replaced &&
-            !source_truncated && !source_reset &&
-            st.st_size == peak_jit_perfmap_last_size &&
-            peak_jit_perfmap_timestamps_changed(&st)) {
-            source_reset = TRUE;
-        }
-
         if (source_replaced) {
             peak_jit_perfmap_offset = 0;
             peak_jit_provider_advance_generation("source-replaced");
         } else if (source_truncated) {
             peak_jit_perfmap_offset = 0;
             peak_jit_provider_advance_generation("source-truncated");
-        } else if (source_reset) {
-            peak_jit_perfmap_offset = 0;
-            peak_jit_provider_advance_generation("source-reset");
         }
         peak_jit_perfmap_identity_known = TRUE;
         peak_jit_perfmap_dev = st.st_dev;
         peak_jit_perfmap_ino = st.st_ino;
-        peak_jit_perfmap_remember_stat(&st);
+        peak_jit_perfmap_last_size = st.st_size;
     }
 
     if (fseeko(fp, 0, SEEK_END) == 0) {
@@ -1286,9 +1120,8 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     }
 
     peak_jit_perfmap_offset = committed_offset;
-    peak_jit_perfmap_remember_prefix(fileno(fp), committed_offset);
     if (fstat(fileno(fp), &st) == 0) {
-        peak_jit_perfmap_remember_stat(&st);
+        peak_jit_perfmap_last_size = st.st_size;
     }
     fclose(fp);
     if (budget > 0) {
@@ -1339,13 +1172,6 @@ peak_jit_provider_enable(void)
     peak_jit_perfmap_dev = 0;
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
-    peak_jit_perfmap_mtime_seconds = 0;
-    peak_jit_perfmap_mtime_nanoseconds = 0;
-    peak_jit_perfmap_ctime_seconds = 0;
-    peak_jit_perfmap_ctime_nanoseconds = 0;
-    peak_jit_perfmap_prefix_signature_known = FALSE;
-    peak_jit_perfmap_prefix_signature_length = 0;
-    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_provider_advance_generation("provider-enabled");
 
     peak_jit_trace("provider-enable",
@@ -1412,13 +1238,6 @@ peak_jit_provider_disable(void)
     peak_jit_perfmap_dev = 0;
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
-    peak_jit_perfmap_mtime_seconds = 0;
-    peak_jit_perfmap_mtime_nanoseconds = 0;
-    peak_jit_perfmap_ctime_seconds = 0;
-    peak_jit_perfmap_ctime_nanoseconds = 0;
-    peak_jit_perfmap_prefix_signature_known = FALSE;
-    peak_jit_perfmap_prefix_signature_length = 0;
-    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_pending_records_clear();
     g_free(peak_jit_pending_records);
     peak_jit_pending_records = NULL;

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -34,6 +34,8 @@
 #define PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV "PEAK_JIT_TEST_ATTACH_SEQUENCE"
 #define PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION_ENV \
     "PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION"
+#define PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER_ENV \
+    "PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"
 #endif
 
 static gboolean peak_jit_provider_enabled = FALSE;
@@ -65,6 +67,8 @@ static off_t peak_jit_perfmap_last_size = 0;
 static unsigned int peak_jit_test_attach_sequence_index = 0;
 static char* configured_jit_test_attach_sequence = NULL;
 static unsigned long peak_jit_test_fail_pending_allocation_remaining = 0;
+static gboolean peak_jit_test_final_stat_barrier_used = FALSE;
+static gboolean peak_jit_test_final_stat_signal_pending = FALSE;
 #endif
 
 typedef enum {
@@ -459,6 +463,56 @@ peak_jit_pending_records_clear(void)
     peak_jit_pending_record_count = 0;
     peak_jit_pending_retry_cursor = 0;
 }
+
+#ifdef PEAK_ENABLE_TEST_HOOKS
+static void
+peak_jit_test_wait_before_final_stat(void)
+{
+    const char* path;
+    FILE* marker;
+
+    if (peak_jit_test_final_stat_barrier_used) {
+        return;
+    }
+    path = g_getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER_ENV);
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    peak_jit_test_final_stat_barrier_used = TRUE;
+    marker = fopen(path, "w");
+    if (marker == NULL) {
+        return;
+    }
+    fclose(marker);
+    for (unsigned int i = 0; i < 10000 && access(path, F_OK) == 0; i++) {
+        usleep(100);
+    }
+    peak_jit_test_final_stat_signal_pending = TRUE;
+}
+
+static void
+peak_jit_test_signal_after_final_stat(void)
+{
+    const char* path;
+    char* done_path;
+    FILE* marker;
+
+    if (!peak_jit_test_final_stat_signal_pending) {
+        return;
+    }
+    peak_jit_test_final_stat_signal_pending = FALSE;
+    path = g_getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER_ENV);
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    done_path = g_strdup_printf("%s.done", path);
+    marker = fopen(done_path, "w");
+    if (marker != NULL) {
+        fclose(marker);
+    }
+    g_free(done_path);
+}
+#endif
 
 static void
 peak_jit_provider_advance_generation(const char* reason)
@@ -993,7 +1047,6 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         peak_jit_perfmap_ino = st.st_ino;
         peak_jit_perfmap_last_size = st.st_size;
     }
-
     if (fseeko(fp, 0, SEEK_END) == 0) {
         off_t end = ftello(fp);
         if (end >= 0 && peak_jit_perfmap_offset > end) {
@@ -1120,9 +1173,26 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     }
 
     peak_jit_perfmap_offset = committed_offset;
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    if (peak_jit_perfmap_offset > 0) {
+        peak_jit_test_wait_before_final_stat();
+    }
+#endif
     if (fstat(fileno(fp), &st) == 0) {
+        if (peak_jit_perfmap_identity_known &&
+            st.st_dev == peak_jit_perfmap_dev &&
+            st.st_ino == peak_jit_perfmap_ino &&
+            (peak_jit_perfmap_offset > st.st_size ||
+             st.st_size < peak_jit_perfmap_last_size)) {
+            peak_jit_perfmap_offset = 0;
+            peak_jit_provider_advance_generation(
+                "source-truncated-during-drain");
+        }
         peak_jit_perfmap_last_size = st.st_size;
     }
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_jit_test_signal_after_final_stat();
+#endif
     fclose(fp);
     if (budget > 0) {
         pending |= peak_jit_provider_retry_pending_records(
@@ -1143,6 +1213,8 @@ peak_jit_provider_enable(void)
     peak_jit_provider_reset_diagnostics();
 #ifdef PEAK_ENABLE_TEST_HOOKS
     peak_jit_test_attach_sequence_index = 0;
+    peak_jit_test_final_stat_barrier_used = FALSE;
+    peak_jit_test_final_stat_signal_pending = FALSE;
 #endif
 
     if (!configured_jit_enabled) {

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -30,6 +30,7 @@
 #define PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET 1024UL
 #define PEAK_JIT_DEFAULT_PENDING_CAPACITY 4096UL
 #define PEAK_JIT_MAX_PENDING_CAPACITY 65536UL
+#define PEAK_JIT_PREFIX_PROBE_BYTES 512U
 #ifdef PEAK_ENABLE_TEST_HOOKS
 #define PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV "PEAK_JIT_TEST_ATTACH_SEQUENCE"
 #define PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION_ENV \
@@ -61,6 +62,13 @@ static gboolean peak_jit_perfmap_identity_known = FALSE;
 static dev_t peak_jit_perfmap_dev = 0;
 static ino_t peak_jit_perfmap_ino = 0;
 static off_t peak_jit_perfmap_last_size = 0;
+static time_t peak_jit_perfmap_mtime_seconds = 0;
+static long peak_jit_perfmap_mtime_nanoseconds = 0;
+static time_t peak_jit_perfmap_ctime_seconds = 0;
+static long peak_jit_perfmap_ctime_nanoseconds = 0;
+static gboolean peak_jit_perfmap_prefix_signature_known = FALSE;
+static off_t peak_jit_perfmap_prefix_signature_length = 0;
+static uint64_t peak_jit_perfmap_prefix_signature = 0;
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static unsigned int peak_jit_test_attach_sequence_index = 0;
 static char* configured_jit_test_attach_sequence = NULL;
@@ -92,6 +100,7 @@ typedef enum {
 
 static PeakJitPendingRecord** peak_jit_pending_records = NULL;
 static size_t peak_jit_pending_record_count = 0;
+static size_t peak_jit_pending_retry_cursor = 0;
 static uint64_t peak_jit_provider_generation = 0;
 static _Atomic uint64_t peak_jit_pending_queue_full = 0;
 static _Atomic uint64_t peak_jit_non_executable_timeout = 0;
@@ -456,12 +465,146 @@ peak_jit_pending_records_clear(void)
         peak_jit_pending_records[i] = NULL;
     }
     peak_jit_pending_record_count = 0;
+    peak_jit_pending_retry_cursor = 0;
+}
+
+static void
+peak_jit_stat_timestamps(const struct stat* st,
+                         time_t* mtime_seconds,
+                         long* mtime_nanoseconds,
+                         time_t* ctime_seconds,
+                         long* ctime_nanoseconds)
+{
+#if defined(__APPLE__)
+    *mtime_seconds = st->st_mtimespec.tv_sec;
+    *mtime_nanoseconds = st->st_mtimespec.tv_nsec;
+    *ctime_seconds = st->st_ctimespec.tv_sec;
+    *ctime_nanoseconds = st->st_ctimespec.tv_nsec;
+#else
+    *mtime_seconds = st->st_mtim.tv_sec;
+    *mtime_nanoseconds = st->st_mtim.tv_nsec;
+    *ctime_seconds = st->st_ctim.tv_sec;
+    *ctime_nanoseconds = st->st_ctim.tv_nsec;
+#endif
+}
+
+static gboolean
+peak_jit_perfmap_timestamps_changed(const struct stat* st)
+{
+    time_t mtime_seconds;
+    long mtime_nanoseconds;
+    time_t ctime_seconds;
+    long ctime_nanoseconds;
+
+    peak_jit_stat_timestamps(st,
+                             &mtime_seconds,
+                             &mtime_nanoseconds,
+                             &ctime_seconds,
+                             &ctime_nanoseconds);
+    return mtime_seconds != peak_jit_perfmap_mtime_seconds ||
+           mtime_nanoseconds != peak_jit_perfmap_mtime_nanoseconds ||
+           ctime_seconds != peak_jit_perfmap_ctime_seconds ||
+           ctime_nanoseconds != peak_jit_perfmap_ctime_nanoseconds;
+}
+
+static void
+peak_jit_perfmap_remember_stat(const struct stat* st)
+{
+    peak_jit_perfmap_last_size = st->st_size;
+    peak_jit_stat_timestamps(st,
+                             &peak_jit_perfmap_mtime_seconds,
+                             &peak_jit_perfmap_mtime_nanoseconds,
+                             &peak_jit_perfmap_ctime_seconds,
+                             &peak_jit_perfmap_ctime_nanoseconds);
+}
+
+static gboolean
+peak_jit_hash_file_range(int fd,
+                         off_t offset,
+                         size_t size,
+                         uint64_t* hash)
+{
+    unsigned char buffer[PEAK_JIT_PREFIX_PROBE_BYTES];
+    size_t consumed = 0;
+
+    while (consumed < size) {
+        ssize_t count = pread(fd,
+                              buffer + consumed,
+                              size - consumed,
+                              offset + (off_t)consumed);
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count <= 0) {
+            return FALSE;
+        }
+        consumed += (size_t)count;
+    }
+    for (size_t i = 0; i < size; i++) {
+        *hash ^= buffer[i];
+        *hash *= UINT64_C(1099511628211);
+    }
+    return TRUE;
+}
+
+static gboolean
+peak_jit_perfmap_compute_prefix_signature(int fd,
+                                          off_t length,
+                                          uint64_t* signature)
+{
+    uint64_t hash = UINT64_C(1469598103934665603);
+    size_t first_size;
+    size_t last_size;
+
+    if (length < 0 || signature == NULL) {
+        return FALSE;
+    }
+    first_size = (size_t)(length < (off_t)PEAK_JIT_PREFIX_PROBE_BYTES
+                              ? length
+                              : (off_t)PEAK_JIT_PREFIX_PROBE_BYTES);
+    last_size = length > (off_t)first_size
+                    ? (size_t)((length - (off_t)first_size) <
+                                       (off_t)PEAK_JIT_PREFIX_PROBE_BYTES
+                                   ? length - (off_t)first_size
+                                   : (off_t)PEAK_JIT_PREFIX_PROBE_BYTES)
+                    : 0;
+    hash ^= (uint64_t)length;
+    hash *= UINT64_C(1099511628211);
+    if (!peak_jit_hash_file_range(fd, 0, first_size, &hash) ||
+        (last_size != 0 &&
+         !peak_jit_hash_file_range(fd,
+                                   length - (off_t)last_size,
+                                   last_size,
+                                   &hash))) {
+        return FALSE;
+    }
+    *signature = hash;
+    return TRUE;
+}
+
+static void
+peak_jit_perfmap_remember_prefix(int fd, off_t length)
+{
+    uint64_t signature;
+
+    if (peak_jit_perfmap_compute_prefix_signature(fd, length, &signature)) {
+        peak_jit_perfmap_prefix_signature = signature;
+        peak_jit_perfmap_prefix_signature_length = length;
+        peak_jit_perfmap_prefix_signature_known = TRUE;
+    } else {
+        peak_jit_perfmap_prefix_signature_known = FALSE;
+        peak_jit_perfmap_prefix_signature_length = 0;
+        peak_jit_perfmap_prefix_signature = 0;
+    }
 }
 
 static void
 peak_jit_provider_advance_generation(const char* reason)
 {
     peak_jit_pending_records_clear();
+    peak_jit_perfmap_prefix_signature_known = FALSE;
+    peak_jit_perfmap_prefix_signature_length = 0;
+    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_provider_generation++;
     if (peak_jit_provider_generation == 0) {
         peak_jit_provider_generation = 1;
@@ -582,6 +725,14 @@ peak_jit_pending_record_remove_index(size_t index)
                         sizeof(*peak_jit_pending_records));
         }
         peak_jit_pending_records[peak_jit_pending_record_count] = NULL;
+        if (peak_jit_pending_record_count == 0) {
+            peak_jit_pending_retry_cursor = 0;
+        } else if (index < peak_jit_pending_retry_cursor) {
+            peak_jit_pending_retry_cursor--;
+        } else if (peak_jit_pending_retry_cursor >=
+                   peak_jit_pending_record_count) {
+            peak_jit_pending_retry_cursor = 0;
+        }
     }
 }
 
@@ -829,13 +980,19 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
                                         unsigned long* budget)
 {
     gboolean pending = FALSE;
+    size_t remaining;
 
     if (peak_jit_pending_records == NULL ||
         peak_jit_pending_record_count == 0) {
         return FALSE;
     }
 
-    for (size_t i = 0; i < peak_jit_pending_record_count;) {
+    remaining = peak_jit_pending_record_count;
+    while (peak_jit_pending_record_count != 0 && remaining != 0) {
+        if (peak_jit_pending_retry_cursor >= peak_jit_pending_record_count) {
+            peak_jit_pending_retry_cursor = 0;
+        }
+        size_t i = peak_jit_pending_retry_cursor;
         PeakJitPendingRecord* record = peak_jit_pending_records[i];
         PeakDynamicAttachResult attach_result;
 
@@ -846,6 +1003,7 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
             }
             (*budget)--;
         }
+        remaining--;
         record->last_attempt_at = peak_second();
         record->attempt_count++;
 
@@ -878,7 +1036,8 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
             }
 
             pending = TRUE;
-            i++;
+            peak_jit_pending_retry_cursor =
+                (i + 1) % peak_jit_pending_record_count;
             continue;
         }
 
@@ -912,7 +1071,8 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
                 continue;
             }
             pending = TRUE;
-            i++;
+            peak_jit_pending_retry_cursor =
+                (i + 1) % peak_jit_pending_record_count;
             continue;
         }
 
@@ -962,6 +1122,27 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
             peak_jit_perfmap_identity_known && !source_replaced &&
             (peak_jit_perfmap_offset > st.st_size ||
              st.st_size < peak_jit_perfmap_last_size);
+        gboolean source_reset = FALSE;
+
+        if (peak_jit_perfmap_identity_known && !source_replaced &&
+            !source_truncated && peak_jit_perfmap_offset > 0 &&
+            st.st_size >= peak_jit_perfmap_offset &&
+            peak_jit_perfmap_prefix_signature_known &&
+            peak_jit_perfmap_prefix_signature_length ==
+                peak_jit_perfmap_offset) {
+            uint64_t signature;
+            source_reset =
+                !peak_jit_perfmap_compute_prefix_signature(fileno(fp),
+                                                            peak_jit_perfmap_offset,
+                                                            &signature) ||
+                signature != peak_jit_perfmap_prefix_signature;
+        }
+        if (peak_jit_perfmap_identity_known && !source_replaced &&
+            !source_truncated && !source_reset &&
+            st.st_size == peak_jit_perfmap_last_size &&
+            peak_jit_perfmap_timestamps_changed(&st)) {
+            source_reset = TRUE;
+        }
 
         if (source_replaced) {
             peak_jit_perfmap_offset = 0;
@@ -969,11 +1150,14 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         } else if (source_truncated) {
             peak_jit_perfmap_offset = 0;
             peak_jit_provider_advance_generation("source-truncated");
+        } else if (source_reset) {
+            peak_jit_perfmap_offset = 0;
+            peak_jit_provider_advance_generation("source-reset");
         }
         peak_jit_perfmap_identity_known = TRUE;
         peak_jit_perfmap_dev = st.st_dev;
         peak_jit_perfmap_ino = st.st_ino;
-        peak_jit_perfmap_last_size = st.st_size;
+        peak_jit_perfmap_remember_stat(&st);
     }
 
     if (fseeko(fp, 0, SEEK_END) == 0) {
@@ -1102,6 +1286,10 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     }
 
     peak_jit_perfmap_offset = committed_offset;
+    peak_jit_perfmap_remember_prefix(fileno(fp), committed_offset);
+    if (fstat(fileno(fp), &st) == 0) {
+        peak_jit_perfmap_remember_stat(&st);
+    }
     fclose(fp);
     if (budget > 0) {
         pending |= peak_jit_provider_retry_pending_records(
@@ -1151,6 +1339,13 @@ peak_jit_provider_enable(void)
     peak_jit_perfmap_dev = 0;
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
+    peak_jit_perfmap_mtime_seconds = 0;
+    peak_jit_perfmap_mtime_nanoseconds = 0;
+    peak_jit_perfmap_ctime_seconds = 0;
+    peak_jit_perfmap_ctime_nanoseconds = 0;
+    peak_jit_perfmap_prefix_signature_known = FALSE;
+    peak_jit_perfmap_prefix_signature_length = 0;
+    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_provider_advance_generation("provider-enabled");
 
     peak_jit_trace("provider-enable",
@@ -1217,6 +1412,13 @@ peak_jit_provider_disable(void)
     peak_jit_perfmap_dev = 0;
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
+    peak_jit_perfmap_mtime_seconds = 0;
+    peak_jit_perfmap_mtime_nanoseconds = 0;
+    peak_jit_perfmap_ctime_seconds = 0;
+    peak_jit_perfmap_ctime_nanoseconds = 0;
+    peak_jit_perfmap_prefix_signature_known = FALSE;
+    peak_jit_perfmap_prefix_signature_length = 0;
+    peak_jit_perfmap_prefix_signature = 0;
     peak_jit_pending_records_clear();
     g_free(peak_jit_pending_records);
     peak_jit_pending_records = NULL;

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -36,6 +36,8 @@
     "PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION"
 #define PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER_ENV \
     "PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"
+#define PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER_ENV \
+    "PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER"
 #endif
 
 static gboolean peak_jit_provider_enabled = FALSE;
@@ -69,6 +71,7 @@ static char* configured_jit_test_attach_sequence = NULL;
 static unsigned long peak_jit_test_fail_pending_allocation_remaining = 0;
 static gboolean peak_jit_test_final_stat_barrier_used = FALSE;
 static gboolean peak_jit_test_final_stat_signal_pending = FALSE;
+static gboolean peak_jit_test_source_observe_barrier_used = FALSE;
 #endif
 
 typedef enum {
@@ -97,6 +100,7 @@ typedef enum {
 static PeakJitPendingRecord** peak_jit_pending_records = NULL;
 static size_t peak_jit_pending_record_count = 0;
 static size_t peak_jit_pending_retry_cursor = 0;
+static gboolean peak_jit_single_budget_retry_turn = FALSE;
 static uint64_t peak_jit_provider_generation = 0;
 static _Atomic uint64_t peak_jit_pending_queue_full = 0;
 static _Atomic uint64_t peak_jit_non_executable_timeout = 0;
@@ -462,9 +466,35 @@ peak_jit_pending_records_clear(void)
     }
     peak_jit_pending_record_count = 0;
     peak_jit_pending_retry_cursor = 0;
+    peak_jit_single_budget_retry_turn = FALSE;
 }
 
 #ifdef PEAK_ENABLE_TEST_HOOKS
+static void
+peak_jit_test_wait_before_source_observation(void)
+{
+    const char* path;
+    FILE* marker;
+
+    if (peak_jit_test_source_observe_barrier_used ||
+        peak_jit_pending_record_count == 0) {
+        return;
+    }
+    path = g_getenv(PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER_ENV);
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    peak_jit_test_source_observe_barrier_used = TRUE;
+    marker = fopen(path, "w");
+    if (marker == NULL) {
+        return;
+    }
+    fclose(marker);
+    for (unsigned int i = 0; i < 10000 && access(path, F_OK) == 0; i++) {
+        usleep(100);
+    }
+}
+
 static void
 peak_jit_test_wait_before_final_stat(void)
 {
@@ -566,19 +596,18 @@ peak_jit_pending_record_add(PeakJitPendingKind kind,
         return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
     }
 
+    if (peak_jit_pending_record_count >= configured_jit_pending_capacity) {
+        atomic_fetch_add_explicit(&peak_jit_pending_queue_full,
+                                  1,
+                                  memory_order_relaxed);
+        return PEAK_JIT_PENDING_ADD_QUEUE_FULL;
+    }
     record = peak_jit_pending_record_find(peak_jit_provider_generation,
                                           address,
                                           size,
                                           name);
     if (record != NULL) {
         return PEAK_JIT_PENDING_ADD_DUPLICATE;
-    }
-
-    if (peak_jit_pending_record_count >= configured_jit_pending_capacity) {
-        atomic_fetch_add_explicit(&peak_jit_pending_queue_full,
-                                  1,
-                                  memory_order_relaxed);
-        return PEAK_JIT_PENDING_ADD_QUEUE_FULL;
     }
     if (!peak_jit_pending_records_ensure()) {
         return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
@@ -632,19 +661,15 @@ peak_jit_pending_record_remove_index(size_t index)
         peak_jit_pending_record_free(peak_jit_pending_records[index]);
         peak_jit_pending_record_count--;
         if (index < peak_jit_pending_record_count) {
-            memmove(&peak_jit_pending_records[index],
-                    &peak_jit_pending_records[index + 1],
-                    (peak_jit_pending_record_count - index) *
-                        sizeof(*peak_jit_pending_records));
+            peak_jit_pending_records[index] =
+                peak_jit_pending_records[peak_jit_pending_record_count];
         }
         peak_jit_pending_records[peak_jit_pending_record_count] = NULL;
         if (peak_jit_pending_record_count == 0) {
             peak_jit_pending_retry_cursor = 0;
-        } else if (index < peak_jit_pending_retry_cursor) {
-            peak_jit_pending_retry_cursor--;
-        } else if (peak_jit_pending_retry_cursor >=
-                   peak_jit_pending_record_count) {
-            peak_jit_pending_retry_cursor = 0;
+        } else {
+            peak_jit_pending_retry_cursor =
+                index < peak_jit_pending_record_count ? index : 0;
         }
     }
 }
@@ -860,6 +885,8 @@ peak_jit_attach_result_string(PeakDynamicAttachResult result)
     switch (result) {
         case PEAK_DYNAMIC_ATTACH_ATTACHED:
             return "attached";
+        case PEAK_DYNAMIC_ATTACH_GENERATION_REFRESHED:
+            return "generation-refreshed";
         case PEAK_DYNAMIC_ATTACH_NO_MATCH:
             return "not-matched";
         case PEAK_DYNAMIC_ATTACH_RETRY:
@@ -868,6 +895,24 @@ peak_jit_attach_result_string(PeakDynamicAttachResult result)
             return "attach-failed";
         default:
             return "attach-unknown";
+    }
+}
+
+static const char*
+peak_jit_pending_add_result_string(PeakJitPendingAddResult result,
+                                   const char* retry_result)
+{
+    switch (result) {
+        case PEAK_JIT_PENDING_ADD_OK:
+            return retry_result;
+        case PEAK_JIT_PENDING_ADD_DUPLICATE:
+            return "already-pending";
+        case PEAK_JIT_PENDING_ADD_QUEUE_FULL:
+            return "pending-queue-full";
+        case PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED:
+            return "pending-allocation-failure";
+        default:
+            return "pending-add-unknown";
     }
 }
 
@@ -957,29 +1002,25 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
         attach_result = peak_jit_attach_perfmap_symbol(record->name,
                                                        record->address,
                                                        record->size);
-        peak_jit_trace("perfmap-record",
-                       "perfmap",
-                       record->name,
-                       record->address,
-                       record->size,
-                       peak_jit_attach_result_string(attach_result));
         if (attach_result == PEAK_DYNAMIC_ATTACH_RETRY) {
             if (record->pending_kind == PEAK_JIT_PENDING_NOT_EXECUTABLE) {
                 record->pending_kind = PEAK_JIT_PENDING_ATTACH_RETRY;
                 record->created_at = peak_second();
             }
-            if (peak_jit_pending_record_timed_out(
-                    record,
-                    force_not_exec_timeout)) {
+            gboolean timed_out = peak_jit_pending_record_timed_out(
+                record,
+                force_not_exec_timeout);
+            peak_jit_trace("perfmap-record",
+                           "perfmap",
+                           record->name,
+                           record->address,
+                           record->size,
+                           timed_out ? "attach-retry-timeout" :
+                                       "attach-retry");
+            if (timed_out) {
                 atomic_fetch_add_explicit(&peak_jit_attach_retry_timeout,
                                           1,
                                           memory_order_relaxed);
-                peak_jit_trace("perfmap-record",
-                               "perfmap",
-                               record->name,
-                               record->address,
-                               record->size,
-                               "attach-retry-timeout");
                 peak_jit_pending_record_remove_index(i);
                 continue;
             }
@@ -989,6 +1030,12 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
             continue;
         }
 
+        peak_jit_trace("perfmap-record",
+                       "perfmap",
+                       record->name,
+                       record->address,
+                       record->size,
+                       peak_jit_attach_result_string(attach_result));
         peak_jit_pending_record_remove_index(i);
     }
 
@@ -1003,13 +1050,9 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     off_t committed_offset;
     gboolean pending = FALSE;
     unsigned long budget = peak_jit_drain_record_budget();
-    unsigned long retry_budget = budget > 1 ? budget / 2 : 0;
-    unsigned long initial_retry_budget = retry_budget;
+    gboolean single_budget = budget == 1;
+    gboolean metadata_consumed = FALSE;
     struct stat st;
-
-    pending |= peak_jit_provider_retry_pending_records(force_not_exec_timeout,
-                                                       &retry_budget);
-    budget -= initial_retry_budget - retry_budget;
 
     if (peak_jit_perfmap_path == NULL) {
         pending |= peak_jit_provider_retry_pending_records(
@@ -1018,6 +1061,9 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         return pending || peak_jit_pending_record_count != 0;
     }
 
+#ifdef PEAK_ENABLE_TEST_HOOKS
+    peak_jit_test_wait_before_source_observation();
+#endif
     fp = fopen(peak_jit_perfmap_path, "r");
     if (fp == NULL) {
         pending |= peak_jit_provider_retry_pending_records(
@@ -1047,6 +1093,27 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         peak_jit_perfmap_ino = st.st_ino;
         peak_jit_perfmap_last_size = st.st_size;
     }
+
+    if (budget > 1) {
+        unsigned long retry_budget = budget / 2;
+        unsigned long initial_retry_budget = retry_budget;
+
+        pending |= peak_jit_provider_retry_pending_records(
+            force_not_exec_timeout,
+            &retry_budget);
+        budget -= initial_retry_budget - retry_budget;
+    } else if (single_budget && peak_jit_single_budget_retry_turn &&
+               peak_jit_pending_record_count != 0) {
+        unsigned long initial_budget = budget;
+
+        pending |= peak_jit_provider_retry_pending_records(
+            force_not_exec_timeout,
+            &budget);
+        if (budget != initial_budget) {
+            peak_jit_single_budget_retry_turn = FALSE;
+        }
+    }
+
     if (fseeko(fp, 0, SEEK_END) == 0) {
         off_t end = ftello(fp);
         if (end >= 0 && peak_jit_perfmap_offset > end) {
@@ -1073,6 +1140,7 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
             break;
         }
         budget--;
+        metadata_consumed = TRUE;
 
         if (!peak_jit_line_is_complete(line)) {
             if (strlen(line) == sizeof(line) - 1 &&
@@ -1109,16 +1177,24 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
             gboolean matches_target =
                 peak_general_listener_dynamic_symbol_matches_any_target(name,
                                                                         "perfmap");
-            peak_jit_trace("perfmap-record",
-                           "perfmap",
-                           name,
-                           address,
-                           size,
-                           matches_target && force_not_exec_timeout ?
-                               "not-executable-timeout" :
-                               matches_target ? "not-executable-retry" :
-                                                "not-executable");
-            if (matches_target && !force_not_exec_timeout) {
+            if (!matches_target) {
+                peak_jit_trace("perfmap-record",
+                               "perfmap",
+                               name,
+                               address,
+                               size,
+                               "not-executable");
+            } else if (force_not_exec_timeout) {
+                atomic_fetch_add_explicit(&peak_jit_non_executable_timeout,
+                                          1,
+                                          memory_order_relaxed);
+                peak_jit_trace("perfmap-record",
+                               "perfmap",
+                               name,
+                               address,
+                               size,
+                               "not-executable-timeout");
+            } else {
                 PeakJitPendingAddResult add_result =
                     peak_jit_pending_record_add(
                         PEAK_JIT_PENDING_NOT_EXECUTABLE,
@@ -1127,10 +1203,15 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
                         name);
                 pending |= add_result == PEAK_JIT_PENDING_ADD_OK ||
                            add_result == PEAK_JIT_PENDING_ADD_DUPLICATE;
-            } else if (matches_target && force_not_exec_timeout) {
-                atomic_fetch_add_explicit(&peak_jit_non_executable_timeout,
-                                          1,
-                                          memory_order_relaxed);
+                peak_jit_trace(
+                    "perfmap-record",
+                    "perfmap",
+                    name,
+                    address,
+                    size,
+                    peak_jit_pending_add_result_string(
+                        add_result,
+                        "not-executable-retry"));
             }
             if (next_offset >= 0) {
                 committed_offset = next_offset;
@@ -1139,12 +1220,6 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         }
 
         attach_result = peak_jit_attach_perfmap_symbol(name, address, size);
-        peak_jit_trace("perfmap-record",
-                       "perfmap",
-                       name,
-                       address,
-                       size,
-                       peak_jit_attach_result_string(attach_result));
         if (attach_result == PEAK_DYNAMIC_ATTACH_RETRY) {
             if (force_not_exec_timeout) {
                 atomic_fetch_add_explicit(&peak_jit_attach_retry_timeout,
@@ -1165,7 +1240,22 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
                         name);
                 pending |= add_result == PEAK_JIT_PENDING_ADD_OK ||
                            add_result == PEAK_JIT_PENDING_ADD_DUPLICATE;
+                peak_jit_trace(
+                    "perfmap-record",
+                    "perfmap",
+                    name,
+                    address,
+                    size,
+                    peak_jit_pending_add_result_string(add_result,
+                                                       "attach-retry"));
             }
+        } else {
+            peak_jit_trace("perfmap-record",
+                           "perfmap",
+                           name,
+                           address,
+                           size,
+                           peak_jit_attach_result_string(attach_result));
         }
         if (next_offset >= 0) {
             committed_offset = next_offset;
@@ -1194,10 +1284,19 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     peak_jit_test_signal_after_final_stat();
 #endif
     fclose(fp);
+    if (single_budget && metadata_consumed &&
+        peak_jit_pending_record_count != 0) {
+        peak_jit_single_budget_retry_turn = TRUE;
+    }
     if (budget > 0) {
+        unsigned long initial_budget = budget;
+
         pending |= peak_jit_provider_retry_pending_records(
             force_not_exec_timeout,
             &budget);
+        if (single_budget && budget != initial_budget) {
+            peak_jit_single_budget_retry_turn = FALSE;
+        }
     }
     return pending || peak_jit_pending_record_count != 0;
 }
@@ -1215,6 +1314,7 @@ peak_jit_provider_enable(void)
     peak_jit_test_attach_sequence_index = 0;
     peak_jit_test_final_stat_barrier_used = FALSE;
     peak_jit_test_final_stat_signal_pending = FALSE;
+    peak_jit_test_source_observe_barrier_used = FALSE;
 #endif
 
     if (!configured_jit_enabled) {

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -21,10 +22,18 @@
 #define PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS_ENV \
     "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS"
 #define PEAK_JIT_DRAIN_RECORD_BUDGET_ENV "PEAK_JIT_DRAIN_RECORD_BUDGET"
+#define PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS_ENV \
+    "PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS"
+#define PEAK_JIT_PENDING_CAPACITY_ENV "PEAK_JIT_PENDING_CAPACITY"
 #define PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS 1000UL
+#define PEAK_JIT_DEFAULT_ATTACH_RETRY_TIMEOUT_MS 1000UL
 #define PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET 1024UL
+#define PEAK_JIT_DEFAULT_PENDING_CAPACITY 4096UL
+#define PEAK_JIT_MAX_PENDING_CAPACITY 65536UL
 #ifdef PEAK_ENABLE_TEST_HOOKS
 #define PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV "PEAK_JIT_TEST_ATTACH_SEQUENCE"
+#define PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION_ENV \
+    "PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION"
 #endif
 
 static gboolean peak_jit_provider_enabled = FALSE;
@@ -36,20 +45,26 @@ static char* configured_jit_map_path = NULL;
 static char* configured_jit_trace_path = NULL;
 static unsigned long configured_jit_not_exec_retry_timeout_ms =
     PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS;
+static unsigned long configured_jit_attach_retry_timeout_ms =
+    PEAK_JIT_DEFAULT_ATTACH_RETRY_TIMEOUT_MS;
 static unsigned long configured_jit_drain_record_budget =
     PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET;
+static unsigned long configured_jit_pending_capacity =
+    PEAK_JIT_DEFAULT_PENDING_CAPACITY;
 static PeakEnvWarningState peak_jit_retry_timeout_warning_emitted;
+static PeakEnvWarningState peak_jit_attach_retry_timeout_warning_emitted;
 static PeakEnvWarningState peak_jit_drain_budget_warning_emitted;
+static PeakEnvWarningState peak_jit_pending_capacity_warning_emitted;
 static char* peak_jit_perfmap_path = NULL;
 static off_t peak_jit_perfmap_offset = 0;
 static gboolean peak_jit_perfmap_identity_known = FALSE;
 static dev_t peak_jit_perfmap_dev = 0;
 static ino_t peak_jit_perfmap_ino = 0;
 static off_t peak_jit_perfmap_last_size = 0;
-static GPtrArray* peak_jit_pending_records = NULL;
 #ifdef PEAK_ENABLE_TEST_HOOKS
 static unsigned int peak_jit_test_attach_sequence_index = 0;
 static char* configured_jit_test_attach_sequence = NULL;
+static unsigned long peak_jit_test_fail_pending_allocation_remaining = 0;
 #endif
 
 typedef enum {
@@ -58,11 +73,31 @@ typedef enum {
 } PeakJitPendingKind;
 
 typedef struct {
+    uint64_t provider_generation;
     uintptr_t address;
     size_t size;
     char* name;
-    double not_exec_started_at;
+    double created_at;
+    double last_attempt_at;
+    uint64_t attempt_count;
+    PeakJitPendingKind pending_kind;
 } PeakJitPendingRecord;
+
+typedef enum {
+    PEAK_JIT_PENDING_ADD_OK = 0,
+    PEAK_JIT_PENDING_ADD_DUPLICATE,
+    PEAK_JIT_PENDING_ADD_QUEUE_FULL,
+    PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED
+} PeakJitPendingAddResult;
+
+static PeakJitPendingRecord** peak_jit_pending_records = NULL;
+static size_t peak_jit_pending_record_count = 0;
+static uint64_t peak_jit_provider_generation = 0;
+static _Atomic uint64_t peak_jit_pending_queue_full = 0;
+static _Atomic uint64_t peak_jit_non_executable_timeout = 0;
+static _Atomic uint64_t peak_jit_attach_retry_timeout = 0;
+static _Atomic uint64_t peak_jit_allocation_failure = 0;
+static _Atomic uint64_t peak_jit_pending_high_water = 0;
 
 static gboolean
 peak_jit_env_truthy(const char* value)
@@ -108,11 +143,12 @@ static unsigned long
 peak_jit_parse_ulong_env(const char* name,
                          const char* unit,
                          unsigned long fallback,
+                         unsigned long maximum,
                          bool zero_allowed,
                          PeakEnvWarningState* warning_emitted)
 {
     PeakEnvUnsignedSchema schema = {
-        name, unit, fallback, zero_allowed ? 0UL : 1UL, ULONG_MAX,
+        name, unit, fallback, zero_allowed ? 0UL : 1UL, maximum,
         zero_allowed, warning_emitted, false,
     };
 
@@ -183,6 +219,7 @@ peak_jit_trace(const char* event,
     peak_jit_trace_csv_field(fp, name);
     fprintf(fp, ",0x%" PRIxPTR ",%zu,", address, size);
     peak_jit_trace_csv_field(fp, result);
+    fprintf(fp, ",%" PRIu64, peak_jit_provider_generation);
     fputc('\n', fp);
     fclose(fp);
 }
@@ -346,6 +383,32 @@ peak_jit_drain_record_budget(void)
     return configured_jit_drain_record_budget;
 }
 
+static unsigned long
+peak_jit_attach_retry_timeout_ms(void)
+{
+    return configured_jit_attach_retry_timeout_ms;
+}
+
+static void
+peak_jit_provider_reset_diagnostics(void)
+{
+    atomic_store_explicit(&peak_jit_pending_queue_full,
+                          0,
+                          memory_order_relaxed);
+    atomic_store_explicit(&peak_jit_non_executable_timeout,
+                          0,
+                          memory_order_relaxed);
+    atomic_store_explicit(&peak_jit_attach_retry_timeout,
+                          0,
+                          memory_order_relaxed);
+    atomic_store_explicit(&peak_jit_allocation_failure,
+                          0,
+                          memory_order_relaxed);
+    atomic_store_explicit(&peak_jit_pending_high_water,
+                          0,
+                          memory_order_relaxed);
+}
+
 static void
 peak_jit_pending_record_free(gpointer data)
 {
@@ -359,37 +422,73 @@ peak_jit_pending_record_free(gpointer data)
     g_free(record);
 }
 
-static GPtrArray*
+static gboolean
 peak_jit_pending_records_ensure(void)
 {
     if (peak_jit_pending_records == NULL) {
+#ifdef PEAK_ENABLE_TEST_HOOKS
+        if (peak_jit_test_fail_pending_allocation_remaining > 0) {
+            peak_jit_test_fail_pending_allocation_remaining--;
+            atomic_fetch_add_explicit(&peak_jit_allocation_failure,
+                                      1,
+                                      memory_order_relaxed);
+            return FALSE;
+        }
+#endif
         peak_jit_pending_records =
-            g_ptr_array_new_with_free_func(peak_jit_pending_record_free);
+            g_try_new0(PeakJitPendingRecord*, configured_jit_pending_capacity);
+        if (peak_jit_pending_records == NULL) {
+            atomic_fetch_add_explicit(&peak_jit_allocation_failure,
+                                      1,
+                                      memory_order_relaxed);
+            return FALSE;
+        }
     }
 
-    return peak_jit_pending_records;
+    return TRUE;
 }
 
 static void
 peak_jit_pending_records_clear(void)
 {
-    if (peak_jit_pending_records != NULL) {
-        g_ptr_array_set_size(peak_jit_pending_records, 0);
+    for (size_t i = 0; i < peak_jit_pending_record_count; i++) {
+        peak_jit_pending_record_free(peak_jit_pending_records[i]);
+        peak_jit_pending_records[i] = NULL;
     }
+    peak_jit_pending_record_count = 0;
+}
+
+static void
+peak_jit_provider_advance_generation(const char* reason)
+{
+    peak_jit_pending_records_clear();
+    peak_jit_provider_generation++;
+    if (peak_jit_provider_generation == 0) {
+        peak_jit_provider_generation = 1;
+    }
+    peak_jit_trace("provider-generation",
+                   "perfmap",
+                   peak_jit_perfmap_path,
+                   0,
+                   0,
+                   reason);
 }
 
 static PeakJitPendingRecord*
-peak_jit_pending_record_find(uintptr_t address, size_t size, const char* name)
+peak_jit_pending_record_find(uint64_t provider_generation,
+                             uintptr_t address,
+                             size_t size,
+                             const char* name)
 {
     if (peak_jit_pending_records == NULL || name == NULL) {
         return NULL;
     }
 
-    for (guint i = 0; i < peak_jit_pending_records->len; i++) {
-        PeakJitPendingRecord* record =
-            g_ptr_array_index(peak_jit_pending_records, i);
+    for (size_t i = 0; i < peak_jit_pending_record_count; i++) {
+        PeakJitPendingRecord* record = peak_jit_pending_records[i];
 
-        if (record->address == address &&
+        if (record->provider_generation == provider_generation &&
+            record->address == address &&
             record->size == size &&
             strcmp(record->name, name) == 0) {
             return record;
@@ -399,7 +498,7 @@ peak_jit_pending_record_find(uintptr_t address, size_t size, const char* name)
     return NULL;
 }
 
-static void
+static PeakJitPendingAddResult
 peak_jit_pending_record_add(PeakJitPendingKind kind,
                             uintptr_t address,
                             size_t size,
@@ -408,35 +507,121 @@ peak_jit_pending_record_add(PeakJitPendingKind kind,
     PeakJitPendingRecord* record;
 
     if (name == NULL || name[0] == '\0') {
-        return;
+        return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
     }
 
-    record = peak_jit_pending_record_find(address, size, name);
+    record = peak_jit_pending_record_find(peak_jit_provider_generation,
+                                          address,
+                                          size,
+                                          name);
     if (record != NULL) {
-        if (kind == PEAK_JIT_PENDING_NOT_EXECUTABLE &&
-            record->not_exec_started_at <= 0.0) {
-            record->not_exec_started_at = peak_second();
-        }
-        return;
+        return PEAK_JIT_PENDING_ADD_DUPLICATE;
     }
 
-    record = g_new0(PeakJitPendingRecord, 1);
+    if (peak_jit_pending_record_count >= configured_jit_pending_capacity) {
+        atomic_fetch_add_explicit(&peak_jit_pending_queue_full,
+                                  1,
+                                  memory_order_relaxed);
+        return PEAK_JIT_PENDING_ADD_QUEUE_FULL;
+    }
+    if (!peak_jit_pending_records_ensure()) {
+        return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
+    }
+
+    record = g_try_new0(PeakJitPendingRecord, 1);
+    if (record == NULL) {
+        atomic_fetch_add_explicit(&peak_jit_allocation_failure,
+                                  1,
+                                  memory_order_relaxed);
+        return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
+    }
+    size_t name_size = strlen(name) + 1;
+    record->name = g_try_malloc(name_size);
+    if (record->name == NULL) {
+        g_free(record);
+        atomic_fetch_add_explicit(&peak_jit_allocation_failure,
+                                  1,
+                                  memory_order_relaxed);
+        return PEAK_JIT_PENDING_ADD_ALLOCATION_FAILED;
+    }
+    memcpy(record->name, name, name_size);
+    record->provider_generation = peak_jit_provider_generation;
     record->address = address;
     record->size = size;
-    record->name = g_strdup(name);
-    record->not_exec_started_at =
-        kind == PEAK_JIT_PENDING_NOT_EXECUTABLE ? peak_second() : 0.0;
+    record->created_at = peak_second();
+    record->last_attempt_at = record->created_at;
+    record->attempt_count = 1;
+    record->pending_kind = kind;
 
-    g_ptr_array_add(peak_jit_pending_records_ensure(), record);
+    peak_jit_pending_records[peak_jit_pending_record_count++] = record;
+    uint64_t previous_high_water =
+        atomic_load_explicit(&peak_jit_pending_high_water,
+                             memory_order_relaxed);
+    while (previous_high_water < peak_jit_pending_record_count &&
+           !atomic_compare_exchange_weak_explicit(
+               &peak_jit_pending_high_water,
+               &previous_high_water,
+               peak_jit_pending_record_count,
+               memory_order_relaxed,
+               memory_order_relaxed)) {
+    }
+    return PEAK_JIT_PENDING_ADD_OK;
 }
 
 static void
-peak_jit_pending_record_remove_index(guint index)
+peak_jit_pending_record_remove_index(size_t index)
 {
     if (peak_jit_pending_records != NULL &&
-        index < peak_jit_pending_records->len) {
-        g_ptr_array_remove_index(peak_jit_pending_records, index);
+        index < peak_jit_pending_record_count) {
+        peak_jit_pending_record_free(peak_jit_pending_records[index]);
+        peak_jit_pending_record_count--;
+        if (index < peak_jit_pending_record_count) {
+            memmove(&peak_jit_pending_records[index],
+                    &peak_jit_pending_records[index + 1],
+                    (peak_jit_pending_record_count - index) *
+                        sizeof(*peak_jit_pending_records));
+        }
+        peak_jit_pending_records[peak_jit_pending_record_count] = NULL;
     }
+}
+
+static void
+peak_jit_pending_records_expire(void)
+{
+    uint64_t non_executable = 0;
+    uint64_t attach_retry = 0;
+
+    for (size_t i = 0; i < peak_jit_pending_record_count; i++) {
+        if (peak_jit_pending_records[i]->pending_kind ==
+            PEAK_JIT_PENDING_ATTACH_RETRY) {
+            attach_retry++;
+        } else {
+            non_executable++;
+        }
+    }
+    if (non_executable != 0) {
+        atomic_fetch_add_explicit(&peak_jit_non_executable_timeout,
+                                  non_executable,
+                                  memory_order_relaxed);
+        peak_jit_trace("perfmap-record",
+                       "perfmap",
+                       "<pending>",
+                       0,
+                       (size_t)non_executable,
+                       "not-executable-timeout");
+    }
+    if (attach_retry != 0) {
+        atomic_fetch_add_explicit(&peak_jit_attach_retry_timeout,
+                                  attach_retry,
+                                  memory_order_relaxed);
+        peak_jit_trace("perfmap-record",
+                       "perfmap",
+                       "<pending>",
+                       0,
+                       (size_t)attach_retry,
+                       "attach-retry-timeout");
+    }
+    peak_jit_pending_records_clear();
 }
 
 static gboolean
@@ -471,6 +656,11 @@ peak_jit_test_forced_attach_result(PeakDynamicAttachResult* result_out)
 
     if (sequence == NULL || sequence[0] == '\0') {
         return FALSE;
+    }
+    if (g_ascii_strcasecmp(sequence, "always-retry") == 0) {
+        peak_jit_test_attach_sequence_index++;
+        *result_out = PEAK_DYNAMIC_ATTACH_RETRY;
+        return TRUE;
     }
 
     parts = g_strsplit(sequence, ",", -1);
@@ -528,20 +718,47 @@ peak_jit_init_runtime_config_once(void)
         peak_jit_parse_ulong_env(PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS_ENV,
                                  "milliseconds",
                                  PEAK_JIT_DEFAULT_NOT_EXEC_RETRY_TIMEOUT_MS,
+                                 ULONG_MAX,
                                  true,
                                  &peak_jit_retry_timeout_warning_emitted);
+    configured_jit_attach_retry_timeout_ms =
+        peak_jit_parse_ulong_env(PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS_ENV,
+                                 "milliseconds",
+                                 PEAK_JIT_DEFAULT_ATTACH_RETRY_TIMEOUT_MS,
+                                 ULONG_MAX,
+                                 true,
+                                 &peak_jit_attach_retry_timeout_warning_emitted);
     budget =
         peak_jit_parse_ulong_env(PEAK_JIT_DRAIN_RECORD_BUDGET_ENV,
                                  "records",
                                  PEAK_JIT_DEFAULT_DRAIN_RECORD_BUDGET,
+                                 ULONG_MAX,
                                  false,
                                  &peak_jit_drain_budget_warning_emitted);
     configured_jit_drain_record_budget = budget;
+    configured_jit_pending_capacity =
+        peak_jit_parse_ulong_env(PEAK_JIT_PENDING_CAPACITY_ENV,
+                                 "records",
+                                 PEAK_JIT_DEFAULT_PENDING_CAPACITY,
+                                 PEAK_JIT_MAX_PENDING_CAPACITY,
+                                 false,
+                                 &peak_jit_pending_capacity_warning_emitted);
 #ifdef PEAK_ENABLE_TEST_HOOKS
     const char* attach_sequence =
         g_getenv(PEAK_JIT_TEST_ATTACH_SEQUENCE_ENV);
     if (attach_sequence != NULL && attach_sequence[0] != '\0') {
         configured_jit_test_attach_sequence = g_strdup(attach_sequence);
+    }
+    const char* fail_pending_allocation =
+        g_getenv(PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION_ENV);
+    if (fail_pending_allocation != NULL &&
+        fail_pending_allocation[0] != '\0') {
+        char* end = NULL;
+        errno = 0;
+        unsigned long parsed = strtoul(fail_pending_allocation, &end, 10);
+        if (errno == 0 && end != fail_pending_allocation && *end == '\0') {
+            peak_jit_test_fail_pending_allocation_remaining = parsed;
+        }
     }
 #endif
 }
@@ -569,7 +786,8 @@ peak_jit_attach_perfmap_symbol(const char* name, uintptr_t address, size_t size)
     return peak_general_listener_dynamic_attach_symbol(name,
                                                        (gpointer)address,
                                                        size,
-                                                       "perfmap");
+                                                       "perfmap",
+                                                       peak_jit_provider_generation);
 }
 
 static const char*
@@ -590,24 +808,19 @@ peak_jit_attach_result_string(PeakDynamicAttachResult result)
 }
 
 static gboolean
-peak_jit_pending_not_exec_timed_out(PeakJitPendingRecord* record,
-                                    gboolean force_not_exec_timeout)
+peak_jit_pending_record_timed_out(const PeakJitPendingRecord* record,
+                                  gboolean force_not_exec_timeout)
 {
-    double now;
     unsigned long timeout_ms;
 
     if (force_not_exec_timeout) {
         return TRUE;
     }
 
-    if (record->not_exec_started_at <= 0.0) {
-        record->not_exec_started_at = peak_second();
-        return FALSE;
-    }
-
-    now = peak_second();
-    timeout_ms = peak_jit_not_exec_retry_timeout_ms();
-    return (now - record->not_exec_started_at) * 1000.0 >=
+    timeout_ms = record->pending_kind == PEAK_JIT_PENDING_NOT_EXECUTABLE
+                     ? peak_jit_not_exec_retry_timeout_ms()
+                     : peak_jit_attach_retry_timeout_ms();
+    return (peak_second() - record->created_at) * 1000.0 >=
            (double)timeout_ms;
 }
 
@@ -618,13 +831,12 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
     gboolean pending = FALSE;
 
     if (peak_jit_pending_records == NULL ||
-        peak_jit_pending_records->len == 0) {
+        peak_jit_pending_record_count == 0) {
         return FALSE;
     }
 
-    for (guint i = 0; i < peak_jit_pending_records->len;) {
-        PeakJitPendingRecord* record =
-            g_ptr_array_index(peak_jit_pending_records, i);
+    for (size_t i = 0; i < peak_jit_pending_record_count;) {
+        PeakJitPendingRecord* record = peak_jit_pending_records[i];
         PeakDynamicAttachResult attach_result;
 
         if (budget != NULL) {
@@ -634,20 +846,33 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
             }
             (*budget)--;
         }
+        record->last_attempt_at = peak_second();
+        record->attempt_count++;
 
         if (!peak_jit_range_is_executable(record->address, record->size)) {
-            gboolean timed_out =
-                peak_jit_pending_not_exec_timed_out(record,
-                                                    force_not_exec_timeout);
+            gboolean timed_out = peak_jit_pending_record_timed_out(
+                record,
+                force_not_exec_timeout);
 
+            const char* timeout_result =
+                record->pending_kind == PEAK_JIT_PENDING_ATTACH_RETRY
+                    ? "attach-retry-timeout"
+                    : "not-executable-timeout";
             peak_jit_trace("perfmap-record",
                            "perfmap",
                            record->name,
                            record->address,
                            record->size,
-                           timed_out ? "not-executable-timeout" :
+                           timed_out ? timeout_result :
                                        "not-executable-retry");
             if (timed_out) {
+                _Atomic uint64_t* timeout_counter =
+                    record->pending_kind == PEAK_JIT_PENDING_ATTACH_RETRY
+                        ? &peak_jit_attach_retry_timeout
+                        : &peak_jit_non_executable_timeout;
+                atomic_fetch_add_explicit(timeout_counter,
+                                          1,
+                                          memory_order_relaxed);
                 peak_jit_pending_record_remove_index(i);
                 continue;
             }
@@ -667,6 +892,25 @@ peak_jit_provider_retry_pending_records(gboolean force_not_exec_timeout,
                        record->size,
                        peak_jit_attach_result_string(attach_result));
         if (attach_result == PEAK_DYNAMIC_ATTACH_RETRY) {
+            if (record->pending_kind == PEAK_JIT_PENDING_NOT_EXECUTABLE) {
+                record->pending_kind = PEAK_JIT_PENDING_ATTACH_RETRY;
+                record->created_at = peak_second();
+            }
+            if (peak_jit_pending_record_timed_out(
+                    record,
+                    force_not_exec_timeout)) {
+                atomic_fetch_add_explicit(&peak_jit_attach_retry_timeout,
+                                          1,
+                                          memory_order_relaxed);
+                peak_jit_trace("perfmap-record",
+                               "perfmap",
+                               record->name,
+                               record->address,
+                               record->size,
+                               "attach-retry-timeout");
+                peak_jit_pending_record_remove_index(i);
+                continue;
+            }
             pending = TRUE;
             i++;
             continue;
@@ -686,38 +930,49 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     off_t committed_offset;
     gboolean pending = FALSE;
     unsigned long budget = peak_jit_drain_record_budget();
+    unsigned long retry_budget = budget > 1 ? budget / 2 : 0;
+    unsigned long initial_retry_budget = retry_budget;
     struct stat st;
 
     pending |= peak_jit_provider_retry_pending_records(force_not_exec_timeout,
-                                                       &budget);
-    if (budget == 0) {
-        return TRUE;
-    }
+                                                       &retry_budget);
+    budget -= initial_retry_budget - retry_budget;
 
     if (peak_jit_perfmap_path == NULL) {
-        return pending;
+        pending |= peak_jit_provider_retry_pending_records(
+            force_not_exec_timeout,
+            &budget);
+        return pending || peak_jit_pending_record_count != 0;
     }
 
     fp = fopen(peak_jit_perfmap_path, "r");
     if (fp == NULL) {
-        return pending;
+        pending |= peak_jit_provider_retry_pending_records(
+            force_not_exec_timeout,
+            &budget);
+        return pending || peak_jit_pending_record_count != 0;
     }
 
     if (fstat(fileno(fp), &st) == 0) {
-        if (peak_jit_perfmap_identity_known &&
+        gboolean source_replaced =
+            peak_jit_perfmap_identity_known &&
             (st.st_dev != peak_jit_perfmap_dev ||
-             st.st_ino != peak_jit_perfmap_ino)) {
+             st.st_ino != peak_jit_perfmap_ino);
+        gboolean source_truncated =
+            peak_jit_perfmap_identity_known && !source_replaced &&
+            (peak_jit_perfmap_offset > st.st_size ||
+             st.st_size < peak_jit_perfmap_last_size);
+
+        if (source_replaced) {
             peak_jit_perfmap_offset = 0;
-            peak_jit_pending_records_clear();
+            peak_jit_provider_advance_generation("source-replaced");
+        } else if (source_truncated) {
+            peak_jit_perfmap_offset = 0;
+            peak_jit_provider_advance_generation("source-truncated");
         }
         peak_jit_perfmap_identity_known = TRUE;
         peak_jit_perfmap_dev = st.st_dev;
         peak_jit_perfmap_ino = st.st_ino;
-        if (peak_jit_perfmap_offset > st.st_size ||
-            st.st_size < peak_jit_perfmap_last_size) {
-            peak_jit_perfmap_offset = 0;
-            peak_jit_pending_records_clear();
-        }
         peak_jit_perfmap_last_size = st.st_size;
     }
 
@@ -725,12 +980,12 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         off_t end = ftello(fp);
         if (end >= 0 && peak_jit_perfmap_offset > end) {
             peak_jit_perfmap_offset = 0;
-            peak_jit_pending_records_clear();
+            peak_jit_provider_advance_generation("source-rewound");
         }
     }
     if (fseeko(fp, peak_jit_perfmap_offset, SEEK_SET) != 0) {
         peak_jit_perfmap_offset = 0;
-        peak_jit_pending_records_clear();
+        peak_jit_provider_advance_generation("source-seek-reset");
         (void)fseeko(fp, 0, SEEK_SET);
     }
 
@@ -793,11 +1048,18 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
                                matches_target ? "not-executable-retry" :
                                                 "not-executable");
             if (matches_target && !force_not_exec_timeout) {
-                peak_jit_pending_record_add(PEAK_JIT_PENDING_NOT_EXECUTABLE,
-                                            address,
-                                            size,
-                                            name);
-                pending = TRUE;
+                PeakJitPendingAddResult add_result =
+                    peak_jit_pending_record_add(
+                        PEAK_JIT_PENDING_NOT_EXECUTABLE,
+                        address,
+                        size,
+                        name);
+                pending |= add_result == PEAK_JIT_PENDING_ADD_OK ||
+                           add_result == PEAK_JIT_PENDING_ADD_DUPLICATE;
+            } else if (matches_target && force_not_exec_timeout) {
+                atomic_fetch_add_explicit(&peak_jit_non_executable_timeout,
+                                          1,
+                                          memory_order_relaxed);
             }
             if (next_offset >= 0) {
                 committed_offset = next_offset;
@@ -813,11 +1075,26 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
                        size,
                        peak_jit_attach_result_string(attach_result));
         if (attach_result == PEAK_DYNAMIC_ATTACH_RETRY) {
-            peak_jit_pending_record_add(PEAK_JIT_PENDING_ATTACH_RETRY,
-                                        address,
-                                        size,
-                                        name);
-            pending = TRUE;
+            if (force_not_exec_timeout) {
+                atomic_fetch_add_explicit(&peak_jit_attach_retry_timeout,
+                                          1,
+                                          memory_order_relaxed);
+                peak_jit_trace("perfmap-record",
+                               "perfmap",
+                               name,
+                               address,
+                               size,
+                               "attach-retry-timeout");
+            } else {
+                PeakJitPendingAddResult add_result =
+                    peak_jit_pending_record_add(
+                        PEAK_JIT_PENDING_ATTACH_RETRY,
+                        address,
+                        size,
+                        name);
+                pending |= add_result == PEAK_JIT_PENDING_ADD_OK ||
+                           add_result == PEAK_JIT_PENDING_ADD_DUPLICATE;
+            }
         }
         if (next_offset >= 0) {
             committed_offset = next_offset;
@@ -826,7 +1103,12 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
 
     peak_jit_perfmap_offset = committed_offset;
     fclose(fp);
-    return pending;
+    if (budget > 0) {
+        pending |= peak_jit_provider_retry_pending_records(
+            force_not_exec_timeout,
+            &budget);
+    }
+    return pending || peak_jit_pending_record_count != 0;
 }
 
 void
@@ -837,6 +1119,7 @@ peak_jit_provider_enable(void)
     const char* map_path = configured_jit_map_path;
 
     peak_jit_provider_disable();
+    peak_jit_provider_reset_diagnostics();
 #ifdef PEAK_ENABLE_TEST_HOOKS
     peak_jit_test_attach_sequence_index = 0;
 #endif
@@ -868,7 +1151,7 @@ peak_jit_provider_enable(void)
     peak_jit_perfmap_dev = 0;
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
-    peak_jit_pending_records_clear();
+    peak_jit_provider_advance_generation("provider-enabled");
 
     peak_jit_trace("provider-enable",
                    "perfmap",
@@ -899,6 +1182,32 @@ peak_jit_provider_is_active(void)
 }
 
 void
+peak_jit_provider_get_diagnostics(PeakJitProviderDiagnostics* diagnostics)
+{
+    if (diagnostics == NULL) {
+        return;
+    }
+
+    diagnostics->pending_queue_full =
+        atomic_load_explicit(&peak_jit_pending_queue_full,
+                             memory_order_relaxed);
+    diagnostics->non_executable_timeout =
+        atomic_load_explicit(&peak_jit_non_executable_timeout,
+                             memory_order_relaxed);
+    diagnostics->attach_retry_timeout =
+        atomic_load_explicit(&peak_jit_attach_retry_timeout,
+                             memory_order_relaxed);
+    diagnostics->allocation_failure =
+        atomic_load_explicit(&peak_jit_allocation_failure,
+                             memory_order_relaxed);
+    diagnostics->provider_generation = peak_jit_provider_generation;
+    diagnostics->pending_count = peak_jit_pending_record_count;
+    diagnostics->pending_high_water =
+        atomic_load_explicit(&peak_jit_pending_high_water,
+                             memory_order_relaxed);
+}
+
+void
 peak_jit_provider_disable(void)
 {
     peak_jit_provider_enabled = FALSE;
@@ -909,6 +1218,8 @@ peak_jit_provider_disable(void)
     peak_jit_perfmap_ino = 0;
     peak_jit_perfmap_last_size = 0;
     peak_jit_pending_records_clear();
+    g_free(peak_jit_pending_records);
+    peak_jit_pending_records = NULL;
     g_free(peak_jit_perfmap_path);
     peak_jit_perfmap_path = NULL;
 }
@@ -937,5 +1248,6 @@ peak_jit_provider_drain_pending(void)
 gboolean
 peak_jit_provider_drain_pending_force_not_exec_timeout(void)
 {
+    peak_jit_pending_records_expire();
     return peak_jit_provider_drain_pending_with_mode(TRUE);
 }

--- a/src/jit_provider.c
+++ b/src/jit_provider.c
@@ -1052,6 +1052,7 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
     unsigned long budget = peak_jit_drain_record_budget();
     gboolean single_budget = budget == 1;
     gboolean metadata_consumed = FALSE;
+    gboolean source_reset_pending = FALSE;
     struct stat st;
 
     if (peak_jit_perfmap_path == NULL) {
@@ -1268,16 +1269,25 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
         peak_jit_test_wait_before_final_stat();
     }
 #endif
-    if (fstat(fileno(fp), &st) == 0) {
-        if (peak_jit_perfmap_identity_known &&
-            st.st_dev == peak_jit_perfmap_dev &&
-            st.st_ino == peak_jit_perfmap_ino &&
+    if (stat(peak_jit_perfmap_path, &st) == 0) {
+        gboolean source_replaced =
+            peak_jit_perfmap_identity_known &&
+            (st.st_dev != peak_jit_perfmap_dev ||
+             st.st_ino != peak_jit_perfmap_ino);
+        gboolean source_truncated =
+            peak_jit_perfmap_identity_known && !source_replaced &&
             (peak_jit_perfmap_offset > st.st_size ||
-             st.st_size < peak_jit_perfmap_last_size)) {
+             st.st_size < peak_jit_perfmap_last_size);
+        if (source_replaced || source_truncated) {
             peak_jit_perfmap_offset = 0;
             peak_jit_provider_advance_generation(
-                "source-truncated-during-drain");
+                source_replaced ? "source-replaced-during-drain" :
+                                  "source-truncated-during-drain");
+            source_reset_pending = TRUE;
         }
+        peak_jit_perfmap_identity_known = TRUE;
+        peak_jit_perfmap_dev = st.st_dev;
+        peak_jit_perfmap_ino = st.st_ino;
         peak_jit_perfmap_last_size = st.st_size;
     }
 #ifdef PEAK_ENABLE_TEST_HOOKS
@@ -1298,7 +1308,8 @@ peak_jit_provider_drain_perfmap(gboolean force_not_exec_timeout)
             peak_jit_single_budget_retry_turn = FALSE;
         }
     }
-    return pending || peak_jit_pending_record_count != 0;
+    return source_reset_pending || pending ||
+           peak_jit_pending_record_count != 0;
 }
 
 void

--- a/test/detach_runtime/run_detach_milc_like_ab_check.py
+++ b/test/detach_runtime/run_detach_milc_like_ab_check.py
@@ -29,6 +29,13 @@ STATS_CSV_FIELDS = (
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
+    "jit_pending_queue_full",
+    "jit_non_executable_timeout",
+    "jit_attach_retry_timeout",
+    "jit_allocation_failure",
+    "jit_provider_generation",
+    "jit_pending_count",
+    "jit_pending_high_water",
     "capability_requested",
     "capability_compiled",
     "capability_active",
@@ -47,7 +54,8 @@ PEAK_STATS_NAME_RE = re.compile(
 )
 STATS_CSV_METRIC_FIELDS = STATS_CSV_FIELDS[4:11]
 STATS_CSV_DIAGNOSTIC_FIELDS = ("dropped_calls", "dropped_threads")
-STATS_CSV_CAPABILITY_FIELDS = STATS_CSV_FIELDS[13:]
+STATS_CSV_JIT_FIELDS = STATS_CSV_FIELDS[13:20]
+STATS_CSV_CAPABILITY_FIELDS = STATS_CSV_FIELDS[20:]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
 CAPABILITY_METADATA_FUNCTION_RE = re.compile(
     r"^PEAK_CAPABILITY_[a-z-]+$"
@@ -957,6 +965,11 @@ def validated_profiled_stats_rows(handle, allowed_targets, rank_count=1):
                     raise AssertionError(
                         f"invalid metadata metric {field}: {row}"
                     ) from exc
+            for field in STATS_CSV_JIT_FIELDS:
+                if row[field] != "0":
+                    raise AssertionError(
+                        f"nonzero capability JIT diagnostic {field}: {row}"
+                    )
             for field in STATS_CSV_CAPABILITY_FIELDS:
                 if not re.fullmatch(r"[0-9]+", row[field]):
                     raise AssertionError(
@@ -981,6 +994,11 @@ def validated_profiled_stats_rows(handle, allowed_targets, rank_count=1):
                 if not re.fullmatch(r"[0-9]+", row[field]):
                     raise AssertionError(
                         f"invalid accounting diagnostic {field}: {row}"
+                    )
+            for field in STATS_CSV_JIT_FIELDS:
+                if row[field] != "0":
+                    raise AssertionError(
+                        f"nonzero accounting JIT diagnostic {field}: {row}"
                     )
             diagnostics = tuple(
                 int(row[field]) for field in STATS_CSV_DIAGNOSTIC_FIELDS
@@ -1026,6 +1044,11 @@ def validated_profiled_stats_rows(handle, allowed_targets, rank_count=1):
             if not re.fullmatch(r"[0-9]+", row[field]):
                 raise AssertionError(
                     f"invalid accounting diagnostic {field}: {row}"
+                )
+        for field in STATS_CSV_JIT_FIELDS:
+            if row[field] != "0":
+                raise AssertionError(
+                    f"nonzero target JIT diagnostic {field}: {row}"
                 )
         row_diagnostics = tuple(
             int(row[field]) for field in STATS_CSV_DIAGNOSTIC_FIELDS

--- a/test/detach_runtime/run_detach_milc_like_ab_check.py
+++ b/test/detach_runtime/run_detach_milc_like_ab_check.py
@@ -29,13 +29,6 @@ STATS_CSV_FIELDS = (
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
-    "jit_pending_queue_full",
-    "jit_non_executable_timeout",
-    "jit_attach_retry_timeout",
-    "jit_allocation_failure",
-    "jit_provider_generation",
-    "jit_pending_count",
-    "jit_pending_high_water",
     "capability_requested",
     "capability_compiled",
     "capability_active",
@@ -47,6 +40,13 @@ STATS_CSV_FIELDS = (
     "cuda_installed_apis",
     "cuda_failed_apis",
     "degraded_mask",
+    "jit_pending_queue_full",
+    "jit_non_executable_timeout",
+    "jit_attach_retry_timeout",
+    "jit_allocation_failure",
+    "jit_provider_generation",
+    "jit_pending_count",
+    "jit_pending_high_water",
 )
 PEAK_STATS_NAME_RE = re.compile(
     r"^milc-like-stats-j[A-Za-z0-9_-]+-s[A-Za-z0-9_-]+-"
@@ -54,8 +54,8 @@ PEAK_STATS_NAME_RE = re.compile(
 )
 STATS_CSV_METRIC_FIELDS = STATS_CSV_FIELDS[4:11]
 STATS_CSV_DIAGNOSTIC_FIELDS = ("dropped_calls", "dropped_threads")
-STATS_CSV_JIT_FIELDS = STATS_CSV_FIELDS[13:20]
-STATS_CSV_CAPABILITY_FIELDS = STATS_CSV_FIELDS[20:]
+STATS_CSV_CAPABILITY_FIELDS = STATS_CSV_FIELDS[13:24]
+STATS_CSV_JIT_FIELDS = STATS_CSV_FIELDS[24:31]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
 CAPABILITY_METADATA_FUNCTION_RE = re.compile(
     r"^PEAK_CAPABILITY_[a-z-]+$"

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -86,13 +86,6 @@ STATS_FIELDS = [
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
-    "jit_pending_queue_full",
-    "jit_non_executable_timeout",
-    "jit_attach_retry_timeout",
-    "jit_allocation_failure",
-    "jit_provider_generation",
-    "jit_pending_count",
-    "jit_pending_high_water",
     "capability_requested",
     "capability_compiled",
     "capability_active",
@@ -104,9 +97,16 @@ STATS_FIELDS = [
     "cuda_installed_apis",
     "cuda_failed_apis",
     "degraded_mask",
+    "jit_pending_queue_full",
+    "jit_non_executable_timeout",
+    "jit_attach_retry_timeout",
+    "jit_allocation_failure",
+    "jit_provider_generation",
+    "jit_pending_count",
+    "jit_pending_high_water",
 ]
 STATS_ACCOUNTING_FIELDS = ["dropped_calls", "dropped_threads"]
-STATS_JIT_FIELDS = STATS_FIELDS[13:20]
+STATS_JIT_FIELDS = STATS_FIELDS[24:31]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
 CAPABILITY_METADATA_FUNCTION_RE = re.compile(r"^PEAK_CAPABILITY_[a-z-]+$")
 CAPABILITY_METADATA_FUNCTIONS = {

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -233,15 +233,15 @@ def require_valid_accounting_diagnostics(name, rows):
         if row.get("function") == ACCOUNTING_DIAGNOSTICS_FUNCTION:
             continue
         function = row.get("function", "")
+        for field in STATS_JIT_FIELDS:
+            if row.get(field, "") != "0":
+                raise AssertionError(
+                    f"nonzero row JIT diagnostic {field}: {name}"
+                )
         if (CAPABILITY_METADATA_FUNCTION_RE.fullmatch(function) or
                 function in CAPABILITY_METADATA_FUNCTIONS):
             continue
         values = []
-        for field in STATS_JIT_FIELDS:
-            if row.get(field, "") != "0":
-                raise AssertionError(
-                    f"nonzero target JIT diagnostic {field}: {name}"
-                )
         for field in STATS_ACCOUNTING_FIELDS:
             value = row.get(field, "") or ""
             if not re.fullmatch(r"[0-9]+", value):

--- a/test/dgemm_mpi/run_mpi_lifecycle_check.py
+++ b/test/dgemm_mpi/run_mpi_lifecycle_check.py
@@ -86,6 +86,13 @@ STATS_FIELDS = [
     "overhead_s",
     "dropped_calls",
     "dropped_threads",
+    "jit_pending_queue_full",
+    "jit_non_executable_timeout",
+    "jit_attach_retry_timeout",
+    "jit_allocation_failure",
+    "jit_provider_generation",
+    "jit_pending_count",
+    "jit_pending_high_water",
     "capability_requested",
     "capability_compiled",
     "capability_active",
@@ -99,6 +106,7 @@ STATS_FIELDS = [
     "degraded_mask",
 ]
 STATS_ACCOUNTING_FIELDS = ["dropped_calls", "dropped_threads"]
+STATS_JIT_FIELDS = STATS_FIELDS[13:20]
 ACCOUNTING_DIAGNOSTICS_FUNCTION = "PEAK_ACCOUNTING_DIAGNOSTICS"
 CAPABILITY_METADATA_FUNCTION_RE = re.compile(r"^PEAK_CAPABILITY_[a-z-]+$")
 CAPABILITY_METADATA_FUNCTIONS = {
@@ -211,6 +219,11 @@ def require_valid_accounting_diagnostics(name, rows):
                 raise AssertionError(
                     f"invalid accounting diagnostic {field}: {name}"
                 )
+        for field in STATS_JIT_FIELDS:
+            if row.get(field, "") != "0":
+                raise AssertionError(
+                    f"nonzero accounting JIT diagnostic {field}: {name}"
+                )
         diagnostics_values = tuple(
             int(row[field]) for field in STATS_ACCOUNTING_FIELDS
         )
@@ -224,6 +237,11 @@ def require_valid_accounting_diagnostics(name, rows):
                 function in CAPABILITY_METADATA_FUNCTIONS):
             continue
         values = []
+        for field in STATS_JIT_FIELDS:
+            if row.get(field, "") != "0":
+                raise AssertionError(
+                    f"nonzero target JIT diagnostic {field}: {name}"
+                )
         for field in STATS_ACCOUNTING_FIELDS:
             value = row.get(field, "") or ""
             if not re.fullmatch(r"[0-9]+", value):

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -279,7 +279,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             allocation-failure
             attach-retry-timeout
             truncated-generation
-            truncated-larger-generation
             replaced-generation)
         string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
         add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -273,6 +273,43 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             PASS_REGULAR_EXPRESSION "jit_profiling_check_ok"
             TIMEOUT 45)
 
+    foreach(jit_bounded_mode IN ITEMS
+            bounded-queue
+            allocation-failure
+            attach-retry-timeout
+            truncated-generation
+            replaced-generation)
+        string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
+        add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/run_jit_profiling_check.py
+                    --exe $<TARGET_FILE:test_jit_mmap_fixture>
+                    --libpeak $<TARGET_FILE:peak>
+                    --mode ${jit_bounded_mode}
+                    --iterations 1000000
+                    --timeout 30)
+        set_tests_properties(test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}
+            PROPERTIES
+                SKIP_RETURN_CODE 77
+                PASS_REGULAR_EXPRESSION "jit_profiling_check_ok"
+                TIMEOUT 45)
+    endforeach()
+
+    add_test(NAME test_jit_profiling_mmap_perfmap_shutdown_full_queue
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_jit_profiling_check.py
+                --exe $<TARGET_FILE:test_jit_mmap_fixture>
+                --libpeak $<TARGET_FILE:peak>
+                --mode shutdown-full-queue
+                --iterations 1
+                --metadata-sleep-us 0
+                --timeout 5)
+    set_tests_properties(test_jit_profiling_mmap_perfmap_shutdown_full_queue
+        PROPERTIES
+            SKIP_RETURN_CODE 77
+            PASS_REGULAR_EXPRESSION "jit_profiling_check_ok"
+            TIMEOUT 10)
+
     add_test(NAME test_jit_framework_metadata_v8_name_patterns
         COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/run_jit_framework_metadata_check.py

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -289,7 +289,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             truncated-generation
             truncated-during-drain-generation
             replaced-generation
-            pending-replaced-generation)
+            pending-replaced-generation
+            pending-replaced-during-drain
+            shutdown-truncate-rewrite)
         string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
         add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}
             COMMAND ${Python3_EXECUTABLE}

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -5,6 +5,13 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_executable(test_jit_mmap_fixture test_jit_mmap_fixture.c)
     target_compile_features(test_jit_mmap_fixture PRIVATE c_std_11)
 
+    add_test(NAME test_jit_bounded_work_invariants
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/check_jit_bounded_work.py
+                ${PROJECT_SOURCE_DIR}/src/jit_provider.c)
+    set_tests_properties(test_jit_bounded_work_invariants
+        PROPERTIES PASS_REGULAR_EXPRESSION "jit_bounded_work_ok")
+
     add_test(NAME test_jit_profiling_mmap_perfmap
         COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/run_jit_profiling_check.py
@@ -276,11 +283,13 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     foreach(jit_bounded_mode IN ITEMS
             bounded-queue
             pending-round-robin
+            pending-timeout-backlog
             allocation-failure
             attach-retry-timeout
             truncated-generation
             truncated-during-drain-generation
-            replaced-generation)
+            replaced-generation
+            pending-replaced-generation)
         string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
         add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}
             COMMAND ${Python3_EXECUTABLE}

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -275,9 +275,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
     foreach(jit_bounded_mode IN ITEMS
             bounded-queue
+            pending-round-robin
             allocation-failure
             attach-retry-timeout
             truncated-generation
+            truncated-larger-generation
             replaced-generation)
         string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
         add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}

--- a/test/jit/CMakeLists.txt
+++ b/test/jit/CMakeLists.txt
@@ -279,6 +279,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
             allocation-failure
             attach-retry-timeout
             truncated-generation
+            truncated-during-drain-generation
             replaced-generation)
         string(REPLACE "-" "_" jit_bounded_suffix "${jit_bounded_mode}")
         add_test(NAME test_jit_profiling_mmap_perfmap_${jit_bounded_suffix}

--- a/test/jit/check_jit_bounded_work.py
+++ b/test/jit/check_jit_bounded_work.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Check the fixed JIT pending queue's controller-work invariants."""
+
+import argparse
+import pathlib
+
+
+def function_body(source, name):
+    marker = f"\n{name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing {name}")
+    opening = source.find("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening : index + 1]
+    raise AssertionError(f"unterminated {name}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source")
+    args = parser.parse_args()
+    source = pathlib.Path(args.source).read_text(encoding="utf-8")
+    add = function_body(source, "peak_jit_pending_record_add")
+    remove = function_body(source, "peak_jit_pending_record_remove_index")
+
+    full = add.find(
+        "peak_jit_pending_record_count >= configured_jit_pending_capacity"
+    )
+    duplicate_scan = add.find("peak_jit_pending_record_find(")
+    if full < 0 or duplicate_scan < 0 or full >= duplicate_scan:
+        raise AssertionError("full pending queues must reject before duplicate scan")
+    if "memmove(" in remove:
+        raise AssertionError("pending removal must not shift the remaining array")
+    if (
+        "peak_jit_pending_records[index] =" not in remove
+        or "peak_jit_pending_records[peak_jit_pending_record_count]" not in remove
+    ):
+        raise AssertionError("pending removal must replace from the final slot")
+
+    print("jit_bounded_work_ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -83,8 +83,6 @@ def mode_flag(mode):
         return "--with-pending-round-robin"
     if mode == "truncated-generation":
         return "--with-truncated-generation"
-    if mode == "truncated-larger-generation":
-        return "--with-truncated-larger-generation"
     if mode == "replaced-generation":
         return "--with-replaced-generation"
     if mode == "attach-retry-timeout":
@@ -128,7 +126,6 @@ def expects_attached_record(mode):
         "allocation-failure",
         "shutdown-full-queue",
         "truncated-generation",
-        "truncated-larger-generation",
         "replaced-generation",
     )
 
@@ -153,7 +150,6 @@ def expects_positive_count(mode):
         "pending-round-robin",
         "allocation-failure",
         "truncated-generation",
-        "truncated-larger-generation",
         "replaced-generation",
     )
 
@@ -199,7 +195,6 @@ def expected_attached_records(mode):
         "two-generations",
         "two-generations-heartbeat",
         "truncated-generation",
-        "truncated-larger-generation",
         "replaced-generation",
     ):
         return 2
@@ -424,11 +419,7 @@ def run_one(args, tmpdir, mode):
                     f"symbol as one CSV field\nexpected={expected}\n"
                     f"rows={trace_rows}\ntrace={trace}\n{output}"
                 )
-        if mode in (
-            "truncated-generation",
-            "truncated-larger-generation",
-            "replaced-generation",
-        ):
+        if mode in ("truncated-generation", "replaced-generation"):
             generations = {row[7] for row in attached_records if len(row) >= 8}
             if len(generations) != 2:
                 raise AssertionError(
@@ -463,11 +454,9 @@ def run_one(args, tmpdir, mode):
         diagnostics, "jit_allocation_failure"
     ) != 1:
         raise AssertionError(f"missing allocation-failure diagnostic: {diagnostics}")
-    if mode in (
-        "truncated-generation",
-        "truncated-larger-generation",
-        "replaced-generation",
-    ) and diagnostic_int(diagnostics, "jit_provider_generation") < 2:
+    if mode in ("truncated-generation", "replaced-generation") and diagnostic_int(
+        diagnostics, "jit_provider_generation"
+    ) < 2:
         raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
         if stats_csv is None:
@@ -533,7 +522,6 @@ def main():
             "attach-retry-timeout",
             "shutdown-full-queue",
             "truncated-generation",
-            "truncated-larger-generation",
             "replaced-generation",
         ),
         default="both",

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -81,12 +81,16 @@ def mode_flag(mode):
         return "--with-bounded-queue-then-valid"
     if mode == "pending-round-robin":
         return "--with-pending-round-robin"
+    if mode == "pending-timeout-backlog":
+        return "--with-pending-timeout-backlog"
     if mode == "truncated-generation":
         return "--with-truncated-generation"
     if mode == "truncated-during-drain-generation":
         return "--with-truncated-during-drain-generation"
     if mode == "replaced-generation":
         return "--with-replaced-generation"
+    if mode == "pending-replaced-generation":
+        return "--with-pending-replaced-generation"
     if mode == "attach-retry-timeout":
         return "--with-perf-map"
     if mode == "negative":
@@ -130,6 +134,7 @@ def expects_attached_record(mode):
         "truncated-generation",
         "truncated-during-drain-generation",
         "replaced-generation",
+        "pending-replaced-generation",
     )
 
 
@@ -155,6 +160,7 @@ def expects_positive_count(mode):
         "truncated-generation",
         "truncated-during-drain-generation",
         "replaced-generation",
+        "pending-replaced-generation",
     )
 
 
@@ -184,6 +190,12 @@ def extra_env_for_mode(mode):
             "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS": "10000",
             "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
         }
+    if mode == "pending-timeout-backlog":
+        return {
+            "PEAK_JIT_PENDING_CAPACITY": "4",
+            "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS": "20",
+            "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
+        }
     if mode == "allocation-failure":
         return {"PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION": "1"}
     if mode == "attach-retry-timeout":
@@ -195,13 +207,7 @@ def extra_env_for_mode(mode):
 
 
 def expected_attached_records(mode):
-    if mode in (
-        "two-generations",
-        "two-generations-heartbeat",
-        "truncated-generation",
-        "truncated-during-drain-generation",
-        "replaced-generation",
-    ):
+    if mode in ("two-generations", "two-generations-heartbeat"):
         return 2
     return 1
 
@@ -303,6 +309,11 @@ def run_one(args, tmpdir, mode):
         extra_env = dict(extra_env)
         extra_env["PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"] = os.path.join(
             tmpdir, "pre-final-stat.barrier"
+        )
+    if mode == "pending-replaced-generation":
+        extra_env = dict(extra_env)
+        extra_env["PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER"] = os.path.join(
+            tmpdir, "pre-source-observe.barrier"
         )
     try:
         os.unlink(map_path)
@@ -435,11 +446,23 @@ def run_one(args, tmpdir, mode):
             "truncated-during-drain-generation",
             "replaced-generation",
         ):
-            generations = {row[7] for row in attached_records if len(row) >= 8}
+            refreshed_records = trace_rows_with_result(
+                trace_rows, "generation-refreshed"
+            )
+            generations = {
+                row[7]
+                for row in attached_records + refreshed_records
+                if len(row) >= 8
+            }
+            if len(refreshed_records) != 1:
+                raise AssertionError(
+                    f"{mode} did not report exactly one same-address generation "
+                    f"refresh\nrows={trace_rows}\ntrace={trace}"
+                )
             if len(generations) != 2:
                 raise AssertionError(
                     f"{mode} did not process the repeated address/name "
-                    f"as a new provider lifetime\nrows={attached_records}\ntrace={trace}"
+                    f"as a new provider lifetime\nrows={trace_rows}\ntrace={trace}"
                 )
     if mode == "attach-retry-timeout":
         trace, trace_rows = read_trace(trace_path)
@@ -452,11 +475,33 @@ def run_one(args, tmpdir, mode):
             )
         if diagnostic_int(diagnostics, "jit_attach_retry_timeout") != 1:
             raise AssertionError(f"missing attach retry timeout diagnostic: {diagnostics}")
+    if mode == "pending-timeout-backlog":
+        trace, trace_rows = read_trace(trace_path)
+        timeout_rows = trace_rows_with_result(
+            trace_rows, "not-executable-timeout"
+        )
+        backlog_end_rows = [
+            row
+            for row in trace_rows
+            if len(row) >= 7 and row[3] == "peak_jit_backlog_63"
+        ]
+        if len(timeout_rows) != 1 or len(backlog_end_rows) != 1 or not (
+            trace_rows.index(timeout_rows[0]) < trace_rows.index(backlog_end_rows[0])
+        ):
+            raise AssertionError(
+                "budget-1 pending timeout did not make progress before the "
+                f"metadata backlog reached EOF\ntrace={trace}\n{output}"
+            )
     if mode in ("bounded-queue", "shutdown-full-queue"):
         if diagnostic_int(diagnostics, "jit_pending_queue_full") < 1:
             raise AssertionError(f"missing queue-full diagnostic: {diagnostics}")
         if diagnostic_int(diagnostics, "jit_pending_high_water") != 2:
             raise AssertionError(f"pending queue exceeded configured bound: {diagnostics}")
+        trace, trace_rows = read_trace(trace_path)
+        if not trace_has_result(trace_rows, "pending-queue-full"):
+            raise AssertionError(
+                f"queue-full record did not report its final drop outcome\n{trace}"
+            )
     if mode == "pending-round-robin" and diagnostic_int(
         diagnostics, "jit_pending_high_water"
     ) != 2:
@@ -469,10 +514,18 @@ def run_one(args, tmpdir, mode):
         diagnostics, "jit_allocation_failure"
     ) != 1:
         raise AssertionError(f"missing allocation-failure diagnostic: {diagnostics}")
+    if mode == "allocation-failure":
+        trace, trace_rows = read_trace(trace_path)
+        if not trace_has_result(trace_rows, "pending-allocation-failure"):
+            raise AssertionError(
+                "allocation-failure record did not report its final drop "
+                f"outcome\n{trace}"
+            )
     if mode in (
         "truncated-generation",
         "truncated-during-drain-generation",
         "replaced-generation",
+        "pending-replaced-generation",
     ) and diagnostic_int(diagnostics, "jit_provider_generation") < 2:
         raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
@@ -541,6 +594,8 @@ def main():
             "truncated-generation",
             "truncated-during-drain-generation",
             "replaced-generation",
+            "pending-replaced-generation",
+            "pending-timeout-backlog",
         ),
         default="both",
     )

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -77,6 +77,14 @@ def mode_flag(mode):
         return "--with-malformed-then-valid"
     if mode == "overlong-then-valid":
         return "--with-overlong-then-valid"
+    if mode in ("bounded-queue", "allocation-failure", "shutdown-full-queue"):
+        return "--with-bounded-queue-then-valid"
+    if mode == "truncated-generation":
+        return "--with-truncated-generation"
+    if mode == "replaced-generation":
+        return "--with-replaced-generation"
+    if mode == "attach-retry-timeout":
+        return "--with-perf-map"
     if mode == "negative":
         return "--without-metadata"
     raise ValueError(f"unknown mode: {mode}")
@@ -111,6 +119,11 @@ def expects_attached_record(mode):
         "v8-js-csv-name",
         "v8-lazycompile-optimized",
         "two-generations-heartbeat",
+        "bounded-queue",
+        "allocation-failure",
+        "shutdown-full-queue",
+        "truncated-generation",
+        "replaced-generation",
     )
 
 
@@ -130,6 +143,10 @@ def expects_positive_count(mode):
         "v8-js-csv-name",
         "v8-lazycompile-optimized",
         "two-generations-heartbeat",
+        "bounded-queue",
+        "allocation-failure",
+        "truncated-generation",
+        "replaced-generation",
     )
 
 
@@ -147,11 +164,29 @@ def extra_env_for_mode(mode):
             "PEAK_COST": "0",
             "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
         }
+    if mode in ("bounded-queue", "shutdown-full-queue"):
+        return {
+            "PEAK_JIT_PENDING_CAPACITY": "2",
+            "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS": "10000",
+            "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
+        }
+    if mode == "allocation-failure":
+        return {"PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION": "1"}
+    if mode == "attach-retry-timeout":
+        return {
+            "PEAK_JIT_TEST_ATTACH_SEQUENCE": "always-retry",
+            "PEAK_JIT_ATTACH_RETRY_TIMEOUT_MS": "20",
+        }
     return {}
 
 
 def expected_attached_records(mode):
-    if mode in ("two-generations", "two-generations-heartbeat"):
+    if mode in (
+        "two-generations",
+        "two-generations-heartbeat",
+        "truncated-generation",
+        "replaced-generation",
+    ):
         return 2
     return 1
 
@@ -190,6 +225,20 @@ def symbol_count(rows, symbol):
         except ValueError:
             raise AssertionError(f"invalid count in stats row: {row}") from None
     return total
+
+
+def jit_diagnostics(rows):
+    matches = [row for row in rows if row.get("function") == "PEAK_JIT_DIAGNOSTICS"]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one JIT diagnostics row, got {matches}")
+    return matches[0]
+
+
+def diagnostic_int(row, name):
+    try:
+        return int(row.get(name, ""))
+    except ValueError:
+        raise AssertionError(f"invalid {name} in JIT diagnostics: {row}") from None
 
 
 def read_text(path):
@@ -290,6 +339,7 @@ def run_one(args, tmpdir, mode):
     stats_csv = find_stats_csv(stats_prefix, pid)
     rows = parse_stats_csv(stats_csv)
     count = symbol_count(rows, JIT_SYMBOL)
+    diagnostics = jit_diagnostics(rows)
     cleanup_perf_map(pid)
     try:
         os.unlink(map_path)
@@ -359,6 +409,41 @@ def run_one(args, tmpdir, mode):
                     f"symbol as one CSV field\nexpected={expected}\n"
                     f"rows={trace_rows}\ntrace={trace}\n{output}"
                 )
+        if mode in ("truncated-generation", "replaced-generation"):
+            generations = {row[7] for row in attached_records if len(row) >= 8}
+            if len(generations) != 2:
+                raise AssertionError(
+                    f"{mode} did not process the repeated address/name "
+                    f"as a new provider lifetime\nrows={attached_records}\ntrace={trace}"
+                )
+    if mode == "attach-retry-timeout":
+        trace, trace_rows = read_trace(trace_path)
+        if trace_has_result(trace_rows, "attached") or not trace_has_result(
+            trace_rows, "attach-retry-timeout"
+        ):
+            raise AssertionError(
+                "attach retry did not expire without attaching\n"
+                f"trace={trace}\n{output}"
+            )
+        if diagnostic_int(diagnostics, "jit_attach_retry_timeout") != 1:
+            raise AssertionError(f"missing attach retry timeout diagnostic: {diagnostics}")
+    if mode in ("bounded-queue", "shutdown-full-queue"):
+        if diagnostic_int(diagnostics, "jit_pending_queue_full") < 1:
+            raise AssertionError(f"missing queue-full diagnostic: {diagnostics}")
+        if diagnostic_int(diagnostics, "jit_pending_high_water") != 2:
+            raise AssertionError(f"pending queue exceeded configured bound: {diagnostics}")
+    if mode in ("stale-then-valid", "final-drain-stale-then-valid") and diagnostic_int(
+        diagnostics, "jit_non_executable_timeout"
+    ) < 1:
+        raise AssertionError(f"missing non-executable timeout diagnostic: {diagnostics}")
+    if mode == "allocation-failure" and diagnostic_int(
+        diagnostics, "jit_allocation_failure"
+    ) != 1:
+        raise AssertionError(f"missing allocation-failure diagnostic: {diagnostics}")
+    if mode in ("truncated-generation", "replaced-generation") and diagnostic_int(
+        diagnostics, "jit_provider_generation"
+    ) < 2:
+        raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
         if stats_csv is None:
             raise AssertionError(
@@ -417,6 +502,12 @@ def main():
             "v8-js-csv-name",
             "v8-lazycompile-optimized",
             "two-generations-heartbeat",
+            "bounded-queue",
+            "allocation-failure",
+            "attach-retry-timeout",
+            "shutdown-full-queue",
+            "truncated-generation",
+            "replaced-generation",
         ),
         default="both",
     )

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -83,6 +83,8 @@ def mode_flag(mode):
         return "--with-pending-round-robin"
     if mode == "truncated-generation":
         return "--with-truncated-generation"
+    if mode == "truncated-during-drain-generation":
+        return "--with-truncated-during-drain-generation"
     if mode == "replaced-generation":
         return "--with-replaced-generation"
     if mode == "attach-retry-timeout":
@@ -126,6 +128,7 @@ def expects_attached_record(mode):
         "allocation-failure",
         "shutdown-full-queue",
         "truncated-generation",
+        "truncated-during-drain-generation",
         "replaced-generation",
     )
 
@@ -150,6 +153,7 @@ def expects_positive_count(mode):
         "pending-round-robin",
         "allocation-failure",
         "truncated-generation",
+        "truncated-during-drain-generation",
         "replaced-generation",
     )
 
@@ -195,6 +199,7 @@ def expected_attached_records(mode):
         "two-generations",
         "two-generations-heartbeat",
         "truncated-generation",
+        "truncated-during-drain-generation",
         "replaced-generation",
     ):
         return 2
@@ -293,6 +298,12 @@ def run_one(args, tmpdir, mode):
     stats_prefix = os.path.join(tmpdir, f"peak-jit-{mode}")
     map_path = os.path.join(tmpdir, f"perf-{mode}.map")
     trace_path = os.path.join(tmpdir, f"jit-{mode}-trace.csv")
+    extra_env = extra_env_for_mode(mode)
+    if mode == "truncated-during-drain-generation":
+        extra_env = dict(extra_env)
+        extra_env["PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"] = os.path.join(
+            tmpdir, "pre-final-stat.barrier"
+        )
     try:
         os.unlink(map_path)
     except FileNotFoundError:
@@ -314,7 +325,7 @@ def run_one(args, tmpdir, mode):
             stats_prefix,
             map_path,
             trace_path,
-            extra_env_for_mode(mode),
+            extra_env,
         ),
         cwd=tmpdir,
         text=True,
@@ -419,7 +430,11 @@ def run_one(args, tmpdir, mode):
                     f"symbol as one CSV field\nexpected={expected}\n"
                     f"rows={trace_rows}\ntrace={trace}\n{output}"
                 )
-        if mode in ("truncated-generation", "replaced-generation"):
+        if mode in (
+            "truncated-generation",
+            "truncated-during-drain-generation",
+            "replaced-generation",
+        ):
             generations = {row[7] for row in attached_records if len(row) >= 8}
             if len(generations) != 2:
                 raise AssertionError(
@@ -454,9 +469,11 @@ def run_one(args, tmpdir, mode):
         diagnostics, "jit_allocation_failure"
     ) != 1:
         raise AssertionError(f"missing allocation-failure diagnostic: {diagnostics}")
-    if mode in ("truncated-generation", "replaced-generation") and diagnostic_int(
-        diagnostics, "jit_provider_generation"
-    ) < 2:
+    if mode in (
+        "truncated-generation",
+        "truncated-during-drain-generation",
+        "replaced-generation",
+    ) and diagnostic_int(diagnostics, "jit_provider_generation") < 2:
         raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
         if stats_csv is None:
@@ -522,6 +539,7 @@ def main():
             "attach-retry-timeout",
             "shutdown-full-queue",
             "truncated-generation",
+            "truncated-during-drain-generation",
             "replaced-generation",
         ),
         default="both",

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -91,6 +91,10 @@ def mode_flag(mode):
         return "--with-replaced-generation"
     if mode == "pending-replaced-generation":
         return "--with-pending-replaced-generation"
+    if mode == "pending-replaced-during-drain":
+        return "--with-pending-replaced-during-drain"
+    if mode == "shutdown-truncate-rewrite":
+        return "--with-shutdown-truncate-rewrite"
     if mode == "attach-retry-timeout":
         return "--with-perf-map"
     if mode == "negative":
@@ -135,6 +139,8 @@ def expects_attached_record(mode):
         "truncated-during-drain-generation",
         "replaced-generation",
         "pending-replaced-generation",
+        "pending-replaced-during-drain",
+        "shutdown-truncate-rewrite",
     )
 
 
@@ -161,6 +167,7 @@ def expects_positive_count(mode):
         "truncated-during-drain-generation",
         "replaced-generation",
         "pending-replaced-generation",
+        "pending-replaced-during-drain",
     )
 
 
@@ -305,7 +312,11 @@ def run_one(args, tmpdir, mode):
     map_path = os.path.join(tmpdir, f"perf-{mode}.map")
     trace_path = os.path.join(tmpdir, f"jit-{mode}-trace.csv")
     extra_env = extra_env_for_mode(mode)
-    if mode == "truncated-during-drain-generation":
+    if mode in (
+        "truncated-during-drain-generation",
+        "pending-replaced-during-drain",
+        "shutdown-truncate-rewrite",
+    ):
         extra_env = dict(extra_env)
         extra_env["PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"] = os.path.join(
             tmpdir, "pre-final-stat.barrier"
@@ -325,7 +336,7 @@ def run_one(args, tmpdir, mode):
         "--iterations",
         str(args.iterations),
         "--metadata-sleep-us",
-        "0" if mode in ("final-drain", "final-drain-retry", "final-drain-stale-then-valid") else str(args.metadata_sleep_us),
+        "0" if mode in ("final-drain", "final-drain-retry", "final-drain-stale-then-valid", "shutdown-truncate-rewrite") else str(args.metadata_sleep_us),
         "--symbol",
         metadata_symbol(mode),
     ]
@@ -464,6 +475,42 @@ def run_one(args, tmpdir, mode):
                     f"{mode} did not process the repeated address/name "
                     f"as a new provider lifetime\nrows={trace_rows}\ntrace={trace}"
                 )
+        if mode == "pending-replaced-during-drain":
+            retry_records = trace_rows_with_result(
+                trace_rows, "not-executable-retry"
+            )
+            if not retry_records or retry_records[0][4] == attached_records[0][4]:
+                raise AssertionError(
+                    "replacement during final validation attached the stale "
+                    f"generation address\nrows={trace_rows}\ntrace={trace}"
+                )
+        if mode == "shutdown-truncate-rewrite":
+            reset_rows = [
+                row
+                for row in trace_rows
+                if len(row) >= 7
+                and row[1] == "provider-generation"
+                and row[6] == "source-truncated-during-drain"
+            ]
+            generation_two_results = [
+                row
+                for row in trace_rows
+                if len(row) >= 8
+                and row[1] == "perfmap-record"
+                and row[3] == JIT_SYMBOL
+                and row[7] == "2"
+                and row[6] in ("attached", "generation-refreshed")
+            ]
+            if (
+                len(reset_rows) != 1
+                or len(generation_two_results) != 1
+                or trace_rows.index(reset_rows[0])
+                >= trace_rows.index(generation_two_results[0])
+            ):
+                raise AssertionError(
+                    "shutdown source reset did not trigger a second drain of "
+                    f"the rewritten metadata\nrows={trace_rows}\ntrace={trace}"
+                )
     if mode == "attach-retry-timeout":
         trace, trace_rows = read_trace(trace_path)
         if trace_has_result(trace_rows, "attached") or not trace_has_result(
@@ -526,6 +573,8 @@ def run_one(args, tmpdir, mode):
         "truncated-during-drain-generation",
         "replaced-generation",
         "pending-replaced-generation",
+        "pending-replaced-during-drain",
+        "shutdown-truncate-rewrite",
     ) and diagnostic_int(diagnostics, "jit_provider_generation") < 2:
         raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
@@ -595,6 +644,8 @@ def main():
             "truncated-during-drain-generation",
             "replaced-generation",
             "pending-replaced-generation",
+            "pending-replaced-during-drain",
+            "shutdown-truncate-rewrite",
             "pending-timeout-backlog",
         ),
         default="both",

--- a/test/jit/run_jit_profiling_check.py
+++ b/test/jit/run_jit_profiling_check.py
@@ -79,8 +79,12 @@ def mode_flag(mode):
         return "--with-overlong-then-valid"
     if mode in ("bounded-queue", "allocation-failure", "shutdown-full-queue"):
         return "--with-bounded-queue-then-valid"
+    if mode == "pending-round-robin":
+        return "--with-pending-round-robin"
     if mode == "truncated-generation":
         return "--with-truncated-generation"
+    if mode == "truncated-larger-generation":
+        return "--with-truncated-larger-generation"
     if mode == "replaced-generation":
         return "--with-replaced-generation"
     if mode == "attach-retry-timeout":
@@ -120,9 +124,11 @@ def expects_attached_record(mode):
         "v8-lazycompile-optimized",
         "two-generations-heartbeat",
         "bounded-queue",
+        "pending-round-robin",
         "allocation-failure",
         "shutdown-full-queue",
         "truncated-generation",
+        "truncated-larger-generation",
         "replaced-generation",
     )
 
@@ -144,8 +150,10 @@ def expects_positive_count(mode):
         "v8-lazycompile-optimized",
         "two-generations-heartbeat",
         "bounded-queue",
+        "pending-round-robin",
         "allocation-failure",
         "truncated-generation",
+        "truncated-larger-generation",
         "replaced-generation",
     )
 
@@ -170,6 +178,12 @@ def extra_env_for_mode(mode):
             "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS": "10000",
             "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
         }
+    if mode == "pending-round-robin":
+        return {
+            "PEAK_JIT_PENDING_CAPACITY": "2",
+            "PEAK_JIT_NOT_EXEC_RETRY_TIMEOUT_MS": "10000",
+            "PEAK_JIT_DRAIN_RECORD_BUDGET": "1",
+        }
     if mode == "allocation-failure":
         return {"PEAK_JIT_TEST_FAIL_PENDING_ALLOCATION": "1"}
     if mode == "attach-retry-timeout":
@@ -185,6 +199,7 @@ def expected_attached_records(mode):
         "two-generations",
         "two-generations-heartbeat",
         "truncated-generation",
+        "truncated-larger-generation",
         "replaced-generation",
     ):
         return 2
@@ -409,7 +424,11 @@ def run_one(args, tmpdir, mode):
                     f"symbol as one CSV field\nexpected={expected}\n"
                     f"rows={trace_rows}\ntrace={trace}\n{output}"
                 )
-        if mode in ("truncated-generation", "replaced-generation"):
+        if mode in (
+            "truncated-generation",
+            "truncated-larger-generation",
+            "replaced-generation",
+        ):
             generations = {row[7] for row in attached_records if len(row) >= 8}
             if len(generations) != 2:
                 raise AssertionError(
@@ -432,6 +451,10 @@ def run_one(args, tmpdir, mode):
             raise AssertionError(f"missing queue-full diagnostic: {diagnostics}")
         if diagnostic_int(diagnostics, "jit_pending_high_water") != 2:
             raise AssertionError(f"pending queue exceeded configured bound: {diagnostics}")
+    if mode == "pending-round-robin" and diagnostic_int(
+        diagnostics, "jit_pending_high_water"
+    ) != 2:
+        raise AssertionError(f"round-robin fixture did not fill both slots: {diagnostics}")
     if mode in ("stale-then-valid", "final-drain-stale-then-valid") and diagnostic_int(
         diagnostics, "jit_non_executable_timeout"
     ) < 1:
@@ -440,9 +463,11 @@ def run_one(args, tmpdir, mode):
         diagnostics, "jit_allocation_failure"
     ) != 1:
         raise AssertionError(f"missing allocation-failure diagnostic: {diagnostics}")
-    if mode in ("truncated-generation", "replaced-generation") and diagnostic_int(
-        diagnostics, "jit_provider_generation"
-    ) < 2:
+    if mode in (
+        "truncated-generation",
+        "truncated-larger-generation",
+        "replaced-generation",
+    ) and diagnostic_int(diagnostics, "jit_provider_generation") < 2:
         raise AssertionError(f"provider generation did not advance: {diagnostics}")
     if expects_positive_count(mode):
         if stats_csv is None:
@@ -503,10 +528,12 @@ def main():
             "v8-lazycompile-optimized",
             "two-generations-heartbeat",
             "bounded-queue",
+            "pending-round-robin",
             "allocation-failure",
             "attach-retry-timeout",
             "shutdown-full-queue",
             "truncated-generation",
+            "truncated-larger-generation",
             "replaced-generation",
         ),
         default="both",

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -15,6 +15,8 @@
 #define PEAK_JIT_SKIP 77
 #define PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER \
     "PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"
+#define PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER \
+    "PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER"
 
 typedef int (*PeakJitFn)(int);
 
@@ -30,9 +32,11 @@ typedef enum {
     PEAK_JIT_WITH_OVERLONG_THEN_VALID,
     PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID,
     PEAK_JIT_WITH_PENDING_ROUND_ROBIN,
+    PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG,
     PEAK_JIT_WITH_TRUNCATED_GENERATION,
     PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION,
-    PEAK_JIT_WITH_REPLACED_GENERATION
+    PEAK_JIT_WITH_REPLACED_GENERATION,
+    PEAK_JIT_WITH_PENDING_REPLACED_GENERATION
 } PeakJitMode;
 
 static int
@@ -103,9 +107,9 @@ print_usage(const char* argv0)
             "--with-pre-exec-perf-map|--with-two-generations|--with-stale-then-valid|"
             "--with-duplicate-perf-map|--with-malformed-then-valid|"
             "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
-            "--with-pending-round-robin|"
+            "--with-pending-round-robin|--with-pending-timeout-backlog|"
             "--with-truncated-generation|--with-truncated-during-drain-generation|"
-            "--with-replaced-generation) "
+            "--with-replaced-generation|--with-pending-replaced-generation) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
 }
@@ -179,6 +183,9 @@ parse_args(int argc,
         } else if (strcmp(argv[i], "--with-pending-round-robin") == 0) {
             *mode = PEAK_JIT_WITH_PENDING_ROUND_ROBIN;
             saw_mode++;
+        } else if (strcmp(argv[i], "--with-pending-timeout-backlog") == 0) {
+            *mode = PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG;
+            saw_mode++;
         } else if (strcmp(argv[i], "--with-truncated-generation") == 0) {
             *mode = PEAK_JIT_WITH_TRUNCATED_GENERATION;
             saw_mode++;
@@ -188,6 +195,10 @@ parse_args(int argc,
             saw_mode++;
         } else if (strcmp(argv[i], "--with-replaced-generation") == 0) {
             *mode = PEAK_JIT_WITH_REPLACED_GENERATION;
+            saw_mode++;
+        } else if (strcmp(argv[i],
+                          "--with-pending-replaced-generation") == 0) {
+            *mode = PEAK_JIT_WITH_PENDING_REPLACED_GENERATION;
             saw_mode++;
         } else if (strcmp(argv[i], "--iterations") == 0) {
             if (i + 1 >= argc ||
@@ -299,9 +310,9 @@ truncate_perf_map(void)
 }
 
 static int
-wait_for_final_stat_barrier(void)
+wait_for_barrier(const char* environment_name)
 {
-    const char* path = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+    const char* path = getenv(environment_name);
 
     if (path == NULL || path[0] == '\0') {
         return -1;
@@ -604,12 +615,16 @@ mode_name(PeakJitMode mode)
             return "with-bounded-queue-then-valid";
         case PEAK_JIT_WITH_PENDING_ROUND_ROBIN:
             return "with-pending-round-robin";
+        case PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG:
+            return "with-pending-timeout-backlog";
         case PEAK_JIT_WITH_TRUNCATED_GENERATION:
             return "with-truncated-generation";
         case PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION:
             return "with-truncated-during-drain-generation";
         case PEAK_JIT_WITH_REPLACED_GENERATION:
             return "with-replaced-generation";
+        case PEAK_JIT_WITH_PENDING_REPLACED_GENERATION:
+            return "with-pending-replaced-generation";
         case PEAK_JIT_WITHOUT_METADATA:
         default:
             return "without-metadata";
@@ -651,7 +666,9 @@ main(int argc, char** argv)
     rc = (mode == PEAK_JIT_WITH_PRE_EXEC_PERF_MAP ||
           mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
           mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
-          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN) ?
+          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
+          mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG ||
+          mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) ?
              allocate_jit_code_with_mode(&code, &code_size, 0) :
              allocate_jit_code(&code, &code_size);
     if (rc != 0) {
@@ -665,7 +682,9 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
          mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
-         mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
+         mode == PEAK_JIT_WITH_REPLACED_GENERATION ||
+         mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG ||
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
         return PEAK_JIT_SKIP;
@@ -802,6 +821,35 @@ main(int argc, char** argv)
         code = second_code;
         code_size = second_code_size;
     }
+    if (mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG) {
+        void* second_code = NULL;
+        size_t second_code_size = 0;
+        char backlog_name[64];
+
+        rc = allocate_jit_code(&second_code, &second_code_size);
+        if (rc != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return rc;
+        }
+        for (size_t i = 0; i < 64; i++) {
+            if (snprintf(backlog_name,
+                         sizeof(backlog_name),
+                         "peak_jit_backlog_%02zu",
+                         i) >= (int)sizeof(backlog_name) ||
+                write_perf_map_row(second_code,
+                                   second_code_size,
+                                   backlog_name) != 0) {
+                munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+                munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+                return PEAK_JIT_SKIP;
+            }
+        }
+        code = second_code;
+        code_size = second_code_size;
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us * 4);
+        }
+    }
     if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION) {
         if (metadata_sleep_us > 0) {
             usleep(metadata_sleep_us * 4);
@@ -821,7 +869,7 @@ main(int argc, char** argv)
     if (mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION) {
         const char* barrier = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
 
-        if (wait_for_final_stat_barrier() != 0 ||
+        if (wait_for_barrier(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER) != 0 ||
             truncate_perf_map() != 0 ||
             barrier == NULL ||
             unlink(barrier) != 0 ||
@@ -850,6 +898,27 @@ main(int argc, char** argv)
             return PEAK_JIT_SKIP;
         }
     }
+    if (mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) {
+        const char* barrier =
+            getenv(PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER);
+        void* second_code = NULL;
+        size_t second_code_size = 0;
+
+        if (wait_for_barrier(PEAK_JIT_TEST_PRE_SOURCE_OBSERVE_BARRIER) != 0 ||
+            allocate_jit_code(&second_code, &second_code_size) != 0 ||
+            replace_perf_map() != 0 ||
+            write_perf_map_row(second_code, second_code_size, symbol_name) != 0 ||
+            make_jit_code_executable(code, code_size) != 0 ||
+            barrier == NULL || unlink(barrier) != 0) {
+            if (second_code != NULL) {
+                munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+            }
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        code = second_code;
+        code_size = second_code_size;
+    }
     if ((mode == PEAK_JIT_WITH_PERF_MAP ||
          mode == PEAK_JIT_WITH_TWO_GENERATIONS ||
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
@@ -858,11 +927,14 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_OVERLONG_THEN_VALID ||
          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
+         mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
          mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
-         mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
+         mode == PEAK_JIT_WITH_REPLACED_GENERATION ||
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) &&
         metadata_sleep_us > 0) {
-        usleep(metadata_sleep_us);
+        usleep(metadata_sleep_us *
+               (mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ? 4 : 1));
     }
     if (mode == PEAK_JIT_WITH_PARTIAL_PERF_MAP) {
         if (metadata_sleep_us > 0) {

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -27,7 +27,9 @@ typedef enum {
     PEAK_JIT_WITH_MALFORMED_THEN_VALID,
     PEAK_JIT_WITH_OVERLONG_THEN_VALID,
     PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID,
+    PEAK_JIT_WITH_PENDING_ROUND_ROBIN,
     PEAK_JIT_WITH_TRUNCATED_GENERATION,
+    PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION,
     PEAK_JIT_WITH_REPLACED_GENERATION
 } PeakJitMode;
 
@@ -99,7 +101,9 @@ print_usage(const char* argv0)
             "--with-pre-exec-perf-map|--with-two-generations|--with-stale-then-valid|"
             "--with-duplicate-perf-map|--with-malformed-then-valid|"
             "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
-            "--with-truncated-generation|--with-replaced-generation) "
+            "--with-pending-round-robin|"
+            "--with-truncated-generation|--with-truncated-larger-generation|"
+            "--with-replaced-generation) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
 }
@@ -170,8 +174,15 @@ parse_args(int argc,
         } else if (strcmp(argv[i], "--with-bounded-queue-then-valid") == 0) {
             *mode = PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID;
             saw_mode++;
+        } else if (strcmp(argv[i], "--with-pending-round-robin") == 0) {
+            *mode = PEAK_JIT_WITH_PENDING_ROUND_ROBIN;
+            saw_mode++;
         } else if (strcmp(argv[i], "--with-truncated-generation") == 0) {
             *mode = PEAK_JIT_WITH_TRUNCATED_GENERATION;
+            saw_mode++;
+        } else if (strcmp(argv[i],
+                          "--with-truncated-larger-generation") == 0) {
+            *mode = PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION;
             saw_mode++;
         } else if (strcmp(argv[i], "--with-replaced-generation") == 0) {
             *mode = PEAK_JIT_WITH_REPLACED_GENERATION;
@@ -552,8 +563,12 @@ mode_name(PeakJitMode mode)
             return "with-overlong-then-valid";
         case PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID:
             return "with-bounded-queue-then-valid";
+        case PEAK_JIT_WITH_PENDING_ROUND_ROBIN:
+            return "with-pending-round-robin";
         case PEAK_JIT_WITH_TRUNCATED_GENERATION:
             return "with-truncated-generation";
+        case PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION:
+            return "with-truncated-larger-generation";
         case PEAK_JIT_WITH_REPLACED_GENERATION:
             return "with-replaced-generation";
         case PEAK_JIT_WITHOUT_METADATA:
@@ -596,7 +611,8 @@ main(int argc, char** argv)
 
     rc = (mode == PEAK_JIT_WITH_PRE_EXEC_PERF_MAP ||
           mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
-          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID) ?
+          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
+          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN) ?
              allocate_jit_code_with_mode(&code, &code_size, 0) :
              allocate_jit_code(&code, &code_size);
     if (rc != 0) {
@@ -609,6 +625,7 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
          mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
@@ -719,16 +736,46 @@ main(int argc, char** argv)
         code = second_code;
         code_size = second_code_size;
     }
-    if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION) {
+    if (mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN) {
+        void* second_code = NULL;
+        size_t second_code_size = 0;
+        if (allocate_jit_code_with_mode(&second_code,
+                                        &second_code_size,
+                                        0) != 0 ||
+            write_perf_map_row(code, code_size, symbol_name) != 0 ||
+            write_perf_map_row(second_code,
+                               second_code_size,
+                               symbol_name) != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            if (second_code != NULL) {
+                munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+            }
+            return PEAK_JIT_SKIP;
+        }
         if (metadata_sleep_us > 0) {
-            usleep(metadata_sleep_us);
+            usleep(metadata_sleep_us * 2);
+        }
+        if (make_jit_code_executable(second_code, second_code_size) != 0) {
+            munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        code = second_code;
+        code_size = second_code_size;
+    }
+    if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+        mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION) {
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us * 4);
         }
         if (truncate_perf_map() != 0) {
             munmap(code, (size_t)sysconf(_SC_PAGESIZE));
             return PEAK_JIT_SKIP;
         }
-        if (metadata_sleep_us > 0) {
-            usleep(metadata_sleep_us);
+        if (mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION &&
+            write_malformed_perf_map_row(code) != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
         }
         if (write_perf_map_row(code, code_size, symbol_name) != 0) {
             munmap(code, (size_t)sysconf(_SC_PAGESIZE));
@@ -758,7 +805,9 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_MALFORMED_THEN_VALID ||
          mode == PEAK_JIT_WITH_OVERLONG_THEN_VALID ||
          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
+         mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         metadata_sleep_us > 0) {
         usleep(metadata_sleep_us);

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -29,7 +29,6 @@ typedef enum {
     PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID,
     PEAK_JIT_WITH_PENDING_ROUND_ROBIN,
     PEAK_JIT_WITH_TRUNCATED_GENERATION,
-    PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION,
     PEAK_JIT_WITH_REPLACED_GENERATION
 } PeakJitMode;
 
@@ -102,7 +101,7 @@ print_usage(const char* argv0)
             "--with-duplicate-perf-map|--with-malformed-then-valid|"
             "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
             "--with-pending-round-robin|"
-            "--with-truncated-generation|--with-truncated-larger-generation|"
+            "--with-truncated-generation|"
             "--with-replaced-generation) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
@@ -179,10 +178,6 @@ parse_args(int argc,
             saw_mode++;
         } else if (strcmp(argv[i], "--with-truncated-generation") == 0) {
             *mode = PEAK_JIT_WITH_TRUNCATED_GENERATION;
-            saw_mode++;
-        } else if (strcmp(argv[i],
-                          "--with-truncated-larger-generation") == 0) {
-            *mode = PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION;
             saw_mode++;
         } else if (strcmp(argv[i], "--with-replaced-generation") == 0) {
             *mode = PEAK_JIT_WITH_REPLACED_GENERATION;
@@ -567,8 +562,6 @@ mode_name(PeakJitMode mode)
             return "with-pending-round-robin";
         case PEAK_JIT_WITH_TRUNCATED_GENERATION:
             return "with-truncated-generation";
-        case PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION:
-            return "with-truncated-larger-generation";
         case PEAK_JIT_WITH_REPLACED_GENERATION:
             return "with-replaced-generation";
         case PEAK_JIT_WITHOUT_METADATA:
@@ -625,7 +618,6 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
          mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
-         mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
@@ -763,8 +755,7 @@ main(int argc, char** argv)
         code = second_code;
         code_size = second_code_size;
     }
-    if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
-        mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION) {
+    if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION) {
         if (metadata_sleep_us > 0) {
             usleep(metadata_sleep_us * 4);
         }
@@ -772,10 +763,8 @@ main(int argc, char** argv)
             munmap(code, (size_t)sysconf(_SC_PAGESIZE));
             return PEAK_JIT_SKIP;
         }
-        if (mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION &&
-            write_malformed_perf_map_row(code) != 0) {
-            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
-            return PEAK_JIT_SKIP;
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us * 2);
         }
         if (write_perf_map_row(code, code_size, symbol_name) != 0) {
             munmap(code, (size_t)sysconf(_SC_PAGESIZE));
@@ -807,7 +796,6 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
-         mode == PEAK_JIT_WITH_TRUNCATED_LARGER_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         metadata_sleep_us > 0) {
         usleep(metadata_sleep_us);

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -25,7 +25,10 @@ typedef enum {
     PEAK_JIT_WITH_STALE_THEN_VALID,
     PEAK_JIT_WITH_DUPLICATE_PERF_MAP,
     PEAK_JIT_WITH_MALFORMED_THEN_VALID,
-    PEAK_JIT_WITH_OVERLONG_THEN_VALID
+    PEAK_JIT_WITH_OVERLONG_THEN_VALID,
+    PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID,
+    PEAK_JIT_WITH_TRUNCATED_GENERATION,
+    PEAK_JIT_WITH_REPLACED_GENERATION
 } PeakJitMode;
 
 static int
@@ -95,7 +98,8 @@ print_usage(const char* argv0)
             "usage: %s (--with-perf-map|--without-metadata|--with-partial-perf-map|"
             "--with-pre-exec-perf-map|--with-two-generations|--with-stale-then-valid|"
             "--with-duplicate-perf-map|--with-malformed-then-valid|"
-            "--with-overlong-then-valid) "
+            "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
+            "--with-truncated-generation|--with-replaced-generation) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
 }
@@ -162,6 +166,15 @@ parse_args(int argc,
             saw_mode++;
         } else if (strcmp(argv[i], "--with-overlong-then-valid") == 0) {
             *mode = PEAK_JIT_WITH_OVERLONG_THEN_VALID;
+            saw_mode++;
+        } else if (strcmp(argv[i], "--with-bounded-queue-then-valid") == 0) {
+            *mode = PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID;
+            saw_mode++;
+        } else if (strcmp(argv[i], "--with-truncated-generation") == 0) {
+            *mode = PEAK_JIT_WITH_TRUNCATED_GENERATION;
+            saw_mode++;
+        } else if (strcmp(argv[i], "--with-replaced-generation") == 0) {
+            *mode = PEAK_JIT_WITH_REPLACED_GENERATION;
             saw_mode++;
         } else if (strcmp(argv[i], "--iterations") == 0) {
             if (i + 1 >= argc ||
@@ -253,6 +266,48 @@ write_perf_map_row(void* code, size_t code_size, const char* symbol_name)
         return -1;
     }
 
+    return 0;
+}
+
+static int
+truncate_perf_map(void)
+{
+    char path[256];
+    FILE* fp;
+
+    if (perf_map_path(path, sizeof(path)) != 0) {
+        return -1;
+    }
+    fp = fopen(path, "w");
+    if (fp == NULL) {
+        return -1;
+    }
+    return fclose(fp) == 0 ? 0 : -1;
+}
+
+static int
+replace_perf_map(void)
+{
+    char path[256];
+    char replacement[288];
+    FILE* fp;
+
+    if (perf_map_path(path, sizeof(path)) != 0 ||
+        snprintf(replacement,
+                 sizeof(replacement),
+                 "%s.replacement-%ld",
+                 path,
+                 (long)getpid()) >= (int)sizeof(replacement)) {
+        return -1;
+    }
+    fp = fopen(replacement, "w");
+    if (fp == NULL) {
+        return -1;
+    }
+    if (fclose(fp) != 0 || rename(replacement, path) != 0) {
+        unlink(replacement);
+        return -1;
+    }
     return 0;
 }
 
@@ -495,6 +550,12 @@ mode_name(PeakJitMode mode)
             return "with-malformed-then-valid";
         case PEAK_JIT_WITH_OVERLONG_THEN_VALID:
             return "with-overlong-then-valid";
+        case PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID:
+            return "with-bounded-queue-then-valid";
+        case PEAK_JIT_WITH_TRUNCATED_GENERATION:
+            return "with-truncated-generation";
+        case PEAK_JIT_WITH_REPLACED_GENERATION:
+            return "with-replaced-generation";
         case PEAK_JIT_WITHOUT_METADATA:
         default:
             return "without-metadata";
@@ -534,7 +595,8 @@ main(int argc, char** argv)
     unlink_stale_perf_map();
 
     rc = (mode == PEAK_JIT_WITH_PRE_EXEC_PERF_MAP ||
-          mode == PEAK_JIT_WITH_STALE_THEN_VALID) ?
+          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
+          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID) ?
              allocate_jit_code_with_mode(&code, &code_size, 0) :
              allocate_jit_code(&code, &code_size);
     if (rc != 0) {
@@ -545,7 +607,9 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_PRE_EXEC_PERF_MAP ||
          mode == PEAK_JIT_WITH_TWO_GENERATIONS ||
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
-         mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP) &&
+         mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
+         mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
         return PEAK_JIT_SKIP;
@@ -631,12 +695,71 @@ main(int argc, char** argv)
         code = second_code;
         code_size = second_code_size;
     }
+    if (mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID) {
+        void* second_code = NULL;
+        size_t second_code_size = 0;
+        for (size_t i = 1; i < 4; i++) {
+            if (write_perf_map_row((unsigned char*)code + i * 8,
+                                   1,
+                                   symbol_name) != 0) {
+                munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+                return PEAK_JIT_SKIP;
+            }
+        }
+        rc = allocate_jit_code(&second_code, &second_code_size);
+        if (rc != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return rc;
+        }
+        if (write_perf_map_row(second_code, second_code_size, symbol_name) != 0) {
+            munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        code = second_code;
+        code_size = second_code_size;
+    }
+    if (mode == PEAK_JIT_WITH_TRUNCATED_GENERATION) {
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us);
+        }
+        if (truncate_perf_map() != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us);
+        }
+        if (write_perf_map_row(code, code_size, symbol_name) != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+    }
+    if (mode == PEAK_JIT_WITH_REPLACED_GENERATION) {
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us);
+        }
+        if (replace_perf_map() != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        if (metadata_sleep_us > 0) {
+            usleep(metadata_sleep_us);
+        }
+        if (write_perf_map_row(code, code_size, symbol_name) != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+    }
     if ((mode == PEAK_JIT_WITH_PERF_MAP ||
          mode == PEAK_JIT_WITH_TWO_GENERATIONS ||
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
          mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
          mode == PEAK_JIT_WITH_MALFORMED_THEN_VALID ||
-         mode == PEAK_JIT_WITH_OVERLONG_THEN_VALID) &&
+         mode == PEAK_JIT_WITH_OVERLONG_THEN_VALID ||
+         mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
+         mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         metadata_sleep_us > 0) {
         usleep(metadata_sleep_us);
     }

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,7 +37,9 @@ typedef enum {
     PEAK_JIT_WITH_TRUNCATED_GENERATION,
     PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION,
     PEAK_JIT_WITH_REPLACED_GENERATION,
-    PEAK_JIT_WITH_PENDING_REPLACED_GENERATION
+    PEAK_JIT_WITH_PENDING_REPLACED_GENERATION,
+    PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN,
+    PEAK_JIT_WITH_SHUTDOWN_TRUNCATE_REWRITE
 } PeakJitMode;
 
 static int
@@ -109,7 +112,9 @@ print_usage(const char* argv0)
             "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
             "--with-pending-round-robin|--with-pending-timeout-backlog|"
             "--with-truncated-generation|--with-truncated-during-drain-generation|"
-            "--with-replaced-generation|--with-pending-replaced-generation) "
+            "--with-replaced-generation|--with-pending-replaced-generation|"
+            "--with-pending-replaced-during-drain|"
+            "--with-shutdown-truncate-rewrite) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
 }
@@ -199,6 +204,14 @@ parse_args(int argc,
         } else if (strcmp(argv[i],
                           "--with-pending-replaced-generation") == 0) {
             *mode = PEAK_JIT_WITH_PENDING_REPLACED_GENERATION;
+            saw_mode++;
+        } else if (strcmp(argv[i],
+                          "--with-pending-replaced-during-drain") == 0) {
+            *mode = PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN;
+            saw_mode++;
+        } else if (strcmp(argv[i],
+                          "--with-shutdown-truncate-rewrite") == 0) {
+            *mode = PEAK_JIT_WITH_SHUTDOWN_TRUNCATE_REWRITE;
             saw_mode++;
         } else if (strcmp(argv[i], "--iterations") == 0) {
             if (i + 1 >= argc ||
@@ -368,6 +381,30 @@ replace_perf_map(void)
     if (fclose(fp) != 0 || rename(replacement, path) != 0) {
         unlink(replacement);
         return -1;
+    }
+    return 0;
+}
+
+static int
+start_shutdown_truncate_rewrite_helper(void* code,
+                                       size_t code_size,
+                                       const char* symbol_name)
+{
+    if (signal(SIGCHLD, SIG_IGN) == SIG_ERR) {
+        return -1;
+    }
+    pid_t child = fork();
+
+    if (child < 0) {
+        return -1;
+    }
+    if (child == 0) {
+        const char* barrier = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+        int ok = wait_for_barrier(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER) == 0 &&
+                 truncate_perf_map() == 0 &&
+                 write_perf_map_row(code, code_size, symbol_name) == 0 &&
+                 barrier != NULL && unlink(barrier) == 0;
+        _exit(ok ? 0 : 1);
     }
     return 0;
 }
@@ -625,6 +662,10 @@ mode_name(PeakJitMode mode)
             return "with-replaced-generation";
         case PEAK_JIT_WITH_PENDING_REPLACED_GENERATION:
             return "with-pending-replaced-generation";
+        case PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN:
+            return "with-pending-replaced-during-drain";
+        case PEAK_JIT_WITH_SHUTDOWN_TRUNCATE_REWRITE:
+            return "with-shutdown-truncate-rewrite";
         case PEAK_JIT_WITHOUT_METADATA:
         default:
             return "without-metadata";
@@ -668,7 +709,8 @@ main(int argc, char** argv)
           mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
           mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
           mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG ||
-          mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) ?
+          mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION ||
+          mode == PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN) ?
              allocate_jit_code_with_mode(&code, &code_size, 0) :
              allocate_jit_code(&code, &code_size);
     if (rc != 0) {
@@ -684,7 +726,9 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION ||
          mode == PEAK_JIT_WITH_PENDING_TIMEOUT_BACKLOG ||
-         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) &&
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION ||
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN ||
+         mode == PEAK_JIT_WITH_SHUTDOWN_TRUNCATE_REWRITE) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
         return PEAK_JIT_SKIP;
@@ -919,6 +963,37 @@ main(int argc, char** argv)
         code = second_code;
         code_size = second_code_size;
     }
+    if (mode == PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN) {
+        const char* barrier = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+        void* second_code = NULL;
+        size_t second_code_size = 0;
+
+        if (wait_for_barrier(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER) != 0 ||
+            allocate_jit_code(&second_code, &second_code_size) != 0 ||
+            replace_perf_map() != 0 ||
+            write_perf_map_row(second_code, second_code_size, symbol_name) != 0 ||
+            make_jit_code_executable(code, code_size) != 0 ||
+            barrier == NULL || unlink(barrier) != 0 ||
+            wait_for_final_stat_done() != 0) {
+            if (second_code != NULL) {
+                munmap(second_code, (size_t)sysconf(_SC_PAGESIZE));
+            }
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        code = second_code;
+        code_size = second_code_size;
+    }
+    if (mode == PEAK_JIT_WITH_SHUTDOWN_TRUNCATE_REWRITE &&
+        (write_perf_map_row((unsigned char*)code + 8,
+                            1,
+                            "peak_jit_shutdown_padding") != 0 ||
+         start_shutdown_truncate_rewrite_helper(code,
+                                                code_size,
+                                                symbol_name) != 0)) {
+        munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+        return PEAK_JIT_SKIP;
+    }
     if ((mode == PEAK_JIT_WITH_PERF_MAP ||
          mode == PEAK_JIT_WITH_TWO_GENERATIONS ||
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
@@ -931,7 +1006,8 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
          mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION ||
-         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION) &&
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_GENERATION ||
+         mode == PEAK_JIT_WITH_PENDING_REPLACED_DURING_DRAIN) &&
         metadata_sleep_us > 0) {
         usleep(metadata_sleep_us *
                (mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ? 4 : 1));

--- a/test/jit/test_jit_mmap_fixture.c
+++ b/test/jit/test_jit_mmap_fixture.c
@@ -13,6 +13,8 @@
 #define PEAK_JIT_SYMBOL "peak_jit_hot"
 #define PEAK_JIT_DEFAULT_ITERATIONS 1000000UL
 #define PEAK_JIT_SKIP 77
+#define PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER \
+    "PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER"
 
 typedef int (*PeakJitFn)(int);
 
@@ -29,6 +31,7 @@ typedef enum {
     PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID,
     PEAK_JIT_WITH_PENDING_ROUND_ROBIN,
     PEAK_JIT_WITH_TRUNCATED_GENERATION,
+    PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION,
     PEAK_JIT_WITH_REPLACED_GENERATION
 } PeakJitMode;
 
@@ -101,7 +104,7 @@ print_usage(const char* argv0)
             "--with-duplicate-perf-map|--with-malformed-then-valid|"
             "--with-overlong-then-valid|--with-bounded-queue-then-valid|"
             "--with-pending-round-robin|"
-            "--with-truncated-generation|"
+            "--with-truncated-generation|--with-truncated-during-drain-generation|"
             "--with-replaced-generation) "
             "[--iterations N] [--metadata-sleep-us N] [--symbol NAME]\n",
             argv0);
@@ -178,6 +181,10 @@ parse_args(int argc,
             saw_mode++;
         } else if (strcmp(argv[i], "--with-truncated-generation") == 0) {
             *mode = PEAK_JIT_WITH_TRUNCATED_GENERATION;
+            saw_mode++;
+        } else if (strcmp(argv[i],
+                          "--with-truncated-during-drain-generation") == 0) {
+            *mode = PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION;
             saw_mode++;
         } else if (strcmp(argv[i], "--with-replaced-generation") == 0) {
             *mode = PEAK_JIT_WITH_REPLACED_GENERATION;
@@ -289,6 +296,43 @@ truncate_perf_map(void)
         return -1;
     }
     return fclose(fp) == 0 ? 0 : -1;
+}
+
+static int
+wait_for_final_stat_barrier(void)
+{
+    const char* path = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+
+    if (path == NULL || path[0] == '\0') {
+        return -1;
+    }
+    for (unsigned int i = 0; i < 10000; i++) {
+        if (access(path, F_OK) == 0) {
+            return 0;
+        }
+        usleep(100);
+    }
+    return -1;
+}
+
+static int
+wait_for_final_stat_done(void)
+{
+    const char* path = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+    char done_path[512];
+
+    if (path == NULL || path[0] == '\0' ||
+        snprintf(done_path, sizeof(done_path), "%s.done", path) >=
+            (int)sizeof(done_path)) {
+        return -1;
+    }
+    for (unsigned int i = 0; i < 10000; i++) {
+        if (access(done_path, F_OK) == 0) {
+            return unlink(done_path) == 0 ? 0 : -1;
+        }
+        usleep(100);
+    }
+    return -1;
 }
 
 static int
@@ -562,6 +606,8 @@ mode_name(PeakJitMode mode)
             return "with-pending-round-robin";
         case PEAK_JIT_WITH_TRUNCATED_GENERATION:
             return "with-truncated-generation";
+        case PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION:
+            return "with-truncated-during-drain-generation";
         case PEAK_JIT_WITH_REPLACED_GENERATION:
             return "with-replaced-generation";
         case PEAK_JIT_WITHOUT_METADATA:
@@ -618,6 +664,7 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_STALE_THEN_VALID ||
          mode == PEAK_JIT_WITH_DUPLICATE_PERF_MAP ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         write_perf_map_row(code, code_size, symbol_name) != 0) {
         munmap(code, (size_t)sysconf(_SC_PAGESIZE));
@@ -771,6 +818,22 @@ main(int argc, char** argv)
             return PEAK_JIT_SKIP;
         }
     }
+    if (mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION) {
+        const char* barrier = getenv(PEAK_JIT_TEST_PRE_FINAL_STAT_BARRIER);
+
+        if (wait_for_final_stat_barrier() != 0 ||
+            truncate_perf_map() != 0 ||
+            barrier == NULL ||
+            unlink(barrier) != 0 ||
+            wait_for_final_stat_done() != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+        if (write_perf_map_row(code, code_size, symbol_name) != 0) {
+            munmap(code, (size_t)sysconf(_SC_PAGESIZE));
+            return PEAK_JIT_SKIP;
+        }
+    }
     if (mode == PEAK_JIT_WITH_REPLACED_GENERATION) {
         if (metadata_sleep_us > 0) {
             usleep(metadata_sleep_us);
@@ -796,6 +859,7 @@ main(int argc, char** argv)
          mode == PEAK_JIT_WITH_BOUNDED_QUEUE_THEN_VALID ||
          mode == PEAK_JIT_WITH_PENDING_ROUND_ROBIN ||
          mode == PEAK_JIT_WITH_TRUNCATED_GENERATION ||
+         mode == PEAK_JIT_WITH_TRUNCATED_DURING_DRAIN_GENERATION ||
          mode == PEAK_JIT_WITH_REPLACED_GENERATION) &&
         metadata_sleep_us > 0) {
         usleep(metadata_sleep_us);

--- a/test/report/test_mpi_report_request_lifetime.c
+++ b/test/report/test_mpi_report_request_lifetime.c
@@ -15,8 +15,8 @@ enum {
     TEST_COLLECTIVE_ALLREDUCE = 0,
     TEST_COLLECTIVE_REDUCE = 1,
     TEST_COLLECTIVE_BCAST = 2,
-    TEST_COLLECTIVE_COUNT = 61,
-    TEST_UNIQUE_LABEL_COUNT = 36,
+    TEST_COLLECTIVE_COUNT = 69,
+    TEST_UNIQUE_LABEL_COUNT = 39,
 };
 
 typedef enum {
@@ -397,6 +397,13 @@ fixture_snapshot(void)
     snapshot->capabilities.cuda_found_apis = 0x3U;
     snapshot->capabilities.cuda_installed_apis = 0x1U;
     snapshot->capabilities.cuda_failed_apis = 0x2U;
+    snapshot->jit.pending_queue_full = 1U;
+    snapshot->jit.non_executable_timeout = 2U;
+    snapshot->jit.attach_retry_timeout = 3U;
+    snapshot->jit.allocation_failure = 4U;
+    snapshot->jit.provider_generation = 5U;
+    snapshot->jit.pending_count = 6U;
+    snapshot->jit.pending_high_water = 7U;
     snapshot->overhead_per_call = 1e-7;
     snapshot->overhead.valid = true;
     snapshot->overhead.accounting_valid = true;
@@ -478,12 +485,17 @@ validate_golden_trace(void)
     EXPECT(5, "accounting-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
     EXPECT(6, "hook-count-min", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MIN, -1);
     EXPECT(7, "hook-count-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MAX, -1);
-    EXPECT(8, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
-    EXPECT(9, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
-    EXPECT(10, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(11, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
-    for (int ordinal = 12; ordinal <= 41; ordinal++) {
-        int field = (ordinal - 12) % 5;
+    EXPECT(8, "jit-diagnostics-max", TEST_COLLECTIVE_ALLREDUCE, 6, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(9, "jit-generation-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    for (int ordinal = 10; ordinal <= 15; ordinal++) {
+        EXPECT(ordinal, "jit-diagnostic-sum", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    }
+    EXPECT(16, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
+    EXPECT(17, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
+    EXPECT(18, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(19, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
+    for (int ordinal = 20; ordinal <= 49; ordinal++) {
+        int field = (ordinal - 20) % 5;
         EXPECT(ordinal,
                bcast_labels[field],
                TEST_COLLECTIVE_BCAST,
@@ -492,26 +504,26 @@ validate_golden_trace(void)
                MPI_OP_NULL,
                0);
     }
-    EXPECT(42, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(43, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(44, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(45, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(46, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(47, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(48, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(49, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(50, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(51, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(52, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(53, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(54, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(55, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(56, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
-    EXPECT(57, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
-    EXPECT(58, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(59, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(60, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(61, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(50, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(51, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(52, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(53, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(54, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(55, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(56, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(57, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(58, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(59, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(60, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(61, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(62, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(63, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(64, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
+    EXPECT(65, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
+    EXPECT(66, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(67, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(68, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(69, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
 
 #undef EXPECT
 
@@ -564,6 +576,7 @@ run_success_case(int rank, int size)
             memcmp(&aggregate->capabilities,
                    &local->capabilities,
                    sizeof(local->capabilities)) != 0 ||
+            memcmp(&aggregate->jit, &local->jit, sizeof(local->jit)) != 0 ||
             !aggregate->overhead.per_rank_max ||
             aggregate->overhead.per_rank_maxima.owner_ranks[0] != 0) {
             failures++;
@@ -806,6 +819,6 @@ main(void)
                 failures);
         return EXIT_FAILURE;
     }
-    puts("mpi_report_request_lifetime_ok operations=59 labels=34 failures=118");
+    puts("mpi_report_request_lifetime_ok operations=69 labels=39 failures=138");
     return EXIT_SUCCESS;
 }

--- a/test/report/test_mpi_report_request_lifetime.c
+++ b/test/report/test_mpi_report_request_lifetime.c
@@ -15,8 +15,9 @@ enum {
     TEST_COLLECTIVE_ALLREDUCE = 0,
     TEST_COLLECTIVE_REDUCE = 1,
     TEST_COLLECTIVE_BCAST = 2,
-    TEST_COLLECTIVE_COUNT = 69,
-    TEST_UNIQUE_LABEL_COUNT = 39,
+    TEST_COLLECTIVE_COUNT = 63,
+    TEST_NON_JIT_COLLECTIVE_COUNT = 61,
+    TEST_UNIQUE_LABEL_COUNT = 38,
 };
 
 typedef enum {
@@ -388,7 +389,8 @@ fixture_snapshot(void)
     snapshot->dropped_threads = 3;
     snapshot->degraded_mask = PEAK_PROFILER_DEGRADED_CUDA;
     snapshot->capabilities.requested =
-        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA;
+        PEAK_CAPABILITY_CPU_TARGET | PEAK_CAPABILITY_CUDA |
+        PEAK_CAPABILITY_JIT;
     snapshot->capabilities.compiled = snapshot->capabilities.requested;
     snapshot->capabilities.active = PEAK_CAPABILITY_CPU_TARGET;
     snapshot->capabilities.partial = PEAK_CAPABILITY_CUDA;
@@ -485,17 +487,14 @@ validate_golden_trace(void)
     EXPECT(5, "accounting-valid", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MIN, -1);
     EXPECT(6, "hook-count-min", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MIN, -1);
     EXPECT(7, "hook-count-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UNSIGNED_LONG, MPI_MAX, -1);
-    EXPECT(8, "jit-diagnostics-max", TEST_COLLECTIVE_ALLREDUCE, 6, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(9, "jit-generation-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    for (int ordinal = 10; ordinal <= 15; ordinal++) {
-        EXPECT(ordinal, "jit-diagnostic-sum", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    }
-    EXPECT(16, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
-    EXPECT(17, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
-    EXPECT(18, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(19, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
-    for (int ordinal = 20; ordinal <= 49; ordinal++) {
-        int field = (ordinal - 20) % 5;
+    EXPECT(8, "jit-diagnostics-max", TEST_COLLECTIVE_ALLREDUCE, 7, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(9, "jit-diagnostics-sum", TEST_COLLECTIVE_REDUCE, 5, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(10, "duplicate-hook-name-check", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_INT, MPI_MAX, -1);
+    EXPECT(11, "hook-slot-min-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MIN, -1);
+    EXPECT(12, "hook-slot-max-hash", TEST_COLLECTIVE_ALLREDUCE, 2, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(13, "profile-control-ratio-maxloc", TEST_COLLECTIVE_REDUCE, 6, MPI_DOUBLE_INT, MPI_MAXLOC, 0);
+    for (int ordinal = 14; ordinal <= 43; ordinal++) {
+        int field = (ordinal - 14) % 5;
         EXPECT(ordinal,
                bcast_labels[field],
                TEST_COLLECTIVE_BCAST,
@@ -504,26 +503,26 @@ validate_golden_trace(void)
                MPI_OP_NULL,
                0);
     }
-    EXPECT(50, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(51, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(52, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(53, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(54, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
-    EXPECT(55, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(56, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
-    EXPECT(57, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(58, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(59, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(60, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(61, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
-    EXPECT(62, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
-    EXPECT(63, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
-    EXPECT(64, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
-    EXPECT(65, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
-    EXPECT(66, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
-    EXPECT(67, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(68, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
-    EXPECT(69, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(44, "profile-seconds", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(45, "failed-stop-window-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(46, "failed-stop-window-count", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(47, "dropped-calls-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(48, "dropped-threads-max", TEST_COLLECTIVE_ALLREDUCE, 1, MPI_UINT64_T, MPI_MAX, -1);
+    EXPECT(49, "dropped-calls", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(50, "dropped-threads", TEST_COLLECTIVE_REDUCE, 1, MPI_UINT64_T, MPI_SUM, 0);
+    EXPECT(51, "elapsed-min", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(52, "elapsed-max", TEST_COLLECTIVE_REDUCE, 1, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(53, "sum-num-calls", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(54, "sum-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(55, "max-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MAX, 0);
+    EXPECT(56, "min-total-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_MIN, 0);
+    EXPECT(57, "sum-exclusive-time", TEST_COLLECTIVE_REDUCE, 2, MPI_DOUBLE, MPI_SUM, 0);
+    EXPECT(58, "sum-max-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MAX, 0);
+    EXPECT(59, "sum-min-time", TEST_COLLECTIVE_REDUCE, 2, MPI_FLOAT, MPI_MIN, 0);
+    EXPECT(60, "thread-count", TEST_COLLECTIVE_REDUCE, 2, MPI_UNSIGNED_LONG, MPI_SUM, 0);
+    EXPECT(61, "detached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(62, "reattached-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
+    EXPECT(63, "revisited-marker", TEST_COLLECTIVE_REDUCE, 2, MPI_INT, MPI_MAX, 0);
 
 #undef EXPECT
 
@@ -591,6 +590,41 @@ run_success_case(int rank, int size)
         failures++;
     }
     failures += validate_golden_trace();
+    peak_report_snapshot_destroy(aggregate);
+    peak_report_snapshot_destroy(local);
+    return failures;
+}
+
+static int
+run_non_jit_success_case(void)
+{
+    PeakReportSnapshot* local;
+    PeakReportSnapshot* aggregate = NULL;
+    PeakMpiReportTransportResult result;
+    int failures = 0;
+
+    fake_reset(0, TEST_REQUEST_COMPLETE, 0, 1);
+    peak_mpi_report_transport_reset_failed_closed();
+    local = fixture_snapshot();
+    if (local == NULL) {
+        return 1;
+    }
+    local->capabilities.requested &= ~PEAK_CAPABILITY_JIT;
+    local->capabilities.compiled &= ~PEAK_CAPABILITY_JIT;
+    memset(&local->jit, 0, sizeof(local->jit));
+    result = peak_mpi_report_transport_reduce(local, &aggregate);
+    if (result != PEAK_MPI_REPORT_TRANSPORT_ROOT_READY ||
+        aggregate == NULL ||
+        fake_operation_count != TEST_NON_JIT_COLLECTIVE_COUNT ||
+        trace_count != TEST_NON_JIT_COLLECTIVE_COUNT ||
+        memcmp(&aggregate->jit, &local->jit, sizeof(local->jit)) != 0) {
+        failures++;
+    }
+    for (int i = 0; i < trace_count; i++) {
+        if (strncmp(trace_records[i].label, "jit-", 4) == 0) {
+            failures++;
+        }
+    }
     peak_report_snapshot_destroy(aggregate);
     peak_report_snapshot_destroy(local);
     return failures;
@@ -796,6 +830,7 @@ main(void)
     (void)setenv("PEAK_VERBOSITY", "silent", 1);
     failures += run_success_case(0, 1);
     failures += run_success_case(1, 2);
+    failures += run_non_jit_success_case();
     /* pending struct, staged send buffer, and staged receive buffer each
      * coordinate local fallback before any payload collective is issued. */
     failures += run_staged_allocation_failure_case(0);
@@ -819,6 +854,6 @@ main(void)
                 failures);
         return EXIT_FAILURE;
     }
-    puts("mpi_report_request_lifetime_ok operations=69 labels=39 failures=138");
+    puts("mpi_report_request_lifetime_ok operations=63 labels=38 failures=126 non_jit_operations=61");
     return EXIT_SUCCESS;
 }

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -273,25 +273,25 @@ check_csv_golden(const char* csv_path)
     static const char expected[] =
         "function,count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
-        "dropped_calls,dropped_threads,jit_pending_queue_full,"
-        "jit_non_executable_timeout,jit_attach_retry_timeout,"
-        "jit_allocation_failure,jit_provider_generation,jit_pending_count,"
-        "jit_pending_high_water,capability_requested,"
+        "dropped_calls,dropped_threads,capability_requested,"
         "capability_compiled,capability_active,capability_partial,"
         "capability_retained,capability_failed,cuda_compiled_apis,"
         "cuda_found_apis,cuda_installed_apis,cuda_failed_apis,"
-        "degraded_mask\n"
+        "degraded_mask,jit_pending_queue_full,"
+        "jit_non_executable_timeout,jit_attach_retry_timeout,"
+        "jit_allocation_failure,jit_provider_generation,jit_pending_count,"
+        "jit_pending_high_water\n"
         "\"alpha\",5,3,2.5,5.000000000e-01,1.250000000e-01,"
         "1.250000000e+00,1.250000000e+00,7.500000000e-01,"
         "2.500000000e-01,5.000000000e-02,7,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_ACCOUNTING_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,7,3,"
         "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_cpu-target\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-        "1,1,1,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_cpu-target\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_CAPABILITY_strict-mutation\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_cuda\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-        "1,1,0,1,0,1,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_cuda\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "1,1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_CAPABILITY_memory\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
@@ -304,10 +304,10 @@ check_csv_golden(const char* csv_path)
         "0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_CAPABILITY_local-report\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CUDA_API_COVERAGE\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-        "0,0,0,0,0,0,7,3,1,2,0\n"
-        "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
-        "0,0,0,0,0,0,0,0,0,0,16\n";
+        "\"PEAK_CUDA_API_COVERAGE\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+        "7,3,1,2,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,16,0,0,0,0,0,0,0\n";
     PeakReportSnapshot* snapshot = create_fixture("alpha");
     PeakReportSnapshot* prepared = peak_report_snapshot_clone(snapshot);
     char* actual;
@@ -617,13 +617,13 @@ check_capability_only_output(const char* csv_path)
     contents = read_file(csv_path);
     assert(strstr(contents,
                   "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,"
-                  "0,0,0,0,0,0,0,1,1,0,0,0,1,0,0,0,0,0\n") != NULL);
+                  "1,1,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0\n") != NULL);
     assert(strstr(contents,
                   "\"PEAK_JIT_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,0,0,"
-                  "2,3,5,7,11,13,17,0,0,0,0,0,0,0,0,0,0,0\n") != NULL);
+                  "0,0,0,0,0,0,0,0,0,0,0,2,3,5,7,11,13,17\n") != NULL);
     assert(strstr(contents,
                   "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,"
-                  "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32\n") != NULL);
+                  "0,0,0,0,0,0,0,0,0,0,0,0,0,32,0,0,0,0,0,0,0\n") != NULL);
     free(contents);
     assert(unlink(csv_path) == 0);
     peak_report_snapshot_destroy(snapshot);

--- a/test/report/test_report_formatter.c
+++ b/test/report/test_report_formatter.c
@@ -273,37 +273,40 @@ check_csv_golden(const char* csv_path)
     static const char expected[] =
         "function,count,per_thread,per_rank,call_max_s,call_min_s,"
         "total_s,exclusive_s,thread_max_s,thread_min_s,overhead_s,"
-        "dropped_calls,dropped_threads,capability_requested,"
+        "dropped_calls,dropped_threads,jit_pending_queue_full,"
+        "jit_non_executable_timeout,jit_attach_retry_timeout,"
+        "jit_allocation_failure,jit_provider_generation,jit_pending_count,"
+        "jit_pending_high_water,capability_requested,"
         "capability_compiled,capability_active,capability_partial,"
         "capability_retained,capability_failed,cuda_compiled_apis,"
         "cuda_found_apis,cuda_installed_apis,cuda_failed_apis,"
         "degraded_mask\n"
         "\"alpha\",5,3,2.5,5.000000000e-01,1.250000000e-01,"
         "1.250000000e+00,1.250000000e+00,7.500000000e-01,"
-        "2.500000000e-01,5.000000000e-02,7,3,0,0,0,0,0,0,0,0,0,0,0\n"
+        "2.500000000e-01,5.000000000e-02,7,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
         "\"PEAK_ACCOUNTING_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,7,3,"
-        "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_cpu-target\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
+        "\"PEAK_CAPABILITY_cpu-target\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "1,1,1,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_strict-mutation\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_strict-mutation\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_cuda\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_cuda\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "1,1,0,1,0,1,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_memory\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_memory\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_dynamic-dso\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_dynamic-dso\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_mpi-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_mpi-report\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_socket-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_socket-report\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CAPABILITY_local-report\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CAPABILITY_local-report\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,0\n"
-        "\"PEAK_CUDA_API_COVERAGE\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_CUDA_API_COVERAGE\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,7,3,1,2,0\n"
-        "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,0,0,0,"
+        "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,"
         "0,0,0,0,0,0,0,0,0,0,16\n";
     PeakReportSnapshot* snapshot = create_fixture("alpha");
     PeakReportSnapshot* prepared = peak_report_snapshot_clone(snapshot);
@@ -603,14 +606,24 @@ check_capability_only_output(const char* csv_path)
     snapshot->capabilities.requested = PEAK_CAPABILITY_JIT;
     snapshot->capabilities.compiled = PEAK_CAPABILITY_JIT;
     snapshot->capabilities.failed = PEAK_CAPABILITY_JIT;
+    snapshot->jit.pending_queue_full = 2;
+    snapshot->jit.non_executable_timeout = 3;
+    snapshot->jit.attach_retry_timeout = 5;
+    snapshot->jit.allocation_failure = 7;
+    snapshot->jit.provider_generation = 11;
+    snapshot->jit.pending_count = 13;
+    snapshot->jit.pending_high_water = 17;
     assert(peak_report_formatter_write_csv(snapshot));
     contents = read_file(csv_path);
     assert(strstr(contents,
                   "\"PEAK_CAPABILITY_jit\",0,0,0,0,0,0,0,0,0,0,0,0,"
-                  "1,1,0,0,0,1,0,0,0,0,0\n") != NULL);
+                  "0,0,0,0,0,0,0,1,1,0,0,0,1,0,0,0,0,0\n") != NULL);
+    assert(strstr(contents,
+                  "\"PEAK_JIT_DIAGNOSTICS\",0,0,0,0,0,0,0,0,0,0,0,0,"
+                  "2,3,5,7,11,13,17,0,0,0,0,0,0,0,0,0,0,0\n") != NULL);
     assert(strstr(contents,
                   "\"PEAK_DEGRADED_CAPABILITIES\",0,0,0,0,0,0,0,0,0,"
-                  "0,0,0,0,0,0,0,0,0,0,0,0,0,32\n") != NULL);
+                  "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32\n") != NULL);
     free(contents);
     assert(unlink(csv_path) == 0);
     peak_report_snapshot_destroy(snapshot);

--- a/test/report/test_report_snapshot.c
+++ b/test/report/test_report_snapshot.c
@@ -26,6 +26,8 @@ int main(void)
     snapshot->overhead_per_call = 0.25;
     snapshot->dropped_calls = 7;
     snapshot->dropped_threads = 3;
+    snapshot->jit.provider_generation = 5;
+    snapshot->jit.pending_high_water = 11;
     peak_report_snapshot_set_transport_overhead(&snapshot->overhead);
     PeakReportOverhead transport = peak_report_snapshot_get_transport_overhead();
     assert(transport.valid && transport.elapsed_seconds == 4.0);
@@ -48,6 +50,8 @@ int main(void)
     assert(copy->overhead_per_call == 0.25);
     assert(copy->dropped_calls == 7);
     assert(copy->dropped_threads == 3);
+    assert(copy->jit.provider_generation == 5);
+    assert(copy->jit.pending_high_water == 11);
 
     peak_report_snapshot_prepare_for_render(copy);
     assert(strcmp(copy->program, "milc -i input") == 0);

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -571,7 +571,7 @@ aggregate_matches(const PeakReportSnapshot* aggregate)
         aggregate->jit.allocation_failure != 44U ||
         aggregate->jit.provider_generation != 9U ||
         aggregate->jit.pending_count != 66U ||
-        aggregate->jit.pending_high_water != 77U) {
+        aggregate->jit.pending_high_water != 70U) {
         return false;
     }
 

--- a/test/report/test_socket_report_transport.c
+++ b/test/report/test_socket_report_transport.c
@@ -479,6 +479,13 @@ fixture_snapshot(int rank, bool mismatch_name)
     snapshot->capabilities.cuda_installed_apis =
         rank == 0 ? 0x3U : 0x1U;
     snapshot->capabilities.cuda_failed_apis = rank == 0 ? 0 : 0x2U;
+    snapshot->jit.pending_queue_full = rank == 0 ? 1U : 10U;
+    snapshot->jit.non_executable_timeout = rank == 0 ? 2U : 20U;
+    snapshot->jit.attach_retry_timeout = rank == 0 ? 3U : 30U;
+    snapshot->jit.allocation_failure = rank == 0 ? 4U : 40U;
+    snapshot->jit.provider_generation = rank == 0 ? 5U : 9U;
+    snapshot->jit.pending_count = rank == 0 ? 6U : 60U;
+    snapshot->jit.pending_high_water = rank == 0 ? 7U : 70U;
 
     snapshot->overhead_per_call = rank == 0 ? 1e-7 : 9e-7;
     snapshot->overhead.valid = true;
@@ -557,7 +564,14 @@ aggregate_matches(const PeakReportSnapshot* aggregate)
         aggregate->capabilities.cuda_compiled_apis != 0x7U ||
         aggregate->capabilities.cuda_found_apis != 0x3U ||
         aggregate->capabilities.cuda_installed_apis != 0x1U ||
-        aggregate->capabilities.cuda_failed_apis != 0x2U) {
+        aggregate->capabilities.cuda_failed_apis != 0x2U ||
+        aggregate->jit.pending_queue_full != 11U ||
+        aggregate->jit.non_executable_timeout != 22U ||
+        aggregate->jit.attach_retry_timeout != 33U ||
+        aggregate->jit.allocation_failure != 44U ||
+        aggregate->jit.provider_generation != 9U ||
+        aggregate->jit.pending_count != 66U ||
+        aggregate->jit.pending_high_water != 77U) {
         return false;
     }
 
@@ -913,8 +927,8 @@ run_two_rank_case_with_peer_start_delay(int port,
         action == TEST_GATHER_PAYLOAD_DROP_FAILURE) {
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_AFTER_BYTES",
-            /* wire-v14 header (216 bytes) plus 17 payload bytes. */
-            action == TEST_GATHER_DROP_FAILURE ? "1" : "233",
+            /* wire-v15 header (272 bytes) plus 17 payload bytes. */
+            action == TEST_GATHER_DROP_FAILURE ? "1" : "289",
             1);
         (void)setenv(
             "PEAK_TEST_OUTPUT_AGGREGATION_GATHER_DROP_RANK",
@@ -1033,7 +1047,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         peer_ready_fds[0] = -1;
         memset(&telemetry, 0, sizeof(telemetry));
         peak_socket_report_test_telemetry_get(&telemetry);
-        if (telemetry.wire_version != 14U ||
+        if (telemetry.wire_version != 15U ||
             telemetry.peer_receipt_received !=
                 peer_registration_expected ||
             telemetry.peer_confirmation_sent !=
@@ -1102,7 +1116,7 @@ run_two_rank_case_with_peer_start_delay(int port,
         peak_socket_report_test_receipt_barrier_set(-1, -1);
     }
     if (!peer_exits_before_connect &&
-        (root_telemetry.wire_version != 14U ||
+        (root_telemetry.wire_version != 15U ||
          (!gather_must_fail &&
           root_telemetry.root_receipt_session_nonce == 0) ||
         (!early_drop_may_skip_accept &&
@@ -1408,7 +1422,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_socket_report_transport_abort(peer_session);
         peak_report_snapshot_destroy(peer_aggregate);
         if (peer_cpu_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-            telemetry.wire_version != 14U ||
+            telemetry.wire_version != 15U ||
             !telemetry.peer_receipt_received ||
             !telemetry.peer_confirmation_sent ||
             !telemetry.peer_release_started ||
@@ -1436,7 +1450,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
         peak_report_snapshot_destroy(peer_cuda);
         if ((!cuda_schema_mismatch &&
              (peer_cuda_status != PEAK_SOCKET_REPORT_PEER_RELEASED ||
-              telemetry.wire_version != 14U ||
+              telemetry.wire_version != 15U ||
               !telemetry.peer_receipt_received ||
               !telemetry.peer_confirmation_sent ||
               !telemetry.peer_release_started ||
@@ -1461,7 +1475,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
     memset(&telemetry, 0, sizeof(telemetry));
     peak_socket_report_test_telemetry_get(&telemetry);
     if (cpu_status != PEAK_SOCKET_REPORT_ROOT_PREPARED || session == NULL ||
-        !aggregate_matches(aggregate) || telemetry.wire_version != 14U ||
+        !aggregate_matches(aggregate) || telemetry.wire_version != 15U ||
         telemetry.root_payload_count != 1U ||
         telemetry.root_receipt_count != 1U ||
         telemetry.root_confirmation_count != 1U ||
@@ -1517,7 +1531,7 @@ run_two_rank_sequential_channels(int port, bool cuda_schema_mismatch)
             }
         } else if (cuda_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
                    session == NULL || !aggregate_matches(aggregate) ||
-                   telemetry.wire_version != 14U ||
+                   telemetry.wire_version != 15U ||
                    telemetry.root_payload_count != 1U ||
                    telemetry.root_receipt_count != 1U ||
                    telemetry.root_confirmation_count != 1U ||
@@ -1878,7 +1892,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
                 &peer_aggregate);
             memset(&telemetry, 0, sizeof(telemetry));
             peak_socket_report_test_telemetry_get(&telemetry);
-            if (telemetry.wire_version != 14U ||
+            if (telemetry.wire_version != 15U ||
                 !telemetry.peer_receipt_received ||
                 !telemetry.peer_confirmation_sent ||
                 !telemetry.peer_release_started ||
@@ -1908,7 +1922,7 @@ run_many_rank_case(int port, int size, bool exercise_concurrency)
         peak_socket_report_test_telemetry_get(&root_telemetry);
         if (root_status != PEAK_SOCKET_REPORT_ROOT_PREPARED ||
             session == NULL || aggregate == NULL ||
-            root_telemetry.wire_version != 14U ||
+            root_telemetry.wire_version != 15U ||
             root_telemetry.root_payload_count != (uint32_t)(size - 1) ||
             root_telemetry.root_receipt_count != (uint32_t)(size - 1) ||
             root_telemetry.root_confirmation_count !=
@@ -2067,7 +2081,7 @@ run_duplicate_rank_case(int port)
         peak_socket_report_test_telemetry_get(&telemetry);
         if (status != PEAK_SOCKET_REPORT_FAILED ||
             session != NULL || aggregate != NULL ||
-            telemetry.wire_version != 14U ||
+            telemetry.wire_version != 15U ||
             telemetry.root_payload_count > 1U ||
             telemetry.root_receipt_count >
                 telemetry.root_payload_count ||

--- a/test/static_checks/check_detach_lifecycle_invariants.py
+++ b/test/static_checks/check_detach_lifecycle_invariants.py
@@ -1481,7 +1481,7 @@ def check_final_report_snapshot_order(repo_root):
         socket_prepare_receipt,
         re.DOTALL,
     ) is not None
-    require("#define PEAK_SOCKET_REDUCE_VERSION 14U" in socket_transport and
+    require("#define PEAK_SOCKET_REDUCE_VERSION 15U" in socket_transport and
             "peak_socket_reduce_header_set_report_tuple" in socket_result and
             "peak_socket_reduce_header_report_tuple" in
                 socket_validate_header and


### PR DESCRIPTION
## Summary

- replace the unbounded JIT pending list with a fixed-capacity array and a documented reject-newest policy
- bound non-executable and controller attach retries independently while preserving fair perf-map consumption and round-robin pending retries
- track monotonic perf-map generations across enable, observed source-size regression, and inode replacement
- transport queue, timeout, allocation, generation, pending, and high-water diagnostics through local, MPI, and socket reports
- document the conservative load-only perf-map lifetime contract and unavailable unload-aware tracking

## Review fixes

- observe perf-map identity and size changes before retrying records from the previous generation
- alternate metadata and pending work when `PEAK_JIT_DRAIN_RECORD_BUDGET=1`, preserving bounded timeout progress under a sustained metadata backlog
- skip new JIT diagnostic collectives for non-JIT MPI jobs and reduce JIT aggregation to one vector `MAX` plus one vector `SUM`
- reject new records before a duplicate scan when the queue is full and remove pending records with an O(1) swap-with-last operation
- report same-address metadata from a new generation as `generation-refreshed`, without claiming or attempting a second Gum attachment
- aggregate pending high-water and provider generation with `MAX`; additive diagnostics and final pending counts use `SUM`
- emit authoritative `pending-queue-full` and `pending-allocation-failure` record outcomes after the enqueue result is known
- append JIT diagnostics after the existing CSV schema so all pre-existing columns retain their positions
- validate the current perf-map pathname before post-read retries, clearing stale-generation pending work if the inode or size changed during the drain
- treat a final source reset as pending work so shutdown performs another drain and consumes rewritten metadata from offset zero

## Correctness and failure behavior

- queue saturation and pending allocation failure skip only the affected metadata record
- a full pending queue cannot starve a later executable record
- shutdown expires retained retry records without an unbounded drain
- replacement or truncation clears old-generation pending records before any retry attempt
- generation refresh does not change the conservative load-only contract or force reattachment of a physically detached hook
- Gum mutation remains controller-owned and the CPU detach/reattach FSM is unchanged

## Validation

- GCC full JIT suite: 34/34 passed
- Clang full JIT suite: 34/34 passed
- deterministic generation/pending replacement, replacement during final validation, shutdown truncate/rewrite, budget-one backlog timeout, queue saturation, allocation failure, truncation, and replacement regressions passed on GCC and Clang
- the two final-validation race regressions each passed 10 consecutive GCC repetitions
- report formatter, MPI request-lifetime transport, socket transport, mutation allowlist, general-listener hot-path, and detach lifecycle invariant tests passed on GCC and Clang
- MPI transport regression proves 61 existing collectives for non-JIT reports and only two additional vector collectives for JIT diagnostics
- CSV golden tests and MILC/MPI positional parsers preserve the original capability and degraded-field offsets
- `git diff --check` and Python syntax checks passed

Closes #93
